### PR TITLE
chore: bump rust to 1.85 (unblocks modern cargo-audit + other 1.85+ tooling)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
   # Security audit on dependency tree. Uses taiki-e/install-action which
   # downloads a prebuilt cargo-audit binary from the cargo-audit release page
-  # — no source compile, so our pinned rust-toolchain.toml (1.82) doesn't
+  # — no source compile, so our pinned rust-toolchain.toml doesn't
   # collide with newer cargo-audit MSRVs (cargo-audit 0.22+ needs rustc 1.85).
   audit:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cilladev/xlstream"
 homepage = "https://github.com/cilladev/xlstream"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.82"
+msrv = "1.85"
 avoid-breaking-exported-api = true
 cognitive-complexity-threshold = 25
 too-many-arguments-threshold = 8

--- a/docs/operations/repo-structure.md
+++ b/docs/operations/repo-structure.md
@@ -103,7 +103,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cilladev/xlstream"
 authors = ["Priscilla Emasoga"]

--- a/docs/phases/phase-00-foundation.md
+++ b/docs/phases/phase-00-foundation.md
@@ -21,7 +21,7 @@
 
 ### Toolchain
 
-- [x] `rust-toolchain.toml` pins Rust 1.82 stable.
+- [x] `rust-toolchain.toml` pins Rust 1.85 stable.
 - [x] `rustfmt.toml` with project conventions (see `docs/standards/code-style.md`).
 - [x] `clippy.toml` with project conventions.
 - [x] `.editorconfig` for cross-editor consistency.
@@ -29,7 +29,7 @@
 ### Workspace
 
 - [x] Root `Cargo.toml` declares `[workspace]` with `members = []` initially. Members added in Phase 1.
-- [x] `[workspace.package]` defines shared metadata: version `0.1.0`, edition `2021`, rust-version `1.82`, licence `MIT OR Apache-2.0`, repository URL.
+- [x] `[workspace.package]` defines shared metadata: version `0.1.0`, edition `2021`, rust-version `1.85`, licence `MIT OR Apache-2.0`, repository URL.
 - [x] `[workspace.dependencies]` declares shared dependency pins (calamine, rust_xlsxwriter with features, formualizer-parse, pyo3, rayon, crossbeam-channel, smallvec, thiserror, tracing, phf, memory-stats, proptest, criterion, tempfile). See `docs/operations/repo-structure.md` for the list.
 
 ### Pre-commit + onboarding
@@ -77,7 +77,7 @@ See [`docs/operations/github-setup.md`](../operations/github-setup.md) for the s
 
 ```toml
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy", "rust-src"]
 profile = "default"
 ```
@@ -92,7 +92,7 @@ members = []
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cilladev/xlstream"
 authors = ["Priscilla Emasoga"]

--- a/docs/standards/code-style.md
+++ b/docs/standards/code-style.md
@@ -27,7 +27,7 @@ Clippy with `-D warnings` in CI. Zero tolerance.
 
 ```toml
 # clippy.toml
-msrv = "1.82"
+msrv = "1.85"
 avoid-breaking-exported-api = true
 ```
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy", "rust-src"]
 profile = "default"


### PR DESCRIPTION
## What

Bumps the pinned Rust toolchain from 1.82 → 1.85.

Files touched:
- \`rust-toolchain.toml\` — channel
- \`Cargo.toml\` — \`workspace.package.rust-version\`
- \`clippy.toml\` — \`msrv\`
- \`docs/operations/repo-structure.md\`, \`docs/standards/code-style.md\`, \`docs/phases/phase-00-foundation.md\` — doc references + sample files
- \`.github/workflows/ci.yml\` — comment referencing old version number

## Why

Our pin (1.82) was chosen in Phase 0 foundation work ~6 months ago. It's now actively blocking tooling:

- \`cargo-audit\` 0.22+ requires rustc 1.85 (CI failure on PR 1).
- Several common tooling bumps in the last year need ≥ 1.85.

1.85 is conservative — it's been stable since Feb 2025 and matches the MSRV floor that modern tool releases assume.

## Testing

- \`cargo build --workspace\` — green (one stub crate, compiles trivially).
- \`cargo test --workspace --all-features\` — green.
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean.
- \`cargo fmt --check\` — clean.

## Impact on Phase 1 in flight

- PR 1 is already merged; this bump is on main after it.
- PR 2 and PR 3 rebase onto main after this lands. Clippy 1.85 may surface lints that 1.82 didn't — any mechanical fixes get applied the same way PR 1's did (update \`[allow(...)]\` lists or test-value literals).
- The Phase 1 plan doc has been updated to reference 1.85.

## Checklist

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --all-features\`
- [x] Doc mentions updated