### PR TITLE
docs: drop rayon/phf/formualizer-parse from xlstream-eval phase-01 expectation

### DIFF
--- a/docs/phases/phase-01-scaffolding.md
+++ b/docs/phases/phase-01-scaffolding.md
@@ -54,7 +54,7 @@
 
 ### `xlstream-eval`
 
-- [ ] Deps: `xlstream-core`, `xlstream-parse`, `xlstream-io`, `rayon`, `tracing`, `phf`.
+- [ ] Deps: `xlstream-core`, `xlstream-parse`, `xlstream-io`, `tracing`. (`rayon` lands in Phase 10, `phf` lands in Phase 7 — each phase declares only what it uses.)
 - [ ] Stubs:
   - [ ] `pub fn evaluate(input: &Path, output: &Path, workers: Option<usize>) -> Result<EvaluateSummary, XlStreamError>`.
   - [ ] `pub struct EvaluateSummary { pub rows_processed: u32, pub duration_ms: u64, pub peak_rss_bytes: u64 }`.
@@ -84,18 +84,17 @@ After this phase, `cargo tree -p xlstream-eval` should show:
 xlstream-eval v0.1.0
 ├── xlstream-core v0.1.0
 ├── xlstream-parse v0.1.0
-│   ├── xlstream-core
-│   └── formualizer-parse v0.5.x
+│   └── xlstream-core
 ├── xlstream-io v0.1.0
 │   ├── xlstream-core
 │   ├── calamine v0.34.x
 │   └── rust_xlsxwriter v0.94.x
-├── rayon v1.10.x
-├── tracing
-└── phf
+└── tracing
 ```
 
 No cycles. Arrows upward only.
+
+`rayon` and `phf` are absent — they land in Phase 10 and Phase 7 respectively, in the PR that first imports them. `formualizer-parse` is also absent: crates.io 0.5.x does not exist, and 1.x transitively requires Rust 1.88+ (`let` chains in `formualizer-common` 1.1.2). Phase 2 picks a resolution (toolchain bump, version pair, or fork).
 
 ## Verification
 


### PR DESCRIPTION
## What

Updates `docs/phases/phase-01-scaffolding.md`:

- Drops `rayon` and `phf` from the `xlstream-eval` deps bullet and from the reference `cargo tree` output. These two deps land in the phase that first imports them (Phase 10 and Phase 7 respectively).
- Drops `formualizer-parse v0.5.x` from the same `cargo tree` output. Phase 2 will pick a resolution — upstream 0.5.x does not exist on crates.io, and 1.x transitively requires Rust 1.88+.

## Why

Pre-approved during Phase 1 plan review (rayon/phf). Expanded to include `formualizer-parse` in response to PR #6's Phase-2 blocker finding (see PR description on PR #6). Keeping the phase-01 dep-graph reference honest about what actually compiles today.

## Testing

Docs-only. No code change.

## Checklist

- [x] `cargo fmt --check` — N/A (docs-only)
- [x] `cargo clippy` — N/A (docs-only)
- [x] `cargo test` — N/A (docs-only)