### PR TITLE
docs: make integration tests mandatory for every builtin

### DIFF
--- a/docs/phases/phase-01-scaffolding.md
+++ b/docs/phases/phase-01-scaffolding.md
@@ -54,7 +54,7 @@
 
 ### `xlstream-eval`
 
-- [ ] Deps: `xlstream-core`, `xlstream-parse`, `xlstream-io`, `rayon`, `tracing`, `phf`.
+- [ ] Deps: `xlstream-core`, `xlstream-parse`, `xlstream-io`, `tracing`. (`rayon` lands in Phase 10, `phf` lands in Phase 7 — each phase declares only what it uses.)
 - [ ] Stubs:
   - [ ] `pub fn evaluate(input: &Path, output: &Path, workers: Option<usize>) -> Result<EvaluateSummary, XlStreamError>`.
   - [ ] `pub struct EvaluateSummary { pub rows_processed: u32, pub duration_ms: u64, pub peak_rss_bytes: u64 }`.
@@ -84,18 +84,17 @@ After this phase, `cargo tree -p xlstream-eval` should show:
 xlstream-eval v0.1.0
 ├── xlstream-core v0.1.0
 ├── xlstream-parse v0.1.0
-│   ├── xlstream-core
-│   └── formualizer-parse v0.5.x
+│   └── xlstream-core
 ├── xlstream-io v0.1.0
 │   ├── xlstream-core
 │   ├── calamine v0.34.x
 │   └── rust_xlsxwriter v0.94.x
-├── rayon v1.10.x
-├── tracing
-└── phf
+└── tracing
 ```
 
 No cycles. Arrows upward only.
+
+`rayon` and `phf` are absent — they land in Phase 10 and Phase 7 respectively, in the PR that first imports them. `formualizer-parse` is also absent: crates.io 0.5.x does not exist, and 1.x transitively requires Rust 1.88+ (`let` chains in `formualizer-common` 1.1.2). Phase 2 picks a resolution (toolchain bump, version pair, or fork).
 
 ## Verification
 

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -14,11 +14,12 @@ Separately: **Python tests** in `bindings/python/tests/` via `pytest`.
 ## Golden rules
 
 1. **Every public function has at least one test.**
-2. **Every bug fix has a regression test.** The test is added before the fix. The test fails, then the fix lands, then the test passes.
-3. **No test is "too trivial."** Trivial code is where bugs hide.
-4. **Tests are code.** Reviewed as rigorously as library code. Poorly named or unassertive tests are rejected.
-5. **Tests must be deterministic.** No `std::thread::sleep`, no time-of-day dependence, no unseeded RNG.
-6. **Tests must be fast.** Anything over 100 ms is flagged. Over 1 s requires a `#[cfg_attr(not(feature = "slow-tests"), ignore)]` marker.
+2. **Every builtin function has at least one integration test that exercises it via the evaluator.** Unit tests that call the builtin directly (`fn sum(&[Value]) -> ...`) are necessary but not sufficient. Integration tests must feed a formula *through the parser, classifier, and evaluator* — the same path a real user hits. A builtin with only direct-call tests is not considered complete.
+3. **Every bug fix has a regression test.** The test is added before the fix. The test fails, then the fix lands, then the test passes.
+4. **No test is "too trivial."** Trivial code is where bugs hide.
+5. **Tests are code.** Reviewed as rigorously as library code. Poorly named or unassertive tests are rejected.
+6. **Tests must be deterministic.** No `std::thread::sleep`, no time-of-day dependence, no unseeded RNG.
+7. **Tests must be fast.** Anything over 100 ms is flagged. Over 1 s requires a `#[cfg_attr(not(feature = "slow-tests"), ignore)]` marker.
 
 ## Unit test rules
 
@@ -59,6 +60,29 @@ crates/xlstream-eval/tests/
 ```
 
 Fixtures (small .xlsx files) live in `fixtures/canonical/`. Committed to the repo, each < 50 KB. Large fixtures go in `fixtures/generated/` and are reproduced by a build script.
+
+### The two layers of integration testing
+
+Every builtin lands with both:
+
+1. **Evaluator-level integration** — drive the builtin via `xlstream_eval::Interpreter::eval` with a real AST node. Proves the builtin is reachable through dispatch, argument coercion, and error propagation. Lives in `crates/xlstream-eval/tests/<family>.rs`.
+2. **End-to-end integration** (at least once per feature area) — drive the builtin via `xlstream_eval::evaluate(input, output, None)` on a tiny committed xlsx fixture. Proves the builtin works through the full pipeline: read → classify → prelude → stream → write. Lives in `tests/end_to_end.rs` at the repo root.
+
+Evaluator-level integration is per-builtin. End-to-end is per-feature-area (one `IF` fixture covers all logical builtins conceptually; one `VLOOKUP` fixture covers the lookup family).
+
+### Minimum bar per builtin PR
+
+A PR that lands a new builtin is not mergeable until it includes:
+
+- **≥ 1 unit test** at the builtin function level (direct `fn` call with a `&[Value]` slice).
+- **≥ 1 evaluator-level integration test** that parses a formula string, evaluates it through `Interpreter`, and asserts the result.
+- **Coverage of the five "shapes"** (happy path, empty args / edge case, error-in-argument propagation, coercion path, type mismatch → appropriate `CellError`). Can be split across unit + integration, but all five must appear somewhere for each builtin.
+
+A PR that lands a new **feature area** (arithmetic, aggregates, lookups, etc.) adds:
+
+- **≥ 1 end-to-end test** that evaluates a fixture xlsx containing formulas from that area and asserts the output matches an Excel-computed golden.
+
+No exceptions without a design note in the PR explaining why.
 
 ## Workspace integration tests
 


### PR DESCRIPTION
## What

Tightens \`docs/standards/testing.md\` so that every builtin PR must include both a unit-level and an evaluator-level integration test. Adds a per-PR minimum bar.

## Why

Before this change, \`testing.md\` said \"every builtin has ≥5 unit tests\" without specifying whether those could all be direct-function calls. A builtin that only has unit tests can pass CI while being unreachable or mis-dispatched through the full evaluator pipeline. The tightening closes that gap.

Surfaced during the re-review of PR 6 — we wanted agents to add evaluator-level integration tests from Phase 5 onwards and realised the standards doc didn't explicitly require it.

## Changes

- Adds a new \"golden rule\": every builtin has an integration test that exercises it *via the evaluator*, not just the direct function.
- New subsection \"The two layers of integration testing\" distinguishes evaluator-level (per builtin) from end-to-end (per feature area).
- New subsection \"Minimum bar per builtin PR\" codifies: ≥1 unit test + ≥1 evaluator-level integration test + five behavioural shapes + ≥1 end-to-end per feature area.

## Impact on in-flight work

- No changes needed to PR 6 (Phase 1 stubs; no builtins).
- Phase 5 onwards (where the first real builtins land) will hit this bar. Plan agents should factor this into their PR scope — roughly one extra test file per builtin family.

## Testing

Docs-only.

## Checklist

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] Pre-commit hooks pass