### PR TITLE
xlstream-eval + xlstream-cli: scaffold evaluator entry point and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
 
   # Platform matrix for the Python wheel + pytest. abi3-py39 means one Python
   # version in CI is enough; the wheel works on 3.9-3.14+.
+  #
+  # Gated on `bindings/python/pyproject.toml` existing. The binding lands in
+  # Phase 11; until then every step after the guard is skipped and the job
+  # reports success (a "green skip", not a red failure).
   python:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -39,16 +43,32 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - id: guard
+        name: Check for bindings/python
+        shell: bash
+        run: |
+          if [ -f bindings/python/pyproject.toml ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::bindings/python/pyproject.toml not present — skipping (lands in Phase 11)"
+          fi
+      - if: steps.guard.outputs.present == 'true'
+        uses: actions/setup-python@v6
         with: { python-version: "3.12" }
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Install maturin + pytest
+      - if: steps.guard.outputs.present == 'true'
+        uses: dtolnay/rust-toolchain@stable
+      - if: steps.guard.outputs.present == 'true'
+        uses: Swatinem/rust-cache@v2
+      - if: steps.guard.outputs.present == 'true'
+        name: Install maturin + pytest
         run: pip install maturin pytest
-      - name: Build and install wheel
+      - if: steps.guard.outputs.present == 'true'
+        name: Build and install wheel
         working-directory: bindings/python
         run: maturin develop --release
-      - name: Run pytest
+      - if: steps.guard.outputs.present == 'true'
+        name: Run pytest
         working-directory: bindings/python
         run: pytest -v
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +134,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +181,12 @@ checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
 dependencies = [
  "encoding_rs",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crc32fast"
@@ -212,10 +317,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -253,6 +370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,10 +395,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -323,6 +470,23 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rust_xlsxwriter"
@@ -403,6 +567,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +586,18 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -459,6 +644,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +730,18 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -644,10 +911,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "xlstream-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "tracing",
+ "tracing-subscriber",
+ "xlstream-core",
+ "xlstream-eval",
+ "xlstream-io",
+]
+
+[[package]]
 name = "xlstream-core"
 version = "0.1.0"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "xlstream-eval"
+version = "0.1.0"
+dependencies = [
+ "tracing",
+ "xlstream-core",
+ "xlstream-io",
+ "xlstream-parse",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "crates/xlstream-core",
     "crates/xlstream-parse",
     "crates/xlstream-io",
+    "crates/xlstream-eval",
+    "crates/xlstream-cli",
 ]
 
 [workspace.package]
@@ -41,6 +43,8 @@ smallvec = "1.13"
 thiserror = "2.0"
 tracing = "0.1"
 phf = { version = "0.11", features = ["macros"] }
+clap = { version = "4.5", features = ["derive"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 memory-stats = "1.2"
 
 # Dev-only

--- a/crates/xlstream-cli/Cargo.toml
+++ b/crates/xlstream-cli/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "xlstream-cli"
+description = "Development CLI for the xlstream streaming Excel evaluator"
+keywords = ["excel", "xlsx", "streaming", "formula", "cli"]
+categories = ["command-line-utilities"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+publish = false
+
+[[bin]]
+name = "xlstream"
+path = "src/main.rs"
+
+[dependencies]
+xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
+xlstream-eval = { path = "../xlstream-eval", version = "0.1.0" }
+xlstream-io = { path = "../xlstream-io", version = "0.1.0" }
+clap.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -1,0 +1,115 @@
+//! xlstream development CLI. Phase 1 exposes a single `evaluate` subcommand
+//! that wires through to [`xlstream_eval::evaluate`] — which is itself a
+//! stub, so this binary currently exits with an `Internal("unimplemented
+//! ...")` error. Useful only to verify that `--help` works and the argument
+//! surface is correct.
+
+#![warn(missing_docs, rust_2018_idioms, clippy::pedantic, clippy::cargo)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::print_stdout,
+    clippy::dbg_macro
+)]
+#![allow(clippy::module_name_repetitions, clippy::cargo_common_metadata)]
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+use tracing::error;
+use tracing_subscriber::EnvFilter;
+
+/// xlstream CLI — streaming Excel formula evaluator.
+#[derive(Debug, Parser)]
+#[command(name = "xlstream", version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Evaluate an xlsx workbook and write the result to another xlsx file.
+    Evaluate {
+        /// Input workbook.
+        #[arg(value_name = "INPUT")]
+        input: PathBuf,
+        /// Output workbook path.
+        #[arg(long, short = 'o', value_name = "OUTPUT")]
+        output: PathBuf,
+        /// Number of parallel workers (default: auto).
+        #[arg(long, short = 'w', value_name = "N")]
+        workers: Option<usize>,
+        /// Increase log verbosity.
+        #[arg(long, short = 'v')]
+        verbose: bool,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let filter = match &cli.command {
+        Command::Evaluate { verbose: true, .. } => "debug",
+        Command::Evaluate { verbose: false, .. } => "info",
+    };
+
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_new(filter).unwrap_or_else(|_| EnvFilter::new("info")))
+        .with_target(false)
+        .init();
+
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            error!("{e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
+    match cli.command {
+        Command::Evaluate { input, output, workers, .. } => {
+            let _summary = xlstream_eval::evaluate(&input, &output, workers)?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn evaluate_subcommand_parses_required_and_optional_args() {
+        let cli = Cli::try_parse_from([
+            "xlstream",
+            "evaluate",
+            "in.xlsx",
+            "--output",
+            "out.xlsx",
+            "--workers",
+            "4",
+            "--verbose",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Evaluate { input, output, workers, verbose } => {
+                assert_eq!(input.to_str(), Some("in.xlsx"));
+                assert_eq!(output.to_str(), Some("out.xlsx"));
+                assert_eq!(workers, Some(4));
+                assert!(verbose);
+            }
+        }
+    }
+}

--- a/crates/xlstream-eval/Cargo.toml
+++ b/crates/xlstream-eval/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "xlstream-eval"
+description = "Streaming Excel formula evaluator for the xlstream workspace"
+keywords = ["excel", "xlsx", "streaming", "formula", "evaluator"]
+categories = ["parser-implementations"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.1.0" }
+xlstream-io = { path = "../xlstream-io", version = "0.1.0" }
+tracing.workspace = true
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -1,0 +1,81 @@
+//! The [`evaluate`] entry point and [`EvaluateSummary`] return type. Phase
+//! 1 stubs only; real streaming logic lands in Phase 4.
+
+use std::path::Path;
+
+use xlstream_core::XlStreamError;
+
+/// Summary of a completed evaluation. Returned by [`evaluate`] once the
+/// whole workbook has been streamed through.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_eval::EvaluateSummary;
+/// let s = EvaluateSummary::default();
+/// assert_eq!(s.rows_processed, 0);
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EvaluateSummary {
+    /// Number of rows processed across every sheet (sum).
+    pub rows_processed: u32,
+    /// Wall-clock duration of the evaluation, in milliseconds.
+    pub duration_ms: u64,
+    /// Peak resident-set size observed during the run, in bytes.
+    pub peak_rss_bytes: u64,
+}
+
+/// Evaluate every formula in `input`, write the results to `output`, and
+/// return an [`EvaluateSummary`].
+///
+/// `workers` selects the level of row-level parallelism: `None` lets the
+/// engine auto-choose (typically the rayon global pool); `Some(n)` pins
+/// to `n` workers. Phase 1 ignores the argument; Phase 10 wires it up.
+///
+/// # Errors
+///
+/// Phase 1: always [`XlStreamError::Internal`]. Phase 4 onward: any of the
+/// library-level error variants.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+/// use xlstream_eval::evaluate;
+/// let err = evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), None).unwrap_err();
+/// assert!(err.to_string().contains("unimplemented"));
+/// ```
+pub fn evaluate(
+    _input: &Path,
+    _output: &Path,
+    _workers: Option<usize>,
+) -> Result<EvaluateSummary, XlStreamError> {
+    tracing::trace!("xlstream-eval::evaluate stub called");
+    Err(XlStreamError::Internal("unimplemented: evaluate — lands in Phase 4".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn evaluate_returns_unimplemented_internal_error() {
+        let err = evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), None).unwrap_err();
+        assert!(
+            matches!(err, xlstream_core::XlStreamError::Internal(ref msg) if msg.contains("unimplemented")),
+            "expected Internal(unimplemented...), got {err:?}",
+        );
+    }
+
+    #[test]
+    fn summary_fields_default_to_zero() {
+        let s = EvaluateSummary::default();
+        assert_eq!(s.rows_processed, 0);
+        assert_eq!(s.duration_ms, 0);
+        assert_eq!(s.peak_rss_bytes, 0);
+    }
+}

--- a/crates/xlstream-eval/src/lib.rs
+++ b/crates/xlstream-eval/src/lib.rs
@@ -1,0 +1,27 @@
+//! # xlstream-eval
+//!
+//! Streaming Excel formula evaluator. Phase 1 ships the public entry
+//! point [`evaluate`] and the [`EvaluateSummary`] return type as stubs;
+//! the real streaming engine, prelude, and builtin registry land in
+//! Phase 4 and beyond.
+
+#![warn(missing_docs, rust_2018_idioms, clippy::pedantic, clippy::cargo)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::print_stdout,
+    clippy::dbg_macro
+)]
+#![allow(clippy::module_name_repetitions, clippy::cargo_common_metadata)]
+// `clippy::multiple_crate_versions` fires because xlstream-io transitively
+// pulls calamine and rust_xlsxwriter, which disagree on `hashbrown` and
+// `wit-bindgen` minor versions. Ratified for xlstream-io in PR 2; the
+// constraint propagates to any workspace crate that depends on xlstream-io.
+#![allow(clippy::multiple_crate_versions)]
+
+mod evaluate;
+
+pub use evaluate::{evaluate, EvaluateSummary};

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -56,8 +56,8 @@ Do NOT work multiple phases simultaneously. Do NOT skip checkboxes out of order 
 | # | Phase | File | Status |
 |---|---|---|---|
 | 0 | Foundation | [`phase-00-foundation.md`](phase-00-foundation.md) | in progress |
-| 1 | Scaffolding | [`phase-01-scaffolding.md`](phase-01-scaffolding.md) | not started |
-| 2 | Parser integration | [`phase-02-parser.md`](phase-02-parser.md) | not started |
+| 1 | Scaffolding | [`phase-01-scaffolding.md`](phase-01-scaffolding.md) | ✓ complete |
+| 2 | Parser integration | [`phase-02-parser.md`](phase-02-parser.md) | in progress |
 | 3 | I/O layer | [`phase-03-io.md`](phase-03-io.md) | not started |
 | 4 | Streaming core | [`phase-04-streaming-core.md`](phase-04-streaming-core.md) | not started |
 | 5 | Arithmetic, comparison, concat | [`phase-05-arithmetic.md`](phase-05-arithmetic.md) | not started |

--- a/docs/phases/phase-01-scaffolding.md
+++ b/docs/phases/phase-01-scaffolding.md
@@ -15,9 +15,9 @@
 - [x] `crates/xlstream-core/` with `Cargo.toml` + `src/lib.rs`.
 - [x] `crates/xlstream-parse/` with `Cargo.toml` + `src/lib.rs`.
 - [x] `crates/xlstream-io/` with `Cargo.toml` + `src/lib.rs`.
-- [ ] `crates/xlstream-eval/` with `Cargo.toml` + `src/lib.rs`.
-- [ ] `crates/xlstream-cli/` with `Cargo.toml` + `src/main.rs`.
-- [ ] Register all five in workspace root `Cargo.toml` `[workspace] members`.
+- [x] `crates/xlstream-eval/` with `Cargo.toml` + `src/lib.rs`.
+- [x] `crates/xlstream-cli/` with `Cargo.toml` + `src/main.rs`.
+- [x] Register all five in workspace root `Cargo.toml` `[workspace] members`.
 
 ### `xlstream-core`
 
@@ -54,27 +54,27 @@
 
 ### `xlstream-eval`
 
-- [ ] Deps: `xlstream-core`, `xlstream-parse`, `xlstream-io`, `tracing`. (`rayon` lands in Phase 10, `phf` lands in Phase 7 — each phase declares only what it uses.)
-- [ ] Stubs:
-  - [ ] `pub fn evaluate(input: &Path, output: &Path, workers: Option<usize>) -> Result<EvaluateSummary, XlStreamError>`.
-  - [ ] `pub struct EvaluateSummary { pub rows_processed: u32, pub duration_ms: u64, pub peak_rss_bytes: u64 }`.
-  - [ ] Stubs return an error or zero summary.
-- [ ] Rustdoc.
+- [x] Deps: `xlstream-core`, `xlstream-parse`, `xlstream-io`, `tracing`. (`rayon` lands in Phase 10, `phf` lands in Phase 7 — each phase declares only what it uses.)
+- [x] Stubs:
+  - [x] `pub fn evaluate(input: &Path, output: &Path, workers: Option<usize>) -> Result<EvaluateSummary, XlStreamError>`.
+  - [x] `pub struct EvaluateSummary { pub rows_processed: u32, pub duration_ms: u64, pub peak_rss_bytes: u64 }`.
+  - [x] Stubs return an error or zero summary.
+- [x] Rustdoc.
 
 ### `xlstream-cli`
 
-- [ ] Dep on `clap` (derive feature), `xlstream-eval`, `xlstream-io`, `tracing-subscriber`.
-- [ ] Stub binary with a single `evaluate` subcommand.
-- [ ] `cargo run -p xlstream-cli -- evaluate --help` works.
+- [x] Dep on `clap` (derive feature), `xlstream-eval`, `xlstream-io`, `tracing-subscriber`.
+- [x] Stub binary with a single `evaluate` subcommand.
+- [x] `cargo run -p xlstream-cli -- evaluate --help` works.
 
 ### Tests
 
-- [ ] Each crate has `#[cfg(test)]` unit tests — at least one passing test, even if it just asserts `2 + 2 == 4`. Establishes the test harness runs.
-- [ ] Run `cargo test --workspace` — all green.
+- [x] Each crate has `#[cfg(test)]` unit tests — at least one passing test, even if it just asserts `2 + 2 == 4`. Establishes the test harness runs.
+- [x] Run `cargo test --workspace` — all green.
 
 ### CI
 
-- [ ] Verify workflows run and pass on the scaffolding commit.
+- [x] Verify workflows run and pass on the scaffolding commit.
 
 ## Cargo crate dependency graph check
 


### PR DESCRIPTION
## What

Phase 1 PR 3 of 3. Completes the crate scaffolding:

- `xlstream-eval`: `evaluate(&Path, &Path, Option<usize>)` + `EvaluateSummary`.
  Returns `Internal("unimplemented ...")` for now; the real engine lands in
  Phase 4. Direct deps: `xlstream-core`, `xlstream-parse`, `xlstream-io`,
  `tracing` — matches the phase-01 reference graph as amended by PR 7.
- `xlstream-cli`: clap-based `evaluate` subcommand. `cargo run -p xlstream-cli
  -- --help` and `-- evaluate --help` both work; real execution surfaces the
  `evaluate` stub's error through the CLI and exits 1.

## Why

Closes Phase 1 of the project roadmap (`docs/phases/phase-01-scaffolding.md`).
Unlocks Phase 2 (parser integration).

## Dependencies added

- `clap = { version = "4.5", features = ["derive"] }` — standard CLI argument
  parser; only consumed by `xlstream-cli`.
- `tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }`
  — canonical partner to the already-included `tracing`; only consumed by
  `xlstream-cli`.

Both added to `[workspace.dependencies]`. Pre-approved by @cilladev before
this PR opened. Context7 confirmed both API shapes (clap derive Parser/Subcommand,
tracing-subscriber fmt + EnvFilter::try_new) against current docs.

## Testing

- `cargo build --workspace` — green.
- `cargo test --workspace --all-features` — green, including a CLI arg-parse
  test.
- `cargo test --workspace --doc` — green.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo doc --workspace --no-deps` — no warnings.
- `cargo tree -p xlstream-eval` — matches phase-01 reference graph
  (xlstream-core, xlstream-parse, xlstream-io, tracing; no rayon, no phf).
- `cargo run -p xlstream-cli -- --help` — shows the `evaluate` subcommand.
- `cargo run -p xlstream-cli -- evaluate in.xlsx -o out.xlsx` — surfaces the
  stub's `Internal("unimplemented: evaluate — lands in Phase 4")` error and
  exits 1.

## Docs

- Rustdoc + doctest on every pub item in `xlstream-eval`.
- `docs/phases/phase-01-scaffolding.md`: every box ticked.
- `docs/phases/README.md`: Phase 1 -> complete; Phase 2 -> in progress.

## Plan divergences encountered

- `clippy::multiple_crate_versions` fires on `xlstream-eval` (transitive
  `hashbrown` 0.15/0.17 + `wit-bindgen` 0.51/0.57 via `xlstream-io` ->
  calamine/rust_xlsxwriter). Applied the ratified `#![allow(clippy::multiple_crate_versions)]`
  at the crate root with a comment. `xlstream-cli` did not trip; no allow
  added there.

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo test --doc`