### PR TITLE
docs: add adr for phase-02 toolchain bump decision

### DIFF
--- a/docs/decisions/2026-04-18-phase-02-toolchain-bump.md
+++ b/docs/decisions/2026-04-18-phase-02-toolchain-bump.md
@@ -1,0 +1,63 @@
+# Bump Rust toolchain 1.85 → 1.88 to integrate formualizer-parse 1.1.2
+
+**Status:** Accepted
+
+## Context
+
+Phase 1 pinned `formualizer-parse = "0.5"` per [`docs/architecture/parse-reuse.md`](../architecture/parse-reuse.md). That version does not exist on crates.io. The only published versions of the upstream parser and its common-types crate are:
+
+- `formualizer-parse 1.1.2`
+- `formualizer-common 1.1.2`
+
+Both were confirmed via `cargo search formualizer-common` and `cargo search formualizer-parse` in the Phase 2 investigation session (2026-04-18). No earlier releases exist.
+
+Both crates require Rust 1.88 to compile:
+
+- `formualizer-common 1.1.2` uses `let` expressions inside `if` conditions — the `let_chains` feature, rust-lang issue #53667 — at three sites: `crates/formualizer-common/src/address.rs:396`, `crates/formualizer-common/src/address.rs:401`, `crates/formualizer-common/src/error.rs:257`. Stabilised in Rust 1.88.
+- Both crates declare `edition = "2024"`, which itself requires Rust 1.85+.
+
+xlstream currently pins Rust 1.85 via `rust-toolchain.toml`, `Cargo.toml` `rust-version = "1.85"`, and `clippy.toml` `msrv = "1.85"`. Phase 1 stubbed `xlstream_parse::Ast` as a unit struct and explicitly deferred the integration decision to Phase 2 (see comment block in the root `Cargo.toml`).
+
+## Decision
+
+Bump the xlstream toolchain and MSRV 1.85 → 1.88. Integrate upstream directly:
+
+- Declare both crates in `[workspace.dependencies]` with **exact** pins:
+  ```toml
+  formualizer-parse = "=1.1.2"
+  formualizer-common = "=1.1.2"
+  ```
+  We declare `formualizer-common` even though it would otherwise come transitively, so we control the pin ourselves.
+- Use `std::sync::OnceLock` (stable since Rust 1.70) in **our own** code wherever a process-global lazy-initialised cell is needed. Do **not** import `once_cell` directly. `once_cell` enters the workspace solely as an upstream transitive dep.
+- Mechanical toolchain bump lands in a separate follow-up PR (one-line diffs across three files) that links back to this ADR. This ADR is docs-only.
+
+## Consequences
+
+- **MSRV advances 1.85 → 1.88.** Acceptable. Rust 1.88 has been stable since 2025-06-26. xlstream's primary downstream consumer is the Python binding (Phase 11), distributed as a maturin-built `abi3-py39` wheel; Rust MSRV only affects Rust consumers of the library crates, a small population.
+- **Two new transitive runtime deps appear:** `chrono` (via `formualizer-common`) and `once_cell` (via `formualizer-parse`). Both are in the standard-Rust-ecosystem baseline; neither requires a dedicated design note beyond a one-line mention in the toolchain-bump PR description.
+- **Upstream public API maps cleanly to the planned `Ast` wrapper.** From `refs/formualizer/crates/formualizer-parse/src/`:
+  - Entry point: `pub fn parse<T: AsRef<str>>(formula: T) -> Result<ASTNode, ParserError>`.
+  - Node type: `ASTNode { node_type: ASTNodeType, source_token: Option<Token>, contains_volatile: bool }`.
+  - Variants: `ASTNodeType::{Literal, Reference, UnaryOp, BinaryOp, Function, Array}`.
+  - Reference enum: `ReferenceType`.
+  - Re-exported from `formualizer-common`: `LiteralValue`, `ExcelError`, `ExcelErrorKind`, `ArgKind`.
+- **Exact pins** per `docs/architecture/parse-reuse.md` guidance — upstream stability policy is unknown, so `=1.1.2` prevents silent minor-version drift. Revisit if upstream publishes stability guarantees.
+- **Empirically verified during the investigation session (2026-04-18):**
+  - `cargo +1.88.0 check` on `refs/formualizer/crates/formualizer-parse` — clean.
+  - `cargo +1.88.0 check --workspace --all-features` on xlstream — clean.
+  - `cargo +1.88.0 clippy --workspace --all-targets --all-features -- -D warnings` on xlstream — clean.
+- **Six ratified Phase 1 clippy divergences still apply.** None are MSRV-sensitive.
+
+## Alternatives considered
+
+### Option B — Pin an older compatible pair
+
+Rejected. Only `1.1.2` is published on crates.io for both `formualizer-parse` and `formualizer-common`; there is no earlier pair to pin. Confirmed via `cargo search`.
+
+### Option C — Vendor `formualizer-parse` and `formualizer-common` into the workspace
+
+Rejected. Vendoring **does not** avoid the toolchain bump: both upstream crates declare `edition = "2024"`, and Rust 2024 edition requires Rust 1.85 at minimum. (Combined with the `let_chains` usage, a vendoring path that wanted to keep today's `1.85` pin would additionally have to *rewrite* the let-chain expressions, which is even more fragile than a toolchain bump.) Vendoring therefore buys no toolchain flexibility while adding ongoing maintenance burden — bug-fix merges, API-drift tracking, two extra crates in our CI matrix. Hold Option C in reserve for a future emergency (upstream goes unmaintained, API diverges destructively, etc.) rather than starting there.
+
+### Option A — Bump toolchain 1.85 → 1.88 (chosen)
+
+Single-commit change across three files (`rust-toolchain.toml`, `Cargo.toml` `rust-version`, `clippy.toml` `msrv`). Same mechanical pattern as PR #5 (1.82 → 1.85). No new maintenance burden. Unblocks the current, maintained upstream parser.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,22 @@
+# Architecture Decision Records (ADRs)
+
+Long-lived decisions that explain *why* a path was chosen — context beyond what fits in a phase doc, commit message, or architecture page.
+
+## Conventions
+
+- **Filename:** `YYYY-MM-DD-<kebab-case-topic>.md`. The date is the date the ADR was accepted (or first drafted if still pending), not the date the underlying change ships.
+- **Sections, in this order:** `## Context` → `## Decision` → `## Consequences` → `## Alternatives considered`.
+- **Status line** as the first line after the title:
+
+  ```
+  **Status:** Accepted
+  ```
+
+  Allowed values: `Accepted`, `Proposed`, `Superseded by [<filename>](./<filename>)`, `Rejected`.
+- One ADR per decision. Do **not** edit an accepted ADR. If the decision is reversed, write a new ADR that references and supersedes the old one; update the old ADR's status to `Superseded by ...`.
+
+## Index
+
+| Date | ADR | Status |
+|---|---|---|
+| 2026-04-18 | [Bump Rust toolchain 1.85 → 1.88 to integrate formualizer-parse 1.1.2](2026-04-18-phase-02-toolchain-bump.md) | Accepted |


### PR DESCRIPTION
## What

ADR capturing the Phase 2 `formualizer-parse` integration decision: bump the xlstream toolchain 1.85 → 1.88. Docs-only. Introduces `docs/decisions/` with filename/section conventions and an index.

## Why

Phase 1 flagged `formualizer-parse` as vaporware at the originally-pinned `0.5`. Only `formualizer-parse = 1.1.2` and `formualizer-common = 1.1.2` are published on crates.io, and both require Rust 1.88 (`let_chains` in `formualizer-common/src/address.rs:396,401` and `formualizer-common/src/error.rs:257`).

Three options evaluated empirically:

- **A — Bump toolchain 1.85 → 1.88.** Chosen. Same mechanical pattern as PR #5. No new maintenance burden.
- **B — Pin older compatible pair.** Impossible. `1.1.2` is the only published version on crates.io for both crates.
- **C — Vendor upstream.** Rejected. Both crates declare `edition = "2024"`, which requires Rust 1.85+; vendoring does not avoid the toolchain bump and adds ongoing maintenance burden.

Empirically verified this session:

- `cargo +1.88.0 check` on `refs/formualizer/crates/formualizer-parse` — clean.
- `cargo +1.88.0 check --workspace --all-features` on xlstream — clean.
- `cargo +1.88.0 clippy --workspace --all-targets --all-features -- -D warnings` on xlstream — clean.

## How

Two new files:

- `docs/decisions/README.md` — ADR conventions (filename `YYYY-MM-DD-<topic>.md`, section order `Context` → `Decision` → `Consequences` → `Alternatives considered`, `**Status:**` line) and a chronological index.
- `docs/decisions/2026-04-18-phase-02-toolchain-bump.md` — the ADR itself.

Explicit decisions locked in by the ADR:

- Declare both `formualizer-parse = "=1.1.2"` and `formualizer-common = "=1.1.2"` in `[workspace.dependencies]` with exact pins. We declare `formualizer-common` directly (not only transitively) so we control the pin.
- Our own code uses `std::sync::OnceLock` (stable since 1.70). `once_cell` enters the graph only as an upstream transitive dep; never import it directly.
- Mechanical toolchain bump ships as a follow-up PR, linking back to this ADR.

## Testing

No code changes. `make check` status unchanged by this PR. The empirical 1.88 compile + clippy runs above stand in for toolchain-level verification; they will be re-run in the follow-up bump PR.

## Docs

- [x] New `docs/decisions/` subtree with index and first ADR
- [ ] Follow-up PR: mechanical toolchain bump (`rust-toolchain.toml`, `Cargo.toml`, `clippy.toml`)

## Checklist

- [x] `docs` prefix commit, lowercase imperative subject
- [x] No `Co-Authored-By: Claude` / `Generated with Claude Code` trailers
- [x] No emojis
- [x] ADR follows the conventions captured in `docs/decisions/README.md`