### PR TITLE
chore: bump rust to 1.88 (unblocks formualizer-parse 1.1.2 for phase 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cilladev/xlstream"
 homepage = "https://github.com/cilladev/xlstream"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.85"
+msrv = "1.88"
 avoid-breaking-exported-api = true
 cognitive-complexity-threshold = 25
 too-many-arguments-threshold = 8

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy", "rust-src"]
 profile = "default"


### PR DESCRIPTION
## What

Mechanical toolchain bump 1.85 → 1.88. Three one-line edits:

- `rust-toolchain.toml`: `channel = "1.85.0"` → `"1.88.0"`
- `Cargo.toml`: `rust-version = "1.85"` → `"1.88"`
- `clippy.toml`: `msrv = "1.85"` → `"1.88"`

Same mechanical pattern as PR #5 (1.82 → 1.85).

## Why

Implements the decision in ADR [`docs/decisions/2026-04-18-phase-02-toolchain-bump.md`](../blob/main/docs/decisions/2026-04-18-phase-02-toolchain-bump.md) (merged in #10).

Summary: upstream `formualizer-parse 1.1.2` / `formualizer-common 1.1.2` are the only published versions on crates.io, both use `let_chains` in `formualizer-common/src/{address,error}.rs` (stabilised in Rust 1.88), and both declare `edition = "2024"` (requires Rust 1.85+). Phase 2 cannot integrate the upstream parser without this bump.

New transitive runtime deps the bump enables Phase 2 to pull in: `chrono` (via `formualizer-common`) and `once_cell` (via `formualizer-parse`). Both are in the standard-Rust-ecosystem baseline. Our own code will use `std::sync::OnceLock`, not `once_cell` directly.

## How

`rustup toolchain install 1.88.0 --profile minimal` followed by `rustup component add clippy rustfmt --toolchain 1.88.0` installs the toolchain on a fresh machine. CI already pulls the toolchain via `rust-toolchain.toml`, so no CI workflow changes are required.

## Testing

Ran `make check` locally on 1.88:

- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo test --workspace --all-features` — 20 unit tests pass.
- `cargo test --workspace --doc` — 18 doctests pass.

All six ratified Phase 1 clippy divergences still apply unchanged; none are MSRV-sensitive.

## Docs

- [x] ADR `docs/decisions/2026-04-18-phase-02-toolchain-bump.md` already merged in #10 captures the rationale
- [x] `MANAGER.md` already anticipates this bump ("Toolchain on 1.85. … Phase 2 may bump to 1.88") — will be updated when Phase 2 closes, not in this PR

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` passes
- [x] `cargo test --doc` passes
- [x] No `Co-Authored-By: Claude` / `Generated with Claude Code` trailers
- [x] No emojis
- [x] `chore` prefix, lowercase imperative subject under 72 chars