### PR TITLE
xlstream-parse: integrate formualizer-parse 1.1.2 (phase 2 chunk 0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +147,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -187,6 +216,12 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -265,6 +300,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "formualizer-common"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f89ff5c5a3b71cd6c684feac9ded5503d698c1d699d924b5e6c7efeb65147de"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "formualizer-parse"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263bc7dfe928ddc7fd9f5f590a39822705d7f3f03bdeee42df0947cb9e293e94"
+dependencies = [
+ "formualizer-common",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +354,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +406,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -401,6 +490,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -511,6 +609,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -768,6 +872,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,10 +951,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -952,6 +1154,9 @@ dependencies = [
 name = "xlstream-parse"
 version = "0.1.0"
 dependencies = [
+ "formualizer-common",
+ "formualizer-parse",
+ "smallvec",
  "xlstream-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,9 @@ authors = ["Priscilla Emasoga"]
 calamine = "0.34"
 rust_xlsxwriter = { version = "0.94", features = ["constant_memory", "zlib", "ryu"] }
 
-# formula parser — reused from formualizer
-# formualizer-parse: upstream 0.5.x does not exist; 1.x pulls in
-# formualizer-common 1.1.2 which uses Rust 1.88 `let` chains, incompatible
-# with our 1.85 toolchain pin. Re-evaluated in Phase 2 (see
-# docs/phases/phase-02-parser.md). Phase 1 ships the Ast as a self-contained
-# stub per the plan's Task 2.3 fallback guidance.
-# formualizer-parse = "0.5"
+# formula parser — pinned exactly per ADR docs/decisions/2026-04-18-phase-02-toolchain-bump.md.
+formualizer-parse = "=1.1.2"
+formualizer-common = "=1.1.2"
 
 # Python binding
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }

--- a/crates/xlstream-core/src/error.rs
+++ b/crates/xlstream-core/src/error.rs
@@ -45,7 +45,8 @@ pub enum XlStreamError {
     },
 
     /// The formula parser rejected the input as malformed.
-    #[error("formula parse error at {address}: {message}\n  formula: {formula}")]
+    #[error("formula parse error at {address}{}: {message}\n  formula: {formula}",
+        position.map_or(String::new(), |p| format!(" (position {p})")))]
     FormulaParse {
         /// The cell address that held the formula.
         address: String,
@@ -53,6 +54,9 @@ pub enum XlStreamError {
         formula: String,
         /// Parser-supplied diagnostic.
         message: String,
+        /// Byte offset into `formula` where the parser failed, if upstream
+        /// reported one.
+        position: Option<usize>,
     },
 
     /// The classifier could not assign a [`Classification`] to a formula.
@@ -89,6 +93,30 @@ mod tests {
     fn internal_variant_formats_with_message() {
         let e = XlStreamError::Internal("oops".into());
         assert_eq!(e.to_string(), "internal invariant violation: oops");
+    }
+
+    #[test]
+    fn formula_parse_includes_position_in_message_when_present() {
+        let e = XlStreamError::FormulaParse {
+            address: "Sheet1!A1".into(),
+            formula: "SUM(A1:".into(),
+            message: "expected closing paren".into(),
+            position: Some(7),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("position 7"), "expected position in message: {msg}");
+    }
+
+    #[test]
+    fn formula_parse_omits_position_when_absent() {
+        let e = XlStreamError::FormulaParse {
+            address: "Sheet1!A1".into(),
+            formula: "SUM(".into(),
+            message: "unexpected end of input".into(),
+            position: None,
+        };
+        let msg = e.to_string();
+        assert!(!msg.contains("position"), "did not expect 'position' in: {msg}");
     }
 
     #[test]

--- a/crates/xlstream-parse/Cargo.toml
+++ b/crates/xlstream-parse/Cargo.toml
@@ -13,10 +13,12 @@ authors.workspace = true
 
 [dependencies]
 xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
-# formualizer-parse: deferred to Phase 2 per plan Task 2.3 fallback.
-# Workspace pin is commented out pending MSRV compatibility — see
-# Cargo.toml comment at the workspace root.
+formualizer-parse = { workspace = true }
+formualizer-common = { workspace = true }
+smallvec = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
+cargo_common_metadata = "allow"
+module_name_repetitions = "allow"

--- a/crates/xlstream-parse/src/ast.rs
+++ b/crates/xlstream-parse/src/ast.rs
@@ -74,22 +74,24 @@ impl PartialEq for Ast {
 }
 
 impl Ast {
-    /// Test-only constructor that builds trees without going through
-    /// [`crate::parse`].
-    #[doc(hidden)]
-    #[must_use]
-    #[allow(private_interfaces)]
-    pub fn from_root_for_tests(root: Node) -> Self {
-        let upstream = formualizer_parse::parse("=0").unwrap_or_else(|_| unreachable!());
-        Self { upstream, root }
-    }
-
     /// Crate-internal accessor for the raw upstream tree.
     /// Used by `extract_references` in Chunk 1.
     #[must_use]
     #[allow(dead_code)]
     pub(crate) fn as_upstream(&self) -> &formualizer_parse::ASTNode {
         &self.upstream
+    }
+}
+
+#[cfg(test)]
+impl Ast {
+    /// Test-only constructor that builds trees without going through
+    /// [`crate::parse`].
+    #[allow(clippy::unwrap_used, clippy::missing_panics_doc, private_interfaces)]
+    #[must_use]
+    pub fn from_root_for_tests(root: Node) -> Self {
+        let upstream = formualizer_parse::parse("=0").unwrap();
+        Self { upstream, root }
     }
 }
 

--- a/crates/xlstream-parse/src/ast.rs
+++ b/crates/xlstream-parse/src/ast.rs
@@ -1,33 +1,122 @@
-//! The [`Ast`] placeholder.
+//! The opaque [`Ast`] — wraps the raw upstream `ASTNode` plus our internal
+//! tree of [`Node`]s mirroring it.
+//!
+//! Why both: `extract_references` (Chunk 1) uses upstream's zero-alloc
+//! `visit_refs` walker via [`Ast::as_upstream`]; classification + rewrite
+//! (Chunks 3-4) use the mirror so we can splice in `Node::PreludeRef`
+//! (Chunk 4) without leaking upstream types in our public API.
 
-/// Parsed-formula AST. Phase 1 ships this as an opaque placeholder; Phase 2
-/// replaces the internals with a wrapper around `formualizer_parse::Ast`.
+use xlstream_core::CellError;
+
+use crate::references::Reference;
+
+/// Numeric or boolean literal carried by [`Node::Literal`].
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum NumLiteral {
+    /// An `f64` numeric value.
+    Number(f64),
+    /// A boolean literal (`TRUE` / `FALSE`).
+    Bool(bool),
+}
+
+/// One node in the parsed-formula tree. Mirrors upstream's
+/// `formualizer_parse::ASTNodeType` so we can splice in `PreludeRef`
+/// (Chunk 4) and so error literals are first-class via `Node::Error`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Node {
+    /// A scalar literal.
+    Literal(NumLiteral),
+    /// A text literal.
+    Text(String),
+    /// An error literal (`=#REF!`, `=#DIV/0!`, etc.).
+    Error(CellError),
+    /// A reference to one or more cells.
+    Reference(Reference),
+    /// Unary operator (`-`, `%`).
+    UnaryOp { op: String, expr: Box<Node> },
+    /// Binary operator (`+ - * / ^ & = <> < > <= >= :`).
+    BinaryOp { op: String, left: Box<Node>, right: Box<Node> },
+    /// Function call.
+    Function { name: String, args: Vec<Node> },
+    /// Array constant `{1,2;3,4}`. `Vec` instead of `SmallVec` because
+    /// inline `Node` storage would create a layout cycle.
+    Array(Vec<Vec<Node>>),
+    // PreludeRef variant added in Chunk 4 (rewrite.rs).
+}
+
+/// Parsed formula. Opaque by design — internals are crate-internal so we
+/// can evolve the tree across phases without breaking semver.
+///
+/// Build one with [`crate::parse`].
 ///
 /// # Examples
 ///
 /// ```
-/// use xlstream_parse::Ast;
-/// let a = Ast::default();
-/// let b = Ast::default();
-/// assert_eq!(a, b);
+/// use xlstream_parse::parse;
+/// let ast = parse("1+2").unwrap();
+/// assert!(format!("{ast:?}").contains("BinaryOp"));
 /// ```
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Ast {
-    // Intentionally private and empty in Phase 1. Phase 2 adds the
-    // upstream-AST field.
-    _private: (),
+    /// Original upstream tree, retained for `visit_refs` etc.
+    /// Read by `as_upstream()` in Chunk 1 (`extract_references`).
+    #[allow(dead_code)]
+    pub(crate) upstream: formualizer_parse::ASTNode,
+    /// Our mirror tree. Used by classify + rewrite.
+    pub(crate) root: Node,
+}
+
+impl PartialEq for Ast {
+    /// Equality compares the mirror tree only.
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+    }
+}
+
+impl Ast {
+    /// Test-only constructor that builds trees without going through
+    /// [`crate::parse`].
+    #[doc(hidden)]
+    #[must_use]
+    #[allow(private_interfaces)]
+    pub fn from_root_for_tests(root: Node) -> Self {
+        let upstream = formualizer_parse::parse("=0").unwrap_or_else(|_| unreachable!());
+        Self { upstream, root }
+    }
+
+    /// Crate-internal accessor for the raw upstream tree.
+    /// Used by `extract_references` in Chunk 1.
+    #[must_use]
+    #[allow(dead_code)]
+    pub(crate) fn as_upstream(&self) -> &formualizer_parse::ASTNode {
+        &self.upstream
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::float_cmp)]
 
     use super::*;
 
     #[test]
-    fn default_constructs_empty_placeholder() {
-        let a = Ast::default();
-        let b = Ast::default();
-        assert_eq!(a, b);
+    fn ast_carries_both_upstream_and_mirror() {
+        let ast = Ast::from_root_for_tests(Node::Literal(NumLiteral::Number(42.0)));
+        assert!(format!("{ast:?}").contains("42"), "expected literal in debug: {ast:?}");
+    }
+
+    #[test]
+    fn node_literal_compares_by_value() {
+        assert_eq!(Node::Literal(NumLiteral::Bool(true)), Node::Literal(NumLiteral::Bool(true)));
+        assert_ne!(Node::Literal(NumLiteral::Bool(true)), Node::Literal(NumLiteral::Bool(false)));
+    }
+
+    #[test]
+    fn node_error_variant_carries_cell_error() {
+        let n = Node::Error(CellError::Ref);
+        match n {
+            Node::Error(CellError::Ref) => (),
+            other => panic!("expected Error(Ref), got {other:?}"),
+        }
     }
 }

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -6,8 +6,9 @@ use crate::ast::Ast;
 
 /// The verdict returned by [`classify`] for a single formula.
 ///
-/// Phase 1 ships this enum shape; Phase 2 replaces `Unsupported(String)`
-/// with a structured reason type (see `docs/phases/phase-02-parser.md`).
+/// Phase 1 ships this enum shape; Phase 2 (Chunk 2) replaces
+/// `Unsupported(String)` with a structured `UnsupportedReason` type
+/// (see `docs/phases/phase-02-parser.md`).
 ///
 /// # Examples
 ///
@@ -31,8 +32,8 @@ pub enum Classification {
     Unsupported(String),
 }
 
-/// Context passed to [`classify`]. Phase 1 is a placeholder; Phase 2 fills
-/// it with workbook metadata (sheet names, header maps, prelude plans).
+/// Context passed to [`classify`]. Chunk 2 fills this with workbook
+/// metadata (sheet names, header maps, prelude plans).
 ///
 /// # Examples
 ///
@@ -45,21 +46,20 @@ pub struct ClassificationContext {
     _private: (),
 }
 
-/// Classify a parsed formula. Phase 1 always returns
-/// [`Classification::Unsupported`] with a note that real classification
-/// lands in Phase 2.
+/// Classify a parsed formula. Stub: always returns
+/// [`Classification::Unsupported`]. Real implementation lands in Chunk 3.
 ///
 /// # Examples
 ///
 /// ```
-/// use xlstream_parse::{classify, Ast, Classification, ClassificationContext};
-/// let ast = Ast::default();
+/// use xlstream_parse::{classify, parse, Classification, ClassificationContext};
+/// let ast = parse("1+2").unwrap();
 /// let ctx = ClassificationContext::default();
 /// matches!(classify(&ast, &ctx), Classification::Unsupported(_));
 /// ```
 #[must_use]
 pub fn classify(_ast: &Ast, _ctx: &ClassificationContext) -> Classification {
-    Classification::Unsupported("classification not implemented until Phase 2".into())
+    Classification::Unsupported("classification not implemented until Phase 2 Chunk 3".into())
 }
 
 #[cfg(test)]
@@ -67,15 +67,14 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
     use super::*;
-    use crate::Ast;
 
     #[test]
     fn classify_returns_unsupported_stub() {
-        let ast = Ast::default();
+        let ast = crate::parse("1+2").unwrap();
         let ctx = ClassificationContext::default();
         match classify(&ast, &ctx) {
             Classification::Unsupported(msg) => {
-                assert!(msg.contains("Phase 2"), "expected Phase 2 note, got: {msg}");
+                assert!(msg.contains("Chunk 3"), "expected Chunk 3 note, got: {msg}");
             }
             other => panic!("expected Unsupported, got {other:?}"),
         }

--- a/crates/xlstream-parse/src/lib.rs
+++ b/crates/xlstream-parse/src/lib.rs
@@ -23,7 +23,9 @@
 mod ast;
 mod classify;
 mod parser;
+mod references;
 
 pub use ast::Ast;
 pub use classify::{classify, Classification, ClassificationContext};
 pub use parser::parse;
+pub use references::{Reference, References};

--- a/crates/xlstream-parse/src/parser.rs
+++ b/crates/xlstream-parse/src/parser.rs
@@ -92,9 +92,9 @@ fn lower_literal(lv: &formualizer_common::LiteralValue) -> Node {
         L::Boolean(b) => Node::Literal(NumLiteral::Bool(*b)),
         L::Text(s) => Node::Text(s.clone()),
         L::Error(e) => Node::Error(map_excel_error(e)),
-        // Phase 4: first-class variants for Date / Time / DateTime /
+        // TODO(phase-4): first-class variants for Date / Time / DateTime /
         // Duration / Empty / Pending / Array literals.
-        other => Node::Text(format!("{other:?}")),
+        _other => Node::Error(xlstream_core::CellError::Value),
     }
 }
 

--- a/crates/xlstream-parse/src/parser.rs
+++ b/crates/xlstream-parse/src/parser.rs
@@ -2,45 +2,174 @@
 
 use xlstream_core::XlStreamError;
 
-use crate::ast::Ast;
+use crate::ast::{Ast, Node, NumLiteral};
+use crate::references::Reference;
 
 /// Parse an Excel formula expression into an [`Ast`].
 ///
 /// The input must **not** include a leading `=`; that's an I/O concern,
 /// stripped before the parser sees the text.
 ///
-/// Phase 1 returns [`XlStreamError::Internal`] so callers do not
-/// accidentally build on a pre-integration parser. The real implementation
-/// lands in Phase 2.
-///
 /// # Errors
 ///
-/// - Phase 1: always [`XlStreamError::Internal`].
-/// - Phase 2 onward: [`XlStreamError::FormulaParse`] for malformed input.
+/// [`XlStreamError::FormulaParse`] for malformed input. The `address`
+/// field is left empty; callers that have the cell address must enrich
+/// with `map_err`. The `position` field carries upstream's byte offset
+/// into `expr` when reported.
 ///
 /// # Examples
 ///
 /// ```
 /// use xlstream_parse::parse;
-/// let err = parse("SUM(A1:A10)").unwrap_err();
-/// assert!(err.to_string().contains("unimplemented"));
+/// let ast = parse("SUM(A1:A10)").expect("parse failed");
+/// assert!(format!("{ast:?}").contains("Function"));
 /// ```
-pub fn parse(_expr: &str) -> Result<Ast, XlStreamError> {
-    Err(XlStreamError::Internal("unimplemented: parse — lands in Phase 2".into()))
+pub fn parse(expr: &str) -> Result<Ast, XlStreamError> {
+    let with_eq = format!("={expr}");
+    let upstream = formualizer_parse::parse(&with_eq).map_err(|e| XlStreamError::FormulaParse {
+        address: String::new(),
+        formula: expr.to_owned(),
+        message: e.message,
+        position: e.position.map(|p| p.saturating_sub(1)),
+    })?;
+
+    let root = lower(&upstream);
+    Ok(Ast { upstream, root })
+}
+
+/// Lower an upstream `ASTNode` into our internal [`Node`].
+pub(crate) fn lower(node: &formualizer_parse::ASTNode) -> Node {
+    use formualizer_parse::ASTNodeType as T;
+
+    match &node.node_type {
+        T::Literal(lv) => lower_literal(lv),
+        T::UnaryOp { op, expr } => Node::UnaryOp { op: op.clone(), expr: Box::new(lower(expr)) },
+        T::BinaryOp { op, left, right } => Node::BinaryOp {
+            op: op.clone(),
+            left: Box::new(lower(left)),
+            right: Box::new(lower(right)),
+        },
+        T::Function { name, args } => {
+            Node::Function { name: name.clone(), args: args.iter().map(lower).collect() }
+        }
+        T::Array(rows) => Node::Array(rows.iter().map(|r| r.iter().map(lower).collect()).collect()),
+        T::Reference { reference, .. } => Node::Reference(lower_reference(reference)),
+    }
+}
+
+fn lower_reference(r: &formualizer_parse::parser::ReferenceType) -> Reference {
+    use formualizer_parse::parser::ReferenceType as R;
+    match r {
+        R::Cell { sheet, row, col, .. } => {
+            Reference::Cell { sheet: sheet.clone(), row: *row, col: *col }
+        }
+        R::Range { sheet, start_row, end_row, start_col, end_col, .. } => Reference::Range {
+            sheet: sheet.clone(),
+            start_row: *start_row,
+            end_row: *end_row,
+            start_col: *start_col,
+            end_col: *end_col,
+        },
+        R::NamedRange(name) => Reference::Named(name.clone()),
+        R::External(ext) => Reference::External {
+            raw: ext.raw.clone(),
+            book: ext.book.token().to_owned(),
+            sheet: ext.sheet.clone(),
+        },
+        R::Table(t) => Reference::Table {
+            name: t.name.clone(),
+            specifier: t.specifier.as_ref().map(|s| format!("{s}")),
+        },
+    }
+}
+
+fn lower_literal(lv: &formualizer_common::LiteralValue) -> Node {
+    use formualizer_common::LiteralValue as L;
+    match lv {
+        L::Number(n) => Node::Literal(NumLiteral::Number(*n)),
+        #[allow(clippy::cast_precision_loss)]
+        L::Int(i) => Node::Literal(NumLiteral::Number(*i as f64)),
+        L::Boolean(b) => Node::Literal(NumLiteral::Bool(*b)),
+        L::Text(s) => Node::Text(s.clone()),
+        L::Error(e) => Node::Error(map_excel_error(e)),
+        // Phase 4: first-class variants for Date / Time / DateTime /
+        // Duration / Empty / Pending / Array literals.
+        other => Node::Text(format!("{other:?}")),
+    }
+}
+
+fn map_excel_error(e: &formualizer_common::ExcelError) -> xlstream_core::CellError {
+    use formualizer_common::ExcelErrorKind as K;
+    use xlstream_core::CellError;
+    match e.kind {
+        K::Div => CellError::Div0,
+        K::Value | K::Error | K::NImpl | K::Spill | K::Calc | K::Circ | K::Cancelled => {
+            CellError::Value
+        }
+        K::Ref => CellError::Ref,
+        K::Name => CellError::Name,
+        K::Na => CellError::Na,
+        K::Num => CellError::Num,
+        K::Null => CellError::Null,
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::float_cmp)]
 
     use super::*;
 
     #[test]
-    fn parse_returns_unimplemented_internal_error() {
-        let err = parse("SUM(A1:A10)").unwrap_err();
-        assert!(
-            matches!(err, xlstream_core::XlStreamError::Internal(ref msg) if msg.contains("unimplemented")),
-            "expected Internal(unimplemented...), got {err:?}",
-        );
+    fn parse_returns_ast_for_simple_arithmetic() {
+        let ast = parse("1+2").unwrap();
+        assert!(format!("{ast:?}").contains("BinaryOp"));
+    }
+
+    #[test]
+    fn parse_returns_formula_parse_on_garbage() {
+        let err = parse("SUM(").unwrap_err();
+        assert!(matches!(err, XlStreamError::FormulaParse { .. }));
+    }
+
+    #[test]
+    fn lower_handles_whole_column_range() {
+        let upstream = formualizer_parse::parse("=SUM(A:A)").unwrap();
+        let node = lower(&upstream);
+        let dbg = format!("{node:?}");
+        assert!(dbg.contains("start_row: None"), "expected open range: {dbg}");
+        assert!(dbg.contains("end_row: None"), "expected open range: {dbg}");
+    }
+
+    #[test]
+    fn lower_handles_text_literal() {
+        let upstream = formualizer_parse::parse("=\"hello\"").unwrap();
+        let node = lower(&upstream);
+        assert!(format!("{node:?}").contains("hello"));
+    }
+
+    #[test]
+    fn lower_handles_boolean_literal() {
+        let upstream = formualizer_parse::parse("=TRUE").unwrap();
+        let node = lower(&upstream);
+        assert!(format!("{node:?}").contains("Bool(true)"));
+    }
+
+    #[test]
+    fn map_excel_error_covers_known_kinds() {
+        use formualizer_common::{ExcelError, ExcelErrorKind};
+        use xlstream_core::CellError;
+        for (kind, expected) in [
+            (ExcelErrorKind::Div, CellError::Div0),
+            (ExcelErrorKind::Value, CellError::Value),
+            (ExcelErrorKind::Ref, CellError::Ref),
+            (ExcelErrorKind::Name, CellError::Name),
+            (ExcelErrorKind::Na, CellError::Na),
+            (ExcelErrorKind::Num, CellError::Num),
+            (ExcelErrorKind::Null, CellError::Null),
+        ] {
+            let e = ExcelError::from(kind);
+            assert_eq!(map_excel_error(&e), expected, "kind={kind:?}");
+        }
     }
 }

--- a/crates/xlstream-parse/src/references.rs
+++ b/crates/xlstream-parse/src/references.rs
@@ -1,0 +1,228 @@
+//! Reference types and (in Chunk 1) the [`extract_references`] walker.
+
+use smallvec::SmallVec;
+
+/// One Excel reference: cell, range, named range, external workbook ref,
+/// or table ref.
+///
+/// External and Table variants preserve enough upstream context for an
+/// actionable refusal message (Chunk 3) without structurally mirroring
+/// upstream's `ExternalRefKind` / `TableSpecifier` (drift risk).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::Reference;
+/// let r = Reference::Cell { sheet: Some("Sheet1".into()), row: 2, col: 3 };
+/// assert_eq!(r.sheet(), Some("Sheet1"));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum Reference {
+    /// `Sheet1!$A$2` — fully-resolved cell address.
+    Cell {
+        /// Sheet name. `None` for an unqualified ref on the active sheet.
+        sheet: Option<String>,
+        /// 1-based row.
+        row: u32,
+        /// 1-based column.
+        col: u32,
+    },
+    /// `A:A`, `A1:B10`, `Sheet2!A:C`. Whole-column refs use
+    /// `start_row = None`, `end_row = None`. Whole-row refs use
+    /// `start_col = None`, `end_col = None`.
+    Range {
+        /// Sheet name. `None` for an unqualified range on the active sheet.
+        sheet: Option<String>,
+        /// 1-based start row, or `None` for whole-column refs.
+        start_row: Option<u32>,
+        /// 1-based end row, or `None` for whole-column refs.
+        end_row: Option<u32>,
+        /// 1-based start column, or `None` for whole-row refs.
+        start_col: Option<u32>,
+        /// 1-based end column, or `None` for whole-row refs.
+        end_col: Option<u32>,
+    },
+    /// `MyRange` — workbook-level named range.
+    Named(String),
+    /// `[OtherBook.xlsx]Sheet1!A1` — reference into another workbook.
+    /// Refused at classification with
+    /// [`crate::UnsupportedReason::ExternalReference`].
+    External {
+        /// Original source text (preserved for diagnostics).
+        raw: String,
+        /// Book token from upstream (e.g. `OtherBook.xlsx` or `[1]`).
+        book: String,
+        /// Sheet name within the external book.
+        sheet: String,
+    },
+    /// `Table[Column]` — structured table reference. Refused at
+    /// classification with [`crate::UnsupportedReason::TableReference`].
+    Table {
+        /// Table name.
+        name: String,
+        /// Column / row / item specifier rendered via upstream's `Display`.
+        /// `None` = whole table.
+        specifier: Option<String>,
+    },
+}
+
+/// References surfaced by the (Chunk 1) `extract_references` walker.
+/// Sized by P99 expectation in `docs/architecture/parse-reuse.md`.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::References;
+/// let refs = References::default();
+/// assert!(refs.cells.is_empty());
+/// ```
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct References {
+    /// Every cell reference reachable from the AST root.
+    pub cells: SmallVec<[Reference; 8]>,
+    /// Every range / named-range / external / table reference.
+    pub ranges: SmallVec<[Reference; 4]>,
+    /// Every distinct sheet name mentioned (de-duplicated).
+    pub sheets: SmallVec<[String; 2]>,
+    /// Every function name called (case-preserved, case-insensitively
+    /// de-duplicated).
+    pub functions: SmallVec<[String; 8]>,
+}
+
+impl Reference {
+    /// Sheet name this reference points to, if explicit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::Reference;
+    /// let r = Reference::Cell { sheet: Some("Sheet1".into()), row: 2, col: 3 };
+    /// assert_eq!(r.sheet(), Some("Sheet1"));
+    /// ```
+    #[must_use]
+    pub fn sheet(&self) -> Option<&str> {
+        match self {
+            Self::Cell { sheet, .. } | Self::Range { sheet, .. } => sheet.as_deref(),
+            Self::External { sheet, .. } => Some(sheet.as_str()),
+            Self::Named(_) | Self::Table { .. } => None,
+        }
+    }
+
+    /// `true` for `A:A`-style refs (no row bounds; column bounds present).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::Reference;
+    /// let r = Reference::Range { sheet: None,
+    ///     start_row: None, end_row: None,
+    ///     start_col: Some(1), end_col: Some(1) };
+    /// assert!(r.is_whole_column());
+    /// ```
+    #[must_use]
+    pub fn is_whole_column(&self) -> bool {
+        matches!(
+            self,
+            Self::Range {
+                start_row: None,
+                end_row: None,
+                start_col: Some(_),
+                end_col: Some(_),
+                ..
+            }
+        )
+    }
+
+    /// `true` for `1:1`-style whole-row refs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::Reference;
+    /// let r = Reference::Range { sheet: None,
+    ///     start_row: Some(1), end_row: Some(1),
+    ///     start_col: None, end_col: None };
+    /// assert!(r.is_whole_row());
+    /// ```
+    #[must_use]
+    pub fn is_whole_row(&self) -> bool {
+        matches!(
+            self,
+            Self::Range {
+                start_col: None,
+                end_col: None,
+                start_row: Some(_),
+                end_row: Some(_),
+                ..
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    #[test]
+    fn cell_reference_reports_its_sheet() {
+        let r = Reference::Cell { sheet: Some("Sheet1".into()), row: 2, col: 3 };
+        assert_eq!(r.sheet(), Some("Sheet1"));
+    }
+
+    #[test]
+    fn unqualified_cell_has_no_sheet() {
+        let r = Reference::Cell { sheet: None, row: 1, col: 1 };
+        assert_eq!(r.sheet(), None);
+    }
+
+    #[test]
+    fn external_reference_reports_its_sheet() {
+        let r = Reference::External {
+            raw: "[Book2]Sheet1!A1".into(),
+            book: "Book2".into(),
+            sheet: "Sheet1".into(),
+        };
+        assert_eq!(r.sheet(), Some("Sheet1"));
+    }
+
+    #[test]
+    fn whole_column_range_is_detected() {
+        let r = Reference::Range {
+            sheet: None,
+            start_row: None,
+            end_row: None,
+            start_col: Some(1),
+            end_col: Some(1),
+        };
+        assert!(r.is_whole_column());
+        assert!(!r.is_whole_row());
+    }
+
+    #[test]
+    fn whole_row_range_is_detected() {
+        let r = Reference::Range {
+            sheet: None,
+            start_row: Some(1),
+            end_row: Some(1),
+            start_col: None,
+            end_col: None,
+        };
+        assert!(r.is_whole_row());
+        assert!(!r.is_whole_column());
+    }
+
+    #[test]
+    fn bounded_range_is_neither_whole_column_nor_whole_row() {
+        let r = Reference::Range {
+            sheet: None,
+            start_row: Some(1),
+            end_row: Some(10),
+            start_col: Some(1),
+            end_col: Some(2),
+        };
+        assert!(!r.is_whole_column());
+        assert!(!r.is_whole_row());
+    }
+}

--- a/crates/xlstream-parse/tests/parse.rs
+++ b/crates/xlstream-parse/tests/parse.rs
@@ -1,0 +1,62 @@
+//! Integration tests for `xlstream_parse::parse`. Drive the public API
+//! exactly as a downstream consumer would.
+
+use xlstream_parse::parse;
+
+#[test]
+fn simple_arithmetic_parses() {
+    let ast = parse("1+2").expect("parse failed");
+    let dbg = format!("{ast:?}");
+    assert!(dbg.contains("BinaryOp"), "expected BinaryOp in debug: {dbg}");
+    assert!(dbg.contains('1'), "expected literal 1: {dbg}");
+    assert!(dbg.contains('2'), "expected literal 2: {dbg}");
+}
+
+#[test]
+fn function_call_parses() {
+    let ast = parse("SUM(A1, B2)").expect("parse failed");
+    let dbg = format!("{ast:?}");
+    assert!(dbg.contains("Function"), "expected Function: {dbg}");
+    assert!(dbg.contains("SUM"), "expected SUM name: {dbg}");
+}
+
+#[test]
+fn whole_column_range_parses() {
+    let ast = parse("SUM(A:A)").expect("parse failed");
+    assert!(format!("{ast:?}").contains("Range"));
+}
+
+#[test]
+fn cross_sheet_reference_parses() {
+    let ast = parse("'Tax Rates'!A1").expect("parse failed");
+    assert!(format!("{ast:?}").contains("Tax Rates"));
+}
+
+#[test]
+fn excel_error_literal_lowers_to_node_error() {
+    let ast = parse("#REF!").expect("parse failed");
+    assert!(format!("{ast:?}").contains("Error"));
+}
+
+#[test]
+fn malformed_input_returns_formula_parse_error() {
+    let err = parse("SUM(").unwrap_err();
+    match err {
+        xlstream_core::XlStreamError::FormulaParse { ref formula, position, .. } => {
+            assert_eq!(formula, "SUM(");
+            let _ = position;
+        }
+        other => panic!("expected FormulaParse, got {other:?}"),
+    }
+}
+
+#[test]
+fn malformed_input_carries_upstream_position_when_available() {
+    let err = parse("1+SUM(A,").unwrap_err();
+    match err {
+        xlstream_core::XlStreamError::FormulaParse { position, .. } => {
+            assert!(position.is_some(), "expected upstream to report position");
+        }
+        other => panic!("expected FormulaParse, got {other:?}"),
+    }
+}

--- a/docs/architecture/errors.md
+++ b/docs/architecture/errors.md
@@ -45,8 +45,9 @@ pub enum XlStreamError {
     #[error("xlsx write error: {0}")]
     XlsxWrite(#[from] rust_xlsxwriter::XlsxError),
 
-    #[error("formula parse error at {address}: {message}\n  formula: {formula}")]
-    FormulaParse { address: String, formula: String, message: String },
+    #[error("formula parse error at {address}{}: {message}\n  formula: {formula}",
+        position.map_or(String::new(), |p| format!(" (position {p})")))]
+    FormulaParse { address: String, formula: String, message: String, position: Option<usize> },
 
     #[error("unsupported formula at {address}: {reason}\n  formula: {formula}\n  see: {doc_link}")]
     Unsupported {

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -1,6 +1,6 @@
 # Phases — roadmap
 
-> **Current phase: 0 — Foundation.** See [`phase-00-foundation.md`](phase-00-foundation.md).
+> **Current phase: 2 — Parser integration.** See [`phase-02-parser.md`](phase-02-parser.md).
 
 ## How this works
 
@@ -55,7 +55,7 @@ Do NOT work multiple phases simultaneously. Do NOT skip checkboxes out of order 
 
 | # | Phase | File | Status |
 |---|---|---|---|
-| 0 | Foundation | [`phase-00-foundation.md`](phase-00-foundation.md) | in progress |
+| 0 | Foundation | [`phase-00-foundation.md`](phase-00-foundation.md) | ✓ complete |
 | 1 | Scaffolding | [`phase-01-scaffolding.md`](phase-01-scaffolding.md) | ✓ complete |
 | 2 | Parser integration | [`phase-02-parser.md`](phase-02-parser.md) | in progress |
 | 3 | I/O layer | [`phase-03-io.md`](phase-03-io.md) | not started |

--- a/docs/phases/phase-02-parser.md
+++ b/docs/phases/phase-02-parser.md
@@ -14,11 +14,11 @@
 
 ### Parser
 
-- [ ] Integrate `formualizer-parse`: call its parser, map its AST to our `Ast` type.
-  - [ ] Define our `Ast` as either a re-export of the upstream type or a thin wrapper. Keep wrapper if we'll extend with extra fields (source spans, rewritten nodes).
-- [ ] `parse(expr: &str)` returns `Result<Ast, XlStreamError>` with `FormulaParse` variant on error.
-- [ ] Include source-error context: line/column if available from upstream, otherwise the offending substring.
-- [ ] Rustdoc + doctest.
+- [x] Integrate `formualizer-parse`: call its parser, map its AST to our `Ast` type.
+  - [x] Define our `Ast` as either a re-export of the upstream type or a thin wrapper. Keep wrapper if we'll extend with extra fields (source spans, rewritten nodes).
+- [x] `parse(expr: &str)` returns `Result<Ast, XlStreamError>` with `FormulaParse` variant on error.
+- [x] Include source-error context: line/column if available from upstream, otherwise the offending substring.
+- [x] Rustdoc + doctest.
 
 ### Reference extraction
 


### PR DESCRIPTION
## Summary

- Wire `formualizer-parse = "=1.1.2"` and `formualizer-common = "=1.1.2"` as workspace deps
- Implement real `parse(expr)` that prepends `=`, calls upstream, and lowers into dual-tree `Ast` (raw upstream `ASTNode` + mirror `Node` enum)
- Add `Reference` enum (Cell, Range, Named, External, Table) and `References` struct with `SmallVec` containers
- Extend `XlStreamError::FormulaParse` with `position: Option<usize>` field
- Map all upstream `ExcelErrorKind` variants to `CellError`
- 17 unit + 7 integration + 10 doc-tests, all green under `make check`

## Design decisions

- **Dual-tree Ast**: retains upstream `ASTNode` for zero-alloc `visit_refs` (Chunk 1), mirror `Node` for `PreludeRef` splicing (Chunk 4) — avoids leaking upstream types in public API
- **`Array(Vec<Vec<Node>>)`** not `SmallVec`: inline `Node` storage causes layout cycle
- **`parse()` prepends `=`**: upstream requires leading `=`; we strip it transparently and adjust error positions with `saturating_sub(1)`

## Test plan

- [x] `make check` passes (fmt, clippy -D warnings, all tests, doc-tests)
- [x] Pre-commit + pre-push hooks pass
- [x] Review: `lower_reference` maps all 5 upstream `ReferenceType` variants
- [x] Review: `map_excel_error` covers all `ExcelErrorKind` variants
- [x] Review: integration tests exercise public API without internal coupling