### PR TITLE
xlstream-parse: add extract_references over upstream visit_refs (phase 2 chunk 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ refs/
 # completes. Real decisions go in docs/decisions/ (ADRs). Real design goes
 # in docs/architecture/.
 docs/superpowers/
+
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ xlstream/
 
 ### Before you touch code
 
+0. **Use `/rust-skills` before writing any Rust code.** Covers idiomatic patterns, error handling, type design, and common pitfalls. Use it alongside (not instead of) any other applicable skills.
 1. **Read the current phase doc.** Find it via [`docs/phases/README.md`](docs/phases/README.md). You are implementing a specific checkbox in a specific phase. Don't free-lance.
 2. **Read the architecture doc that covers your area.** Unclear architecture → stop and ask. Do not invent.
 3. **Search for existing patterns.** If three other builtins handle errors a given way, yours does too. Consistency outranks cleverness.

--- a/crates/xlstream-parse/src/ast.rs
+++ b/crates/xlstream-parse/src/ast.rs
@@ -59,8 +59,6 @@ pub(crate) enum Node {
 #[derive(Debug, Clone)]
 pub struct Ast {
     /// Original upstream tree, retained for `visit_refs` etc.
-    /// Read by `as_upstream()` in Chunk 1 (`extract_references`).
-    #[allow(dead_code)]
     pub(crate) upstream: formualizer_parse::ASTNode,
     /// Our mirror tree. Used by classify + rewrite.
     pub(crate) root: Node,
@@ -75,9 +73,7 @@ impl PartialEq for Ast {
 
 impl Ast {
     /// Crate-internal accessor for the raw upstream tree.
-    /// Used by `extract_references` in Chunk 1.
     #[must_use]
-    #[allow(dead_code)]
     pub(crate) fn as_upstream(&self) -> &formualizer_parse::ASTNode {
         &self.upstream
     }

--- a/crates/xlstream-parse/src/lib.rs
+++ b/crates/xlstream-parse/src/lib.rs
@@ -28,4 +28,4 @@ mod references;
 pub use ast::Ast;
 pub use classify::{classify, Classification, ClassificationContext};
 pub use parser::parse;
-pub use references::{Reference, References};
+pub use references::{extract_references, Reference, References};

--- a/crates/xlstream-parse/src/references.rs
+++ b/crates/xlstream-parse/src/references.rs
@@ -1,6 +1,8 @@
-//! Reference types and (in Chunk 1) the [`extract_references`] walker.
+//! Reference types and the [`extract_references`] walker.
 
 use smallvec::SmallVec;
+
+use crate::ast::Ast;
 
 /// One Excel reference: cell, range, named range, external workbook ref,
 /// or table ref.
@@ -87,6 +89,100 @@ pub struct References {
     /// Every function name called (case-preserved, case-insensitively
     /// de-duplicated).
     pub functions: SmallVec<[String; 8]>,
+}
+
+/// Walk `ast` and collect every reference, sheet name, and function name.
+///
+/// Uses upstream's zero-alloc `visit_refs` walker for references; walks
+/// the upstream tree once more for function names. Both passes are
+/// stack-based.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::{extract_references, parse};
+/// let ast = parse("SUM(A:A)").unwrap();
+/// let refs = extract_references(&ast);
+/// assert_eq!(refs.ranges.len(), 1);
+/// ```
+#[must_use]
+pub fn extract_references(ast: &Ast) -> References {
+    let mut out = References::default();
+    ast.as_upstream().visit_refs(|rv| collect_view(rv, &mut out));
+    walk_functions(ast.as_upstream(), &mut out);
+    out
+}
+
+fn collect_view(rv: formualizer_parse::parser::RefView<'_>, out: &mut References) {
+    use formualizer_parse::parser::RefView as V;
+    match rv {
+        V::Cell { sheet, row, col, .. } => {
+            push_sheet(sheet, out);
+            out.cells.push(Reference::Cell { sheet: sheet.map(str::to_owned), row, col });
+        }
+        V::Range { sheet, start_row, end_row, start_col, end_col, .. } => {
+            push_sheet(sheet, out);
+            out.ranges.push(Reference::Range {
+                sheet: sheet.map(str::to_owned),
+                start_row,
+                end_row,
+                start_col,
+                end_col,
+            });
+        }
+        V::External { raw, book, sheet, .. } => {
+            push_sheet(Some(sheet), out);
+            out.ranges.push(Reference::External {
+                raw: raw.to_owned(),
+                book: book.to_owned(),
+                sheet: sheet.to_owned(),
+            });
+        }
+        V::Table { name, specifier } => {
+            out.ranges.push(Reference::Table {
+                name: name.to_owned(),
+                specifier: specifier.map(|s| format!("{s}")),
+            });
+        }
+        V::NamedRange { name } => {
+            out.ranges.push(Reference::Named(name.to_owned()));
+        }
+    }
+}
+
+fn push_sheet(sheet: Option<&str>, out: &mut References) {
+    if let Some(s) = sheet {
+        if !out.sheets.iter().any(|existing| existing == s) {
+            out.sheets.push(s.to_owned());
+        }
+    }
+}
+
+fn walk_functions(node: &formualizer_parse::ASTNode, out: &mut References) {
+    use formualizer_parse::ASTNodeType as T;
+    match &node.node_type {
+        T::Literal(_) | T::Reference { .. } => {}
+        T::UnaryOp { expr, .. } => walk_functions(expr, out),
+        T::BinaryOp { left, right, .. } => {
+            walk_functions(left, out);
+            walk_functions(right, out);
+        }
+        T::Function { name, args } => {
+            if !out.functions.iter().any(|n| n.eq_ignore_ascii_case(name)) {
+                out.functions.push(name.clone());
+            }
+            for a in args {
+                walk_functions(a, out);
+            }
+        }
+        T::Array(rows) => {
+            for row in rows {
+                for cell in row {
+                    walk_functions(cell, out);
+                }
+            }
+        }
+    }
 }
 
 impl Reference {

--- a/crates/xlstream-parse/src/references.rs
+++ b/crates/xlstream-parse/src/references.rs
@@ -94,8 +94,8 @@ pub struct References {
 /// Walk `ast` and collect every reference, sheet name, and function name.
 ///
 /// Uses upstream's zero-alloc `visit_refs` walker for references; walks
-/// the upstream tree once more for function names. Both passes are
-/// stack-based.
+/// the upstream tree with an explicit stack for function names. Both
+/// passes avoid recursion.
 ///
 /// # Examples
 ///
@@ -130,6 +130,8 @@ fn collect_view(rv: formualizer_parse::parser::RefView<'_>, out: &mut References
                 end_col,
             });
         }
+        // `kind` (ExternalRefKind) carries coordinate details we don't
+        // need — classification refuses all external refs wholesale.
         V::External { raw, book, sheet, .. } => {
             push_sheet(Some(sheet), out);
             out.ranges.push(Reference::External {
@@ -152,33 +154,36 @@ fn collect_view(rv: formualizer_parse::parser::RefView<'_>, out: &mut References
 
 fn push_sheet(sheet: Option<&str>, out: &mut References) {
     if let Some(s) = sheet {
-        if !out.sheets.iter().any(|existing| existing == s) {
+        if !out.sheets.iter().any(|existing| existing.eq_ignore_ascii_case(s)) {
             out.sheets.push(s.to_owned());
         }
     }
 }
 
-fn walk_functions(node: &formualizer_parse::ASTNode, out: &mut References) {
+fn walk_functions(root: &formualizer_parse::ASTNode, out: &mut References) {
     use formualizer_parse::ASTNodeType as T;
-    match &node.node_type {
-        T::Literal(_) | T::Reference { .. } => {}
-        T::UnaryOp { expr, .. } => walk_functions(expr, out),
-        T::BinaryOp { left, right, .. } => {
-            walk_functions(left, out);
-            walk_functions(right, out);
-        }
-        T::Function { name, args } => {
-            if !out.functions.iter().any(|n| n.eq_ignore_ascii_case(name)) {
-                out.functions.push(name.clone());
+    let mut stack: Vec<&formualizer_parse::ASTNode> = vec![root];
+    while let Some(node) = stack.pop() {
+        match &node.node_type {
+            T::Literal(_) | T::Reference { .. } => {}
+            T::UnaryOp { expr, .. } => stack.push(expr),
+            T::BinaryOp { left, right, .. } => {
+                stack.push(right);
+                stack.push(left);
             }
-            for a in args {
-                walk_functions(a, out);
+            T::Function { name, args } => {
+                if !out.functions.iter().any(|n| n.eq_ignore_ascii_case(name)) {
+                    out.functions.push(name.clone());
+                }
+                for a in args.iter().rev() {
+                    stack.push(a);
+                }
             }
-        }
-        T::Array(rows) => {
-            for row in rows {
-                for cell in row {
-                    walk_functions(cell, out);
+            T::Array(rows) => {
+                for row in rows.iter().rev() {
+                    for cell in row.iter().rev() {
+                        stack.push(cell);
+                    }
                 }
             }
         }

--- a/crates/xlstream-parse/tests/references.rs
+++ b/crates/xlstream-parse/tests/references.rs
@@ -17,6 +17,16 @@ fn range_extracts_one_range_ref() {
     let ast = parse("A1:B10").unwrap();
     let refs = extract_references(&ast);
     assert_eq!(refs.ranges.len(), 1);
+    assert!(matches!(
+        refs.ranges[0],
+        Reference::Range {
+            start_row: Some(1),
+            end_row: Some(10),
+            start_col: Some(1),
+            end_col: Some(2),
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -57,5 +67,50 @@ fn external_reference_lands_in_ranges() {
     let ast = parse("[Book2]Sheet1!A1").unwrap();
     let refs = extract_references(&ast);
     assert_eq!(refs.ranges.len(), 1);
-    assert!(matches!(refs.ranges[0], Reference::External { .. }));
+    match &refs.ranges[0] {
+        Reference::External { book, sheet, .. } => {
+            assert_eq!(book, "[Book2]");
+            assert_eq!(sheet, "Sheet1");
+        }
+        other => panic!("expected External, got {other:?}"),
+    }
+}
+
+#[test]
+fn named_range_lands_in_ranges() {
+    let ast = parse("MyRange").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.ranges.len(), 1);
+    assert!(matches!(refs.ranges[0], Reference::Named(ref n) if n == "MyRange"));
+}
+
+#[test]
+fn table_reference_lands_in_ranges() {
+    let ast = parse("Table1[Column1]").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.ranges.len(), 1);
+    match &refs.ranges[0] {
+        Reference::Table { name, specifier } => {
+            assert_eq!(name, "Table1");
+            assert!(specifier.is_some(), "expected specifier for Table1[Column1]");
+        }
+        other => panic!("expected Table, got {other:?}"),
+    }
+}
+
+#[test]
+fn literal_only_formula_returns_empty_references() {
+    let ast = parse("1+2").unwrap();
+    let refs = extract_references(&ast);
+    assert!(refs.cells.is_empty());
+    assert!(refs.ranges.is_empty());
+    assert!(refs.sheets.is_empty());
+    assert!(refs.functions.is_empty());
+}
+
+#[test]
+fn sheet_dedup_is_case_insensitive() {
+    let ast = parse("Sheet1!A1 + SHEET1!B2").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.sheets.len(), 1, "expected case-insensitive dedup: {:?}", refs.sheets);
 }

--- a/crates/xlstream-parse/tests/references.rs
+++ b/crates/xlstream-parse/tests/references.rs
@@ -1,0 +1,61 @@
+//! Integration tests for `extract_references`.
+
+use xlstream_parse::{extract_references, parse, Reference};
+
+#[test]
+fn single_cell_extracts_one_cell_ref() {
+    let ast = parse("A1").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.cells.len(), 1);
+    assert!(matches!(refs.cells[0], Reference::Cell { row: 1, col: 1, .. }));
+    assert!(refs.ranges.is_empty());
+    assert!(refs.functions.is_empty());
+}
+
+#[test]
+fn range_extracts_one_range_ref() {
+    let ast = parse("A1:B10").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.ranges.len(), 1);
+}
+
+#[test]
+fn cross_sheet_dedupes_sheet_names() {
+    let ast = parse("'Tax Rates'!A1 + 'Tax Rates'!B2").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.sheets.iter().filter(|s| s.as_str() == "Tax Rates").count(), 1);
+}
+
+#[test]
+fn whole_column_extracts_range() {
+    let ast = parse("SUM(A:A)").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.ranges.len(), 1);
+    assert!(refs.ranges[0].is_whole_column());
+}
+
+#[test]
+fn nested_function_collects_all_function_names() {
+    let ast = parse("IF(SUM(A1:A10) > 0, VLOOKUP(B1, X:Y, 2, FALSE), 0)").unwrap();
+    let refs = extract_references(&ast);
+    let names: Vec<&str> = refs.functions.iter().map(String::as_str).collect();
+    assert!(names.contains(&"IF"));
+    assert!(names.contains(&"SUM"));
+    assert!(names.contains(&"VLOOKUP"));
+}
+
+#[test]
+fn function_names_dedup_case_insensitively_keeping_first_seen() {
+    let ast = parse("Sum(A1) + SUM(A2) + sum(A3)").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.functions.len(), 1);
+    assert_eq!(refs.functions[0], "Sum");
+}
+
+#[test]
+fn external_reference_lands_in_ranges() {
+    let ast = parse("[Book2]Sheet1!A1").unwrap();
+    let refs = extract_references(&ast);
+    assert_eq!(refs.ranges.len(), 1);
+    assert!(matches!(refs.ranges[0], Reference::External { .. }));
+}

--- a/docs/phases/phase-02-parser.md
+++ b/docs/phases/phase-02-parser.md
@@ -22,13 +22,13 @@
 
 ### Reference extraction
 
-- [ ] `extract_references(ast: &Ast) -> References` walks the AST and returns:
-  - [ ] All `CellRef`s.
-  - [ ] All `RangeRef`s.
-  - [ ] All `SheetRef`s.
-  - [ ] All function names called (for classification).
-- [ ] `References` uses `SmallVec<[T; N]>` with N sized to the P99 case.
-- [ ] Tests cover: single cell, range, cross-sheet, whole-column, nested functions.
+- [x] `extract_references(ast: &Ast) -> References` walks the AST and returns:
+  - [x] All `CellRef`s.
+  - [x] All `RangeRef`s.
+  - [x] All `SheetRef`s.
+  - [x] All function names called (for classification).
+- [x] `References` uses `SmallVec<[T; N]>` with N sized to the P99 case.
+- [x] Tests cover: single cell, range, cross-sheet, whole-column, nested functions.
 
 ### Classification
 


### PR DESCRIPTION
## Summary

- Implement `extract_references(&ast) -> References` using upstream's zero-alloc `visit_refs` walker
- Maps all 5 `RefView` variants (Cell, Range, External, Table, NamedRange) to our `Reference` enum
- Second pass walks upstream `ASTNode` for function-name collection with case-insensitive dedup (first-seen casing preserved)
- Sheet-name dedup via linear scan (P99 formula references <= 2 sheets)
- Remove `#[allow(dead_code)]` on `upstream` field and `as_upstream()` now that they're used
- Re-export `extract_references` from crate root

## Design decisions

- **Two-pass approach**: `visit_refs` handles references (zero-alloc, upstream-maintained); `walk_functions` handles function names (upstream doesn't ship a function-name visitor). Both are stack-based, no recursion.
- **Linear dedup over HashSet**: sheet names (P99: 2) and function names (P99: 8) are tiny — linear scan beats hash overhead.

## Test plan

- [x] `make check` passes (fmt, clippy -D warnings, all tests, doc-tests)
- [x] 7 new integration tests: single cell, range, cross-sheet dedup, whole-column, nested functions, case-insensitive function dedup, external ref
- [x] 1 new doc-test on `extract_references`
- [x] Review: all 5 `RefView` variants mapped correctly
- [x] Review: function-name dedup is case-insensitive, first-seen casing preserved