### PR TITLE
xlstream-parse: structured UnsupportedReason + phf support sets (phase 2 chunk 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +610,21 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex-automata"
@@ -690,6 +747,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -1156,6 +1219,7 @@ version = "0.1.0"
 dependencies = [
  "formualizer-common",
  "formualizer-parse",
+ "phf",
  "smallvec",
  "xlstream-core",
 ]

--- a/crates/xlstream-parse/Cargo.toml
+++ b/crates/xlstream-parse/Cargo.toml
@@ -16,6 +16,7 @@ xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
 formualizer-parse = { workspace = true }
 formualizer-common = { workspace = true }
 smallvec = { workspace = true }
+phf = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -95,13 +95,14 @@ impl UnsupportedReason {
     #[must_use]
     pub fn doc_link(&self) -> &'static str {
         match self {
-            Self::NonCurrentRowRef | Self::CircularRef => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#classification-algorithm",
+            Self::NonCurrentRowRef
+            | Self::CircularRef
+            | Self::LookupIntoStreamingSheet
+            | Self::ExternalReference => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#classification-algorithm",
             Self::UnsupportedFunction(_) | Self::DynamicArray | Self::VolatileUnsupported => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#why-offset-and-indirect-are-unsupported",
             Self::UnboundedRange => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#aggregate-of-a-column",
             Self::NonStaticCriteria => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#aggregate-pre-pass",
             Self::LookupSheetNotPrepared => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#lookup-index-pre-pass",
-            Self::LookupIntoStreamingSheet => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#lookup-into-loaded-sheet",
-            Self::ExternalReference => "https://github.com/cilladev/xlstream/blob/main/MANAGER.md#permanent-exclusions",
             Self::TableReference | Self::NamedRange => "https://github.com/cilladev/xlstream/blob/main/docs/backlog/v0.2.md",
             Self::NestedUnsupported => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md",
         }
@@ -128,13 +129,9 @@ pub enum Classification {
     /// Formula mixes row-local, aggregate, and/or lookup reads — still
     /// streamable via prelude + row data.
     Mixed,
-    /// Formula cannot be streamed.
-    Unsupported {
-        /// Specific reason for refusal.
-        reason: UnsupportedReason,
-        /// Stable documentation URL explaining the refusal class.
-        doc_link: &'static str,
-    },
+    /// Formula cannot be streamed. Use [`UnsupportedReason::doc_link`] for
+    /// the stable documentation URL.
+    Unsupported(UnsupportedReason),
 }
 
 /// Context passed to [`classify`]. Real fields land in Chunk 3.
@@ -159,13 +156,11 @@ pub struct ClassificationContext {
 /// use xlstream_parse::{classify, parse, Classification, ClassificationContext};
 /// let ast = parse("1+2").unwrap();
 /// let ctx = ClassificationContext::default();
-/// assert!(matches!(classify(&ast, &ctx), Classification::Unsupported { .. }));
+/// assert!(matches!(classify(&ast, &ctx), Classification::Unsupported(_)));
 /// ```
 #[must_use]
 pub fn classify(_ast: &Ast, _ctx: &ClassificationContext) -> Classification {
-    let reason = UnsupportedReason::NestedUnsupported;
-    let doc_link = reason.doc_link();
-    Classification::Unsupported { reason, doc_link }
+    Classification::Unsupported(UnsupportedReason::NestedUnsupported)
 }
 
 #[cfg(test)]
@@ -179,9 +174,9 @@ mod tests {
         let ast = crate::parse("1+2").unwrap();
         let ctx = ClassificationContext::default();
         match classify(&ast, &ctx) {
-            Classification::Unsupported { reason, doc_link } => {
+            Classification::Unsupported(reason) => {
                 assert!(matches!(reason, UnsupportedReason::NestedUnsupported));
-                assert!(doc_link.starts_with("https://"));
+                assert!(reason.doc_link().starts_with("https://"));
             }
             other => panic!("expected Unsupported, got {other:?}"),
         }

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -4,11 +4,111 @@
 
 use crate::ast::Ast;
 
-/// The verdict returned by [`classify`] for a single formula.
+/// The specific reason a formula was rejected.
 ///
-/// Phase 1 ships this enum shape; Phase 2 (Chunk 2) replaces
-/// `Unsupported(String)` with a structured `UnsupportedReason` type
-/// (see `docs/phases/phase-02-parser.md`).
+/// Each variant maps to a `&'static str` doc link via [`Self::doc_link`]
+/// so the user-facing error message can deep-link to the explanation.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::UnsupportedReason;
+/// let r = UnsupportedReason::UnsupportedFunction("OFFSET".into());
+/// assert!(r.to_string().contains("OFFSET"));
+/// assert!(r.doc_link().starts_with("https://"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnsupportedReason {
+    /// Reference to a row other than the current streaming row.
+    NonCurrentRowRef,
+    /// Cell references itself (directly or transitively).
+    CircularRef,
+    /// Function not in any of the supported sets.
+    UnsupportedFunction(String),
+    /// Bare `A:A` (or `1:1`) outside an aggregate.
+    UnboundedRange,
+    /// Aggregate criteria computed per-row are not supported.
+    NonStaticCriteria,
+    /// Dynamic-array spill (`FILTER`, `UNIQUE`, ...).
+    DynamicArray,
+    /// Volatile function not in [`crate::sets::VOLATILE_STREAMING_OK`].
+    VolatileUnsupported,
+    /// `[Book.xlsx]Sheet1!A1`-style external workbook reference.
+    ExternalReference,
+    /// `Table[Column]`-style structured table reference.
+    TableReference,
+    /// `MyRange`-style workbook-level named range.
+    NamedRange,
+    /// Sub-expression nested under another unsupported sub-expression.
+    NestedUnsupported,
+    /// Lookup range points at a sheet the prelude has not indexed.
+    LookupSheetNotPrepared,
+    /// Lookup range points at the main streaming sheet.
+    LookupIntoStreamingSheet,
+}
+
+impl std::fmt::Display for UnsupportedReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonCurrentRowRef => {
+                write!(f, "references a row other than the current one — unstreamable")
+            }
+            Self::CircularRef => write!(f, "circular reference"),
+            Self::UnsupportedFunction(name) => write!(f, "function {name} is not supported"),
+            Self::UnboundedRange => {
+                write!(f, "whole-column or whole-row reference outside an aggregate")
+            }
+            Self::NonStaticCriteria => {
+                write!(f, "aggregate criteria computed per-row are not supported")
+            }
+            Self::DynamicArray => write!(f, "dynamic-array spill is not supported"),
+            Self::VolatileUnsupported => {
+                write!(f, "volatile function is not in the streaming-OK set")
+            }
+            Self::ExternalReference => {
+                write!(f, "external-workbook references are not supported (single-file model)")
+            }
+            Self::TableReference => {
+                write!(f, "structured table references are not supported in v0.1")
+            }
+            Self::NamedRange => write!(f, "named ranges are not supported in v0.1"),
+            Self::NestedUnsupported => write!(f, "contains an unsupported sub-expression"),
+            Self::LookupSheetNotPrepared => {
+                write!(f, "lookup range points at a sheet the prelude has not indexed")
+            }
+            Self::LookupIntoStreamingSheet => {
+                write!(f, "lookup range points at the main streaming sheet")
+            }
+        }
+    }
+}
+
+impl UnsupportedReason {
+    /// Stable documentation URL for this refusal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::UnsupportedReason;
+    /// assert!(UnsupportedReason::NonCurrentRowRef.doc_link().starts_with("https://"));
+    /// ```
+    #[must_use]
+    pub fn doc_link(&self) -> &'static str {
+        match self {
+            Self::NonCurrentRowRef | Self::CircularRef => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#classification-algorithm",
+            Self::UnsupportedFunction(_) | Self::DynamicArray | Self::VolatileUnsupported => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#why-offset-and-indirect-are-unsupported",
+            Self::UnboundedRange => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#aggregate-of-a-column",
+            Self::NonStaticCriteria => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#aggregate-pre-pass",
+            Self::LookupSheetNotPrepared => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#lookup-index-pre-pass",
+            Self::LookupIntoStreamingSheet => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#lookup-into-loaded-sheet",
+            Self::ExternalReference => "https://github.com/cilladev/xlstream/blob/main/MANAGER.md#permanent-exclusions",
+            Self::TableReference | Self::NamedRange => "https://github.com/cilladev/xlstream/blob/main/docs/backlog/v0.2.md",
+            Self::NestedUnsupported => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md",
+        }
+    }
+}
+
+/// The verdict returned by [`classify`] for a single formula.
 ///
 /// # Examples
 ///
@@ -28,12 +128,16 @@ pub enum Classification {
     /// Formula mixes row-local, aggregate, and/or lookup reads — still
     /// streamable via prelude + row data.
     Mixed,
-    /// Formula cannot be streamed. The string explains why.
-    Unsupported(String),
+    /// Formula cannot be streamed.
+    Unsupported {
+        /// Specific reason for refusal.
+        reason: UnsupportedReason,
+        /// Stable documentation URL explaining the refusal class.
+        doc_link: &'static str,
+    },
 }
 
-/// Context passed to [`classify`]. Chunk 2 fills this with workbook
-/// metadata (sheet names, header maps, prelude plans).
+/// Context passed to [`classify`]. Real fields land in Chunk 3.
 ///
 /// # Examples
 ///
@@ -55,11 +159,13 @@ pub struct ClassificationContext {
 /// use xlstream_parse::{classify, parse, Classification, ClassificationContext};
 /// let ast = parse("1+2").unwrap();
 /// let ctx = ClassificationContext::default();
-/// matches!(classify(&ast, &ctx), Classification::Unsupported(_));
+/// assert!(matches!(classify(&ast, &ctx), Classification::Unsupported { .. }));
 /// ```
 #[must_use]
 pub fn classify(_ast: &Ast, _ctx: &ClassificationContext) -> Classification {
-    Classification::Unsupported("classification not implemented until Phase 2 Chunk 3".into())
+    let reason = UnsupportedReason::NestedUnsupported;
+    let doc_link = reason.doc_link();
+    Classification::Unsupported { reason, doc_link }
 }
 
 #[cfg(test)]
@@ -73,8 +179,9 @@ mod tests {
         let ast = crate::parse("1+2").unwrap();
         let ctx = ClassificationContext::default();
         match classify(&ast, &ctx) {
-            Classification::Unsupported(msg) => {
-                assert!(msg.contains("Chunk 3"), "expected Chunk 3 note, got: {msg}");
+            Classification::Unsupported { reason, doc_link } => {
+                assert!(matches!(reason, UnsupportedReason::NestedUnsupported));
+                assert!(doc_link.starts_with("https://"));
             }
             other => panic!("expected Unsupported, got {other:?}"),
         }
@@ -84,5 +191,29 @@ mod tests {
     fn classification_variants_compare_equal() {
         assert_eq!(Classification::RowLocal, Classification::RowLocal);
         assert_ne!(Classification::RowLocal, Classification::AggregateOnly);
+    }
+
+    #[test]
+    fn unsupported_reason_renders_human_message() {
+        let r = UnsupportedReason::UnsupportedFunction("OFFSET".into());
+        let s = r.to_string();
+        assert!(s.contains("OFFSET"), "expected OFFSET in message: {s}");
+    }
+
+    #[test]
+    fn unsupported_reason_doc_link_is_stable_url() {
+        let r = UnsupportedReason::NonCurrentRowRef;
+        assert!(r.doc_link().starts_with("https://"));
+    }
+
+    #[test]
+    fn lookup_into_streaming_sheet_has_distinct_doc_link() {
+        let a = UnsupportedReason::LookupIntoStreamingSheet;
+        let b = UnsupportedReason::LookupSheetNotPrepared;
+        assert_ne!(
+            a.doc_link(),
+            b.doc_link(),
+            "distinct lookup-failure modes should deep-link to distinct sections"
+        );
     }
 }

--- a/crates/xlstream-parse/src/lib.rs
+++ b/crates/xlstream-parse/src/lib.rs
@@ -24,8 +24,9 @@ mod ast;
 mod classify;
 mod parser;
 mod references;
+pub mod sets;
 
 pub use ast::Ast;
-pub use classify::{classify, Classification, ClassificationContext};
+pub use classify::{classify, Classification, ClassificationContext, UnsupportedReason};
 pub use parser::parse;
 pub use references::{extract_references, Reference, References};

--- a/crates/xlstream-parse/src/sets.rs
+++ b/crates/xlstream-parse/src/sets.rs
@@ -1,0 +1,122 @@
+//! Function-name sets used by the classifier.
+//!
+//! Sets are stored in upper-case; lookups normalise the incoming name to
+//! upper-case to give Excel-style case-insensitivity.
+
+use phf::{phf_set, Set};
+
+/// Functions xlstream cannot stream.
+pub static UNSUPPORTED_FUNCTIONS: Set<&'static str> = phf_set! {
+    "OFFSET", "INDIRECT", "FILTER", "UNIQUE", "SORT", "SORTBY",
+    "SEQUENCE", "RANDARRAY", "LAMBDA", "LET", "HYPERLINK",
+    "WEBSERVICE", "CUBEVALUE", "CUBEMEMBER", "CUBESET",
+    "RAND", "RANDBETWEEN",
+};
+
+/// Functions evaluable in a single column pre-pass.
+pub static AGGREGATE_FUNCTIONS: Set<&'static str> = phf_set! {
+    "SUM", "COUNT", "COUNTA", "AVERAGE", "MIN", "MAX", "PRODUCT",
+    "SUMIF", "COUNTIF", "AVERAGEIF",
+    "SUMIFS", "COUNTIFS", "AVERAGEIFS", "MINIFS", "MAXIFS",
+    "MEDIAN",
+};
+
+/// Lookup functions allowed against pre-loaded lookup sheets.
+pub static LOOKUP_FUNCTIONS: Set<&'static str> = phf_set! {
+    "VLOOKUP", "HLOOKUP", "XLOOKUP", "MATCH", "XMATCH", "INDEX", "CHOOSE",
+};
+
+/// Volatile functions whose semantics fit single-evaluation-per-run
+/// (the evaluator memoises in Phase 4).
+pub static VOLATILE_STREAMING_OK: Set<&'static str> = phf_set! {
+    "TODAY", "NOW",
+};
+
+/// `true` if `name` is in [`UNSUPPORTED_FUNCTIONS`] (case-insensitive).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::sets::is_unsupported;
+/// assert!(is_unsupported("offset"));
+/// ```
+#[must_use]
+pub fn is_unsupported(name: &str) -> bool {
+    UNSUPPORTED_FUNCTIONS.contains(name.to_uppercase().as_str())
+}
+
+/// `true` if `name` is in [`AGGREGATE_FUNCTIONS`] (case-insensitive).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::sets::is_aggregate;
+/// assert!(is_aggregate("Sum"));
+/// ```
+#[must_use]
+pub fn is_aggregate(name: &str) -> bool {
+    AGGREGATE_FUNCTIONS.contains(name.to_uppercase().as_str())
+}
+
+/// `true` if `name` is in [`LOOKUP_FUNCTIONS`] (case-insensitive).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::sets::is_lookup;
+/// assert!(is_lookup("vlookup"));
+/// ```
+#[must_use]
+pub fn is_lookup(name: &str) -> bool {
+    LOOKUP_FUNCTIONS.contains(name.to_uppercase().as_str())
+}
+
+/// `true` if `name` is in [`VOLATILE_STREAMING_OK`] (case-insensitive).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::sets::is_volatile_streaming_ok;
+/// assert!(is_volatile_streaming_ok("TODAY"));
+/// ```
+#[must_use]
+pub fn is_volatile_streaming_ok(name: &str) -> bool {
+    VOLATILE_STREAMING_OK.contains(name.to_uppercase().as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    #[test]
+    fn aggregate_set_recognises_sum_case_insensitively() {
+        assert!(is_aggregate("SUM"));
+        assert!(is_aggregate("sum"));
+        assert!(is_aggregate("Sum"));
+    }
+
+    #[test]
+    fn unsupported_set_lists_offset_indirect_filter_rand() {
+        assert!(is_unsupported("OFFSET"));
+        assert!(is_unsupported("INDIRECT"));
+        assert!(is_unsupported("FILTER"));
+        assert!(is_unsupported("RAND"));
+        assert!(is_unsupported("RANDBETWEEN"));
+    }
+
+    #[test]
+    fn lookup_set_lists_vlookup_xlookup_index() {
+        assert!(is_lookup("VLOOKUP"));
+        assert!(is_lookup("XLOOKUP"));
+        assert!(is_lookup("INDEX"));
+    }
+
+    #[test]
+    fn volatile_streaming_ok_set_lists_today_now() {
+        assert!(is_volatile_streaming_ok("TODAY"));
+        assert!(is_volatile_streaming_ok("NOW"));
+        assert!(!is_volatile_streaming_ok("RAND"));
+    }
+}

--- a/crates/xlstream-parse/src/sets.rs
+++ b/crates/xlstream-parse/src/sets.rs
@@ -2,19 +2,44 @@
 //!
 //! Sets are stored in upper-case; lookups normalise the incoming name to
 //! upper-case to give Excel-style case-insensitivity.
+//!
+//! # Precedence
+//!
+//! Some functions appear in `UNSUPPORTED_FUNCTIONS` despite having a more
+//! specific `UnsupportedReason` variant (`DynamicArray` for FILTER/UNIQUE/
+//! SORT/SORTBY/SEQUENCE/RANDARRAY; `VolatileUnsupported` for RAND/
+//! RANDBETWEEN). The classifier checks the specific variant first and
+//! emits the more descriptive reason; `is_unsupported` is the catch-all
+//! for anything that doesn't match a specific category.
 
 use phf::{phf_set, Set};
 
-/// Functions xlstream cannot stream.
-pub static UNSUPPORTED_FUNCTIONS: Set<&'static str> = phf_set! {
+/// Functions xlstream cannot stream. Superset: includes dynamic-array
+/// and volatile entries for catch-all lookup. The classifier checks
+/// `DYNAMIC_ARRAY_FUNCTIONS` and `VOLATILE_UNSUPPORTED` first for a
+/// more specific `UnsupportedReason`.
+pub(crate) static UNSUPPORTED_FUNCTIONS: Set<&'static str> = phf_set! {
     "OFFSET", "INDIRECT", "FILTER", "UNIQUE", "SORT", "SORTBY",
     "SEQUENCE", "RANDARRAY", "LAMBDA", "LET", "HYPERLINK",
     "WEBSERVICE", "CUBEVALUE", "CUBEMEMBER", "CUBESET",
     "RAND", "RANDBETWEEN",
 };
 
+/// Dynamic-array functions that spill to multiple cells.
+/// Classifier emits `UnsupportedReason::DynamicArray`.
+pub(crate) static DYNAMIC_ARRAY_FUNCTIONS: Set<&'static str> = phf_set! {
+    "FILTER", "UNIQUE", "SORT", "SORTBY", "SEQUENCE", "RANDARRAY",
+};
+
+/// Volatile functions whose per-cell semantics don't fit
+/// single-evaluation-per-run. Classifier emits
+/// `UnsupportedReason::VolatileUnsupported`.
+pub(crate) static VOLATILE_UNSUPPORTED: Set<&'static str> = phf_set! {
+    "RAND", "RANDBETWEEN",
+};
+
 /// Functions evaluable in a single column pre-pass.
-pub static AGGREGATE_FUNCTIONS: Set<&'static str> = phf_set! {
+pub(crate) static AGGREGATE_FUNCTIONS: Set<&'static str> = phf_set! {
     "SUM", "COUNT", "COUNTA", "AVERAGE", "MIN", "MAX", "PRODUCT",
     "SUMIF", "COUNTIF", "AVERAGEIF",
     "SUMIFS", "COUNTIFS", "AVERAGEIFS", "MINIFS", "MAXIFS",
@@ -22,13 +47,13 @@ pub static AGGREGATE_FUNCTIONS: Set<&'static str> = phf_set! {
 };
 
 /// Lookup functions allowed against pre-loaded lookup sheets.
-pub static LOOKUP_FUNCTIONS: Set<&'static str> = phf_set! {
+pub(crate) static LOOKUP_FUNCTIONS: Set<&'static str> = phf_set! {
     "VLOOKUP", "HLOOKUP", "XLOOKUP", "MATCH", "XMATCH", "INDEX", "CHOOSE",
 };
 
 /// Volatile functions whose semantics fit single-evaluation-per-run
 /// (the evaluator memoises in Phase 4).
-pub static VOLATILE_STREAMING_OK: Set<&'static str> = phf_set! {
+pub(crate) static VOLATILE_STREAMING_OK: Set<&'static str> = phf_set! {
     "TODAY", "NOW",
 };
 
@@ -84,6 +109,32 @@ pub fn is_volatile_streaming_ok(name: &str) -> bool {
     VOLATILE_STREAMING_OK.contains(name.to_uppercase().as_str())
 }
 
+/// `true` if `name` is in [`DYNAMIC_ARRAY_FUNCTIONS`] (case-insensitive).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::sets::is_dynamic_array;
+/// assert!(is_dynamic_array("FILTER"));
+/// ```
+#[must_use]
+pub fn is_dynamic_array(name: &str) -> bool {
+    DYNAMIC_ARRAY_FUNCTIONS.contains(name.to_uppercase().as_str())
+}
+
+/// `true` if `name` is in [`VOLATILE_UNSUPPORTED`] (case-insensitive).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::sets::is_volatile_unsupported;
+/// assert!(is_volatile_unsupported("RAND"));
+/// ```
+#[must_use]
+pub fn is_volatile_unsupported(name: &str) -> bool {
+    VOLATILE_UNSUPPORTED.contains(name.to_uppercase().as_str())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -118,5 +169,38 @@ mod tests {
         assert!(is_volatile_streaming_ok("TODAY"));
         assert!(is_volatile_streaming_ok("NOW"));
         assert!(!is_volatile_streaming_ok("RAND"));
+    }
+
+    #[test]
+    fn dynamic_array_set_lists_filter_unique_sort() {
+        assert!(is_dynamic_array("FILTER"));
+        assert!(is_dynamic_array("UNIQUE"));
+        assert!(is_dynamic_array("SORT"));
+        assert!(is_dynamic_array("RANDARRAY"));
+        assert!(!is_dynamic_array("SUM"));
+    }
+
+    #[test]
+    fn volatile_unsupported_set_lists_rand() {
+        assert!(is_volatile_unsupported("RAND"));
+        assert!(is_volatile_unsupported("RANDBETWEEN"));
+        assert!(!is_volatile_unsupported("TODAY"));
+    }
+
+    #[test]
+    #[allow(clippy::explicit_iter_loop)]
+    fn all_set_entries_are_uppercase() {
+        for set in [
+            &UNSUPPORTED_FUNCTIONS,
+            &AGGREGATE_FUNCTIONS,
+            &LOOKUP_FUNCTIONS,
+            &VOLATILE_STREAMING_OK,
+            &DYNAMIC_ARRAY_FUNCTIONS,
+            &VOLATILE_UNSUPPORTED,
+        ] {
+            for &entry in set.iter() {
+                assert_eq!(entry, entry.to_uppercase(), "set entry {entry:?} must be uppercase");
+            }
+        }
     }
 }

--- a/docs/architecture/streaming-model.md
+++ b/docs/architecture/streaming-model.md
@@ -69,7 +69,7 @@ For each formula found in the main sheet, walk the AST. Record every `CellRef`, 
 | `A:A` outside an aggregate function (e.g. `A:A * 2`) | **Unsupported** (would require full-column materialisation) |
 | `A3` where 3 ≠ current row | **Unsupported** (forward/backward row ref) |
 | Self-reference (`A2` in cell `A2`) | **Unsupported** (circular) |
-| Function in the `VOLATILE_STREAMING_OK` set (`TODAY`, `NOW`, `RAND`) | **Supported** with single-evaluation-per-run semantics |
+| Function in the `VOLATILE_STREAMING_OK` set (`TODAY`, `NOW`) | **Supported** with single-evaluation-per-run semantics |
 | Function in the `UNSUPPORTED` set (`OFFSET`, `INDIRECT`, `FILTER`, `UNIQUE`, `SORT`) | **Unsupported** |
 | Named range (`MyRange`) | **Unsupported** (v0.2 candidate; requires name-resolution layer) |
 | Table reference (`Table1[Column]`) | **Unsupported** (v0.2 candidate; requires table-definition loading) |

--- a/docs/backlog/v0.2.md
+++ b/docs/backlog/v0.2.md
@@ -1,10 +1,35 @@
 # v0.2 backlog
 
-Deferred features that are out of scope for v0.1 but worth revisiting. Each item names the feature, why it was deferred, and which phase surfaced it.
+Features deliberately deferred from v0.1. Each entry names what's required
+to lift the restriction. Tracked in `UnsupportedReason::doc_link()` so
+refusal messages link here for context.
 
-Agents: check this list before widening scope. If the feature is here, it's intentionally deferred.
+## Structured table references — `Table[Column]`, `Table[@Column]`
 
-## Deferred features
+**Refused at:** `xlstream_parse::classify` returning
+`Unsupported { reason: UnsupportedReason::TableReference, .. }`.
 
-- [ ] **Named ranges** — requires a name-resolution layer (defined-name table loading, scope handling, shadow rules). Most business workbooks use plain cell/range refs. Surfaced: Phase 2 review.
-- [ ] **Table references** (`Table1[Column]`) — requires reading table definitions from xlsx metadata and mapping structured refs to concrete ranges. Surfaced: Phase 2 review.
+**What v0.2 needs:**
+- Parse the workbook's `tables/table*.xml` parts to learn each table's
+  underlying range + column-name to column-index map.
+- During prelude, register tables with their resolved ranges in the
+  `ClassificationContext`.
+- Map `Table[Column]` to `Reference::Range` of the corresponding
+  table-relative range, then run the existing classifier rules.
+
+## Workbook-level named ranges — `MyRange`, `=MyRange + 1`
+
+**Refused at:** `xlstream_parse::classify` returning
+`Unsupported { reason: UnsupportedReason::NamedRange, .. }`.
+
+**What v0.2 needs:**
+- Parse `workbook.xml`'s `<definedNames>` to build a name to resolved-range
+  map.
+- Plumb the map through `ClassificationContext::named_ranges`.
+- During classification, resolve the named range and recurse with the
+  resolved `Reference::Range` / `Reference::Cell`.
+
+## Out of v0.2 scope
+
+- **External workbook references** (`[Book.xlsx]Sheet1!A1`) — permanent
+  v0.1+ exclusion. Violates the single-file model. See `MANAGER.md`.

--- a/docs/phases/phase-02-parser.md
+++ b/docs/phases/phase-02-parser.md
@@ -38,11 +38,12 @@
   - [ ] `LookupOnly` — supported lookup function with cross-sheet range into a lookup sheet.
   - [ ] `Mixed` — recurses; ok if every sub-expression classifies.
   - [ ] `Unsupported(UnsupportedReason)` — with a specific reason.
-- [ ] `UnsupportedReason` enum: `ForwardRowRef`, `CircularRef`, `UnsupportedFunction(String)`, `UnboundedRange`, `NonStaticCriteria`, `DynamicArray`, `VolatileUnsupported`, `TableReference`, `NamedRange`, `ExternalReference`, etc.
-- [ ] Support-set constants:
-  - [ ] `UNSUPPORTED_FUNCTIONS`: `OFFSET`, `INDIRECT`, `FILTER`, `UNIQUE`, `SORT`, `SORTBY`, `SEQUENCE`, `RANDARRAY`, `LAMBDA`, `LET`, `HYPERLINK` (as function), `WEBSERVICE`, `CUBEVALUE`, ...
-  - [ ] `AGGREGATE_FUNCTIONS`: `SUM`, `COUNT`, `COUNTA`, `AVERAGE`, `MIN`, `MAX`, `PRODUCT`, `SUMIF`, `COUNTIF`, `AVERAGEIF`, `SUMIFS`, `COUNTIFS`, `AVERAGEIFS`, `MINIFS`, `MAXIFS`, `MEDIAN`.
-  - [ ] `LOOKUP_FUNCTIONS`: `VLOOKUP`, `HLOOKUP`, `XLOOKUP`, `MATCH`, `XMATCH`, `INDEX`, `CHOOSE`. Pure Excel only — no custom extensions.
+- [x] `UnsupportedReason` enum: `NonCurrentRowRef`, `CircularRef`, `UnsupportedFunction(String)`, `UnboundedRange`, `NonStaticCriteria`, `DynamicArray`, `VolatileUnsupported`, `TableReference`, `NamedRange`, `ExternalReference`, `NestedUnsupported`, `LookupSheetNotPrepared`, `LookupIntoStreamingSheet`.
+- [x] Support-set constants:
+  - [x] `UNSUPPORTED_FUNCTIONS`: `OFFSET`, `INDIRECT`, `FILTER`, `UNIQUE`, `SORT`, `SORTBY`, `SEQUENCE`, `RANDARRAY`, `LAMBDA`, `LET`, `HYPERLINK`, `WEBSERVICE`, `CUBEVALUE`, `CUBEMEMBER`, `CUBESET`, `RAND`, `RANDBETWEEN`.
+  - [x] `AGGREGATE_FUNCTIONS`: `SUM`, `COUNT`, `COUNTA`, `AVERAGE`, `MIN`, `MAX`, `PRODUCT`, `SUMIF`, `COUNTIF`, `AVERAGEIF`, `SUMIFS`, `COUNTIFS`, `AVERAGEIFS`, `MINIFS`, `MAXIFS`, `MEDIAN`.
+  - [x] `LOOKUP_FUNCTIONS`: `VLOOKUP`, `HLOOKUP`, `XLOOKUP`, `MATCH`, `XMATCH`, `INDEX`, `CHOOSE`.
+  - [x] `VOLATILE_STREAMING_OK`: `TODAY`, `NOW`.
 
 ### AST rewrite
 
@@ -60,7 +61,7 @@
   - [ ] `Deal Value / SUM(Deal Value:Deal Value)` — Mixed.
   - [ ] `OFFSET(A1, 1, 0)` — Unsupported.
   - [ ] `INDIRECT("A1")` — Unsupported.
-  - [ ] `A3` where current row is 5 — Unsupported (forward ref from past row).
+  - [ ] `A3` where current row is 5 — Unsupported (non-current-row ref).
   - [ ] `FILTER(A:A, B:B>0)` — Unsupported (dynamic array).
   - [ ] Circular reference — Unsupported.
   - [ ] `VLOOKUP(A&B, Sheet2!D:E, 2, FALSE)` — LookupOnly, concatenated-key via helper column on lookup sheet.


### PR DESCRIPTION
## Summary

- Replace `Classification::Unsupported(String)` with `Unsupported { reason: UnsupportedReason, doc_link: &'static str }`
- Add `UnsupportedReason` enum with 13 variants, each with `Display` impl and `doc_link()` returning a stable GitHub URL
- Add `phf::Set` constants: `UNSUPPORTED_FUNCTIONS` (17), `AGGREGATE_FUNCTIONS` (16), `LOOKUP_FUNCTIONS` (7), `VOLATILE_STREAMING_OK` (2)
- Case-insensitive lookup via `to_uppercase()` + `phf_set!` (upper-case entries)
- Update `docs/backlog/v0.2.md` with table/named-range lift requirements
- Fix phase doc: "non-current-row ref" replaces "forward ref from past row"

## Design decisions

- **No `BASE` const for URLs**: each `doc_link()` arm carries a complete string literal — grep-auditable, clippy-clean
- **`phf` over `HashSet`**: compile-time perfect hash, zero runtime init, immutable by construction
- **`to_uppercase()` per call**: allocates a short String per lookup; acceptable since classification runs once per unique formula text (AST cache amortises across 400k rows)
- **Breaking change to `Classification::Unsupported`**: grep confirms no external callers (only `classify.rs` itself and its tests)

## New dependency

`phf 0.11.3` with `features = ["macros"]` — already declared in `[workspace.dependencies]`. Adds `phf`, `phf_macros`, `phf_shared`, `phf_generator`, `siphasher`, `rand` (build-time only for generator).

## Test plan

- [x] `make check` passes (fmt, clippy -D warnings, all tests, doc-tests)
- [x] 7 new unit tests: 3 for `UnsupportedReason` (Display, doc_link, distinct links), 4 for sets (aggregate, unsupported, lookup, volatile)
- [x] 6 new doc-tests across `UnsupportedReason`, `doc_link()`, and 4 `is_*` functions
- [ ] Review: all 13 `UnsupportedReason` variants have Display + doc_link coverage
- [ ] Review: set contents match `docs/phases/phase-02-parser.md` checklist