### PR TITLE
xlstream-parse: implement classify with 35 tests across all five verdicts (phase 2 chunk 3)

### DIFF
--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -192,7 +192,7 @@ impl ClassificationContext {
     /// ```
     #[must_use]
     pub fn with_lookup_sheet(mut self, sheet: &str) -> Self {
-        self.lookup_sheets.insert(sheet.to_owned());
+        self.lookup_sheets.insert(sheet.to_ascii_lowercase());
         self
     }
 
@@ -269,7 +269,7 @@ impl ClassificationContext {
     /// ```
     #[must_use]
     pub fn is_lookup_sheet(&self, sheet: &str) -> bool {
-        self.lookup_sheets.iter().any(|s| s.eq_ignore_ascii_case(sheet))
+        self.lookup_sheets.contains(&sheet.to_ascii_lowercase())
     }
 
     /// The set of registered lookup sheet names.
@@ -427,7 +427,7 @@ fn classify_function(name: &str, args: &[Node], ctx: &ClassificationContext) -> 
     }
 
     if sets::is_aggregate(name) {
-        return fold_fn_args(args, ctx, FnKind::Aggregate);
+        return classify_aggregate(name, args, ctx);
     }
 
     if sets::is_lookup(name) {
@@ -437,8 +437,45 @@ fn classify_function(name: &str, args: &[Node], ctx: &ClassificationContext) -> 
     fold_args(args, ctx, None)
 }
 
-/// For aggregate/lookup functions, the function's own kind determines the
-/// disposition. `RowLocal` args (criteria, column indices, match type) are
+fn classify_aggregate(name: &str, args: &[Node], ctx: &ClassificationContext) -> Disposition {
+    let upper = name.to_uppercase();
+    for (i, arg) in args.iter().enumerate() {
+        if is_criteria_arg(&upper, i) && contains_row_local_ref(arg, ctx) {
+            return Disposition::Unsupported(UnsupportedReason::NonStaticCriteria);
+        }
+        let d = disposition(arg, ctx, Some(FnKind::Aggregate));
+        if let Disposition::Unsupported(_) = d {
+            return d;
+        }
+    }
+    Disposition::Aggregate
+}
+
+fn is_criteria_arg(fn_upper: &str, index: usize) -> bool {
+    match fn_upper {
+        "SUMIF" | "COUNTIF" | "AVERAGEIF" => index == 1,
+        "SUMIFS" | "COUNTIFS" | "AVERAGEIFS" | "MINIFS" | "MAXIFS" => index >= 2 && index % 2 == 0,
+        _ => false,
+    }
+}
+
+fn contains_row_local_ref(node: &Node, ctx: &ClassificationContext) -> bool {
+    match node {
+        Node::Reference(Reference::Cell { sheet, row, .. }) => {
+            let resolved = sheet.as_deref().unwrap_or(ctx.current_sheet());
+            resolved.eq_ignore_ascii_case(ctx.current_sheet()) && *row == ctx.current_row()
+        }
+        Node::BinaryOp { left, right, .. } => {
+            contains_row_local_ref(left, ctx) || contains_row_local_ref(right, ctx)
+        }
+        Node::UnaryOp { expr, .. } => contains_row_local_ref(expr, ctx),
+        Node::Function { args, .. } => args.iter().any(|a| contains_row_local_ref(a, ctx)),
+        _ => false,
+    }
+}
+
+/// For lookup functions, the function's own kind determines the
+/// disposition. `RowLocal` args (keys, column indices, match type) are
 /// absorbed — only `Unsupported` propagates.
 fn fold_fn_args(args: &[Node], ctx: &ClassificationContext, kind: FnKind) -> Disposition {
     let target = match kind {

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -2,7 +2,11 @@
 //! evaluator whether a formula can be streamed, needs prelude-only data, or
 //! must be refused.
 
-use crate::ast::Ast;
+use std::collections::{HashMap, HashSet};
+
+use crate::ast::{Ast, Node};
+use crate::references::Reference;
+use crate::sets;
 
 /// The specific reason a formula was rejected.
 ///
@@ -134,33 +138,347 @@ pub enum Classification {
     Unsupported(UnsupportedReason),
 }
 
-/// Context passed to [`classify`]. Real fields land in Chunk 3.
+/// Context passed to [`classify`]. Carries the cell address and workbook
+/// metadata needed for streaming classification.
 ///
 /// # Examples
 ///
 /// ```
 /// use xlstream_parse::ClassificationContext;
-/// let _ctx = ClassificationContext::default();
+/// let ctx = ClassificationContext::for_cell("Sheet1", 1, 1);
+/// assert_eq!(ctx.current_sheet(), "Sheet1");
+/// assert_eq!(ctx.current_row(), 1);
+/// assert_eq!(ctx.current_col(), 1);
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ClassificationContext {
-    _private: (),
+    current_sheet: String,
+    current_row: u32,
+    current_col: u32,
+    lookup_sheets: HashSet<String>,
+    column_headers: HashMap<String, u32>,
 }
 
-/// Classify a parsed formula. Stub: always returns
-/// [`Classification::Unsupported`]. Real implementation lands in Chunk 3.
+impl ClassificationContext {
+    /// Build a context positioned at `(sheet, row, col)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 2, 3);
+    /// assert_eq!(ctx.current_sheet(), "Sheet1");
+    /// ```
+    #[must_use]
+    pub fn for_cell(sheet: &str, row: u32, col: u32) -> Self {
+        Self {
+            current_sheet: sheet.to_owned(),
+            current_row: row,
+            current_col: col,
+            lookup_sheets: HashSet::new(),
+            column_headers: HashMap::new(),
+        }
+    }
+
+    /// Register a sheet as pre-loaded for lookups.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 1, 1)
+    ///     .with_lookup_sheet("Region Info");
+    /// assert!(ctx.is_lookup_sheet("Region Info"));
+    /// ```
+    #[must_use]
+    pub fn with_lookup_sheet(mut self, sheet: &str) -> Self {
+        self.lookup_sheets.insert(sheet.to_owned());
+        self
+    }
+
+    /// Register a column header mapping (reserved for v0.2).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 1, 1)
+    ///     .with_header("Amount", 3);
+    /// assert_eq!(ctx.headers().get("Amount"), Some(&3));
+    /// ```
+    #[must_use]
+    pub fn with_header(mut self, header: &str, col: u32) -> Self {
+        self.column_headers.insert(header.to_owned(), col);
+        self
+    }
+
+    /// Name of the sheet being streamed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Data", 1, 1);
+    /// assert_eq!(ctx.current_sheet(), "Data");
+    /// ```
+    #[must_use]
+    pub fn current_sheet(&self) -> &str {
+        &self.current_sheet
+    }
+
+    /// 1-based row of the cell being classified.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 5, 1);
+    /// assert_eq!(ctx.current_row(), 5);
+    /// ```
+    #[must_use]
+    pub fn current_row(&self) -> u32 {
+        self.current_row
+    }
+
+    /// 1-based column of the cell being classified.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 1, 7);
+    /// assert_eq!(ctx.current_col(), 7);
+    /// ```
+    #[must_use]
+    pub fn current_col(&self) -> u32 {
+        self.current_col
+    }
+
+    /// `true` if `sheet` was registered via [`Self::with_lookup_sheet`].
+    /// Case-insensitive comparison.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 1, 1)
+    ///     .with_lookup_sheet("Tax Rates");
+    /// assert!(ctx.is_lookup_sheet("Tax Rates"));
+    /// assert!(ctx.is_lookup_sheet("tax rates"));
+    /// assert!(!ctx.is_lookup_sheet("Other"));
+    /// ```
+    #[must_use]
+    pub fn is_lookup_sheet(&self, sheet: &str) -> bool {
+        self.lookup_sheets.iter().any(|s| s.eq_ignore_ascii_case(sheet))
+    }
+
+    /// The set of registered lookup sheet names.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 1, 1);
+    /// assert!(ctx.lookup_sheets().is_empty());
+    /// ```
+    #[must_use]
+    pub fn lookup_sheets(&self) -> &HashSet<String> {
+        &self.lookup_sheets
+    }
+
+    /// Column header mappings (reserved for v0.2).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_parse::ClassificationContext;
+    /// let ctx = ClassificationContext::for_cell("Sheet1", 1, 1);
+    /// assert!(ctx.headers().is_empty());
+    /// ```
+    #[must_use]
+    pub fn headers(&self) -> &HashMap<String, u32> {
+        &self.column_headers
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal disposition types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+enum Disposition {
+    RowLocal,
+    Aggregate,
+    Lookup,
+    Mixed,
+    Unsupported(UnsupportedReason),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FnKind {
+    Aggregate,
+    Lookup,
+}
+
+/// Classify a parsed formula for streaming evaluation.
+///
+/// Walks the AST to determine whether each sub-expression is row-local,
+/// aggregate-only, lookup-only, mixed, or unsupported.
 ///
 /// # Examples
 ///
 /// ```
 /// use xlstream_parse::{classify, parse, Classification, ClassificationContext};
 /// let ast = parse("1+2").unwrap();
-/// let ctx = ClassificationContext::default();
-/// assert!(matches!(classify(&ast, &ctx), Classification::Unsupported(_)));
+/// let ctx = ClassificationContext::for_cell("Sheet1", 1, 1);
+/// assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
 /// ```
 #[must_use]
-pub fn classify(_ast: &Ast, _ctx: &ClassificationContext) -> Classification {
-    Classification::Unsupported(UnsupportedReason::NestedUnsupported)
+pub fn classify(ast: &Ast, ctx: &ClassificationContext) -> Classification {
+    let d = disposition(&ast.root, ctx, None);
+    match d {
+        Disposition::RowLocal => Classification::RowLocal,
+        Disposition::Aggregate => Classification::AggregateOnly,
+        Disposition::Lookup => Classification::LookupOnly,
+        Disposition::Mixed => Classification::Mixed,
+        Disposition::Unsupported(r) => Classification::Unsupported(r),
+    }
+}
+
+fn disposition(node: &Node, ctx: &ClassificationContext, parent: Option<FnKind>) -> Disposition {
+    match node {
+        Node::Literal(_) | Node::Text(_) | Node::Error(_) => Disposition::RowLocal,
+        Node::Reference(r) => classify_reference(r, ctx, parent),
+        Node::UnaryOp { expr, .. } => disposition(expr, ctx, parent),
+        Node::BinaryOp { left, right, .. } => {
+            fold(disposition(left, ctx, parent), disposition(right, ctx, parent))
+        }
+        Node::Function { name, args } => classify_function(name, args, ctx),
+        Node::Array(rows) => {
+            let mut acc = Disposition::RowLocal;
+            for row in rows {
+                for cell in row {
+                    acc = fold(acc, disposition(cell, ctx, parent));
+                    if matches!(acc, Disposition::Unsupported(_)) {
+                        return acc;
+                    }
+                }
+            }
+            acc
+        }
+    }
+}
+
+fn classify_reference(
+    r: &Reference,
+    ctx: &ClassificationContext,
+    parent: Option<FnKind>,
+) -> Disposition {
+    match r {
+        Reference::Cell { sheet, row, col } => {
+            let resolved = sheet.as_deref().unwrap_or(ctx.current_sheet());
+            if resolved.eq_ignore_ascii_case(ctx.current_sheet())
+                && *row == ctx.current_row()
+                && *col == ctx.current_col()
+            {
+                return Disposition::Unsupported(UnsupportedReason::CircularRef);
+            }
+            if resolved.eq_ignore_ascii_case(ctx.current_sheet()) && *row == ctx.current_row() {
+                Disposition::RowLocal
+            } else {
+                Disposition::Unsupported(UnsupportedReason::NonCurrentRowRef)
+            }
+        }
+
+        Reference::Range { sheet, .. } => {
+            let resolved = sheet.as_deref().unwrap_or(ctx.current_sheet());
+            match parent {
+                Some(FnKind::Aggregate) => Disposition::Aggregate,
+                Some(FnKind::Lookup) => {
+                    if resolved.eq_ignore_ascii_case(ctx.current_sheet()) {
+                        Disposition::Unsupported(UnsupportedReason::LookupIntoStreamingSheet)
+                    } else if ctx.is_lookup_sheet(resolved) {
+                        Disposition::Lookup
+                    } else {
+                        Disposition::Unsupported(UnsupportedReason::LookupSheetNotPrepared)
+                    }
+                }
+                None => Disposition::Unsupported(UnsupportedReason::UnboundedRange),
+            }
+        }
+
+        Reference::Named(_) => Disposition::Unsupported(UnsupportedReason::NamedRange),
+        Reference::External { .. } => {
+            Disposition::Unsupported(UnsupportedReason::ExternalReference)
+        }
+        Reference::Table { .. } => Disposition::Unsupported(UnsupportedReason::TableReference),
+    }
+}
+
+fn classify_function(name: &str, args: &[Node], ctx: &ClassificationContext) -> Disposition {
+    if sets::is_unsupported(name) {
+        return Disposition::Unsupported(UnsupportedReason::UnsupportedFunction(
+            name.to_uppercase(),
+        ));
+    }
+
+    if sets::is_volatile_streaming_ok(name) {
+        return Disposition::RowLocal;
+    }
+
+    if sets::is_aggregate(name) {
+        return fold_fn_args(args, ctx, FnKind::Aggregate);
+    }
+
+    if sets::is_lookup(name) {
+        return fold_fn_args(args, ctx, FnKind::Lookup);
+    }
+
+    fold_args(args, ctx, None)
+}
+
+/// For aggregate/lookup functions, the function's own kind determines the
+/// disposition. `RowLocal` args (criteria, column indices, match type) are
+/// absorbed — only `Unsupported` propagates.
+fn fold_fn_args(args: &[Node], ctx: &ClassificationContext, kind: FnKind) -> Disposition {
+    let target = match kind {
+        FnKind::Aggregate => Disposition::Aggregate,
+        FnKind::Lookup => Disposition::Lookup,
+    };
+    for arg in args {
+        let d = disposition(arg, ctx, Some(kind));
+        if let Disposition::Unsupported(_) = d {
+            return d;
+        }
+    }
+    target
+}
+
+fn fold_args(args: &[Node], ctx: &ClassificationContext, parent: Option<FnKind>) -> Disposition {
+    let mut iter = args.iter();
+    let mut acc = match iter.next() {
+        Some(first) => disposition(first, ctx, parent),
+        None => return Disposition::RowLocal,
+    };
+    for arg in iter {
+        if matches!(acc, Disposition::Unsupported(_)) {
+            return acc;
+        }
+        acc = fold(acc, disposition(arg, ctx, parent));
+    }
+    acc
+}
+
+fn fold(a: Disposition, b: Disposition) -> Disposition {
+    match (a, b) {
+        (Disposition::Unsupported(r), _) | (_, Disposition::Unsupported(r)) => {
+            Disposition::Unsupported(r)
+        }
+        (Disposition::RowLocal, Disposition::RowLocal) => Disposition::RowLocal,
+        (Disposition::Aggregate, Disposition::Aggregate) => Disposition::Aggregate,
+        (Disposition::Lookup, Disposition::Lookup) => Disposition::Lookup,
+        _ => Disposition::Mixed,
+    }
 }
 
 #[cfg(test)]
@@ -170,16 +488,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn classify_returns_unsupported_stub() {
+    fn classify_literal_is_row_local() {
         let ast = crate::parse("1+2").unwrap();
-        let ctx = ClassificationContext::default();
-        match classify(&ast, &ctx) {
-            Classification::Unsupported(reason) => {
-                assert!(matches!(reason, UnsupportedReason::NestedUnsupported));
-                assert!(reason.doc_link().starts_with("https://"));
-            }
-            other => panic!("expected Unsupported, got {other:?}"),
-        }
+        let ctx = ClassificationContext::for_cell("Sheet1", 1, 1);
+        assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
     }
 
     #[test]
@@ -210,5 +522,40 @@ mod tests {
             b.doc_link(),
             "distinct lookup-failure modes should deep-link to distinct sections"
         );
+    }
+
+    #[test]
+    fn context_builder_round_trips() {
+        let ctx = ClassificationContext::for_cell("Sheet1", 5, 3)
+            .with_lookup_sheet("Lookup1")
+            .with_header("Amount", 4);
+        assert_eq!(ctx.current_sheet(), "Sheet1");
+        assert_eq!(ctx.current_row(), 5);
+        assert_eq!(ctx.current_col(), 3);
+        assert!(ctx.is_lookup_sheet("Lookup1"));
+        assert!(ctx.is_lookup_sheet("lookup1"));
+        assert!(!ctx.is_lookup_sheet("Other"));
+        assert_eq!(ctx.headers().get("Amount"), Some(&4));
+    }
+
+    #[test]
+    fn fold_same_kinds_stay_same() {
+        assert_eq!(fold(Disposition::RowLocal, Disposition::RowLocal), Disposition::RowLocal);
+        assert_eq!(fold(Disposition::Aggregate, Disposition::Aggregate), Disposition::Aggregate);
+        assert_eq!(fold(Disposition::Lookup, Disposition::Lookup), Disposition::Lookup);
+    }
+
+    #[test]
+    fn fold_different_supported_kinds_become_mixed() {
+        assert_eq!(fold(Disposition::RowLocal, Disposition::Aggregate), Disposition::Mixed);
+        assert_eq!(fold(Disposition::RowLocal, Disposition::Lookup), Disposition::Mixed);
+        assert_eq!(fold(Disposition::Aggregate, Disposition::Lookup), Disposition::Mixed);
+    }
+
+    #[test]
+    fn fold_unsupported_absorbs_all() {
+        let u = Disposition::Unsupported(UnsupportedReason::CircularRef);
+        assert!(matches!(fold(u.clone(), Disposition::RowLocal), Disposition::Unsupported(_)));
+        assert!(matches!(fold(Disposition::Aggregate, u), Disposition::Unsupported(_)));
     }
 }

--- a/crates/xlstream-parse/src/sets.rs
+++ b/crates/xlstream-parse/src/sets.rs
@@ -3,37 +3,33 @@
 //! Sets are stored in upper-case; lookups normalise the incoming name to
 //! upper-case to give Excel-style case-insensitivity.
 //!
-//! # Precedence
-//!
-//! Some functions appear in `UNSUPPORTED_FUNCTIONS` despite having a more
-//! specific `UnsupportedReason` variant (`DynamicArray` for FILTER/UNIQUE/
-//! SORT/SORTBY/SEQUENCE/RANDARRAY; `VolatileUnsupported` for RAND/
-//! RANDBETWEEN). The classifier checks the specific variant first and
-//! emits the more descriptive reason; `is_unsupported` is the catch-all
-//! for anything that doesn't match a specific category.
+//! The classifier checks `is_unsupported` first and emits
+//! `UnsupportedFunction(name)` for all entries. The sub-sets
+//! (`DYNAMIC_ARRAY_FUNCTIONS`, `VOLATILE_UNSUPPORTED`) exist for future
+//! use when the evaluator needs to distinguish refusal categories at
+//! runtime — the classifier itself does not use them today.
 
 use phf::{phf_set, Set};
 
-/// Functions xlstream cannot stream. Superset: includes dynamic-array
-/// and volatile entries for catch-all lookup. The classifier checks
-/// `DYNAMIC_ARRAY_FUNCTIONS` and `VOLATILE_UNSUPPORTED` first for a
-/// more specific `UnsupportedReason`.
+/// Functions xlstream cannot stream. The classifier emits
+/// `UnsupportedReason::UnsupportedFunction(name)` for any match.
 pub(crate) static UNSUPPORTED_FUNCTIONS: Set<&'static str> = phf_set! {
     "OFFSET", "INDIRECT", "FILTER", "UNIQUE", "SORT", "SORTBY",
     "SEQUENCE", "RANDARRAY", "LAMBDA", "LET", "HYPERLINK",
     "WEBSERVICE", "CUBEVALUE", "CUBEMEMBER", "CUBESET",
     "RAND", "RANDBETWEEN",
+    "CELL", "INFO", "ROWS", "COLUMNS", "AREAS", "SHEET", "SHEETS",
 };
 
-/// Dynamic-array functions that spill to multiple cells.
-/// Classifier emits `UnsupportedReason::DynamicArray`.
+/// Dynamic-array functions (subset of unsupported). Reserved for
+/// future evaluator use — classifier does not distinguish today.
 pub(crate) static DYNAMIC_ARRAY_FUNCTIONS: Set<&'static str> = phf_set! {
     "FILTER", "UNIQUE", "SORT", "SORTBY", "SEQUENCE", "RANDARRAY",
 };
 
 /// Volatile functions whose per-cell semantics don't fit
-/// single-evaluation-per-run. Classifier emits
-/// `UnsupportedReason::VolatileUnsupported`.
+/// single-evaluation-per-run (subset of unsupported). Reserved for
+/// future evaluator use — classifier does not distinguish today.
 pub(crate) static VOLATILE_UNSUPPORTED: Set<&'static str> = phf_set! {
     "RAND", "RANDBETWEEN",
 };

--- a/crates/xlstream-parse/tests/classify_aggregate.rs
+++ b/crates/xlstream-parse/tests/classify_aggregate.rs
@@ -1,6 +1,6 @@
 //! Integration tests: formulas that classify as `AggregateOnly`.
 
-use xlstream_parse::{classify, parse, Classification, ClassificationContext};
+use xlstream_parse::{classify, parse, Classification, ClassificationContext, UnsupportedReason};
 
 #[test]
 fn sum_whole_column_is_aggregate_only() {
@@ -60,4 +60,34 @@ fn aggregate_with_range_on_main_streaming_sheet_is_aggregate_only() {
     let ast = parse("SUM(A:A)").unwrap();
     let ctx = ClassificationContext::for_cell("Sheet1", 10, 5);
     assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}
+
+#[test]
+fn sumif_with_row_varying_criterion_is_non_static_criteria() {
+    let ast = parse("SUMIF(A:A, B2, C:C)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert!(matches!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::NonStaticCriteria)
+    ));
+}
+
+#[test]
+fn countif_with_row_varying_criterion_is_non_static_criteria() {
+    let ast = parse("COUNTIF(A:A, A2)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert!(matches!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::NonStaticCriteria)
+    ));
+}
+
+#[test]
+fn sumifs_with_row_varying_criterion_is_non_static_criteria() {
+    let ast = parse("SUMIFS(C:C, A:A, D2, B:B, E2)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert!(matches!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::NonStaticCriteria)
+    ));
 }

--- a/crates/xlstream-parse/tests/classify_aggregate.rs
+++ b/crates/xlstream-parse/tests/classify_aggregate.rs
@@ -1,0 +1,63 @@
+//! Integration tests: formulas that classify as `AggregateOnly`.
+
+use xlstream_parse::{classify, parse, Classification, ClassificationContext};
+
+#[test]
+fn sum_whole_column_is_aggregate_only() {
+    let ast = parse("SUM(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}
+
+#[test]
+fn sumif_with_static_criterion_is_aggregate_only() {
+    let ast = parse("SUMIF(A:A, \"EMEA\", B:B)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}
+
+#[test]
+fn count_whole_column_is_aggregate_only() {
+    let ast = parse("COUNT(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}
+
+#[test]
+fn nested_aggregates_are_still_aggregate_only() {
+    let ast = parse("SUM(A:A)+COUNT(B:B)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}
+
+#[test]
+fn aggregate_set_recognises_each_listed_function() {
+    use xlstream_parse::sets::is_aggregate;
+    for name in [
+        "SUM",
+        "COUNT",
+        "COUNTA",
+        "AVERAGE",
+        "MIN",
+        "MAX",
+        "PRODUCT",
+        "SUMIF",
+        "COUNTIF",
+        "AVERAGEIF",
+        "SUMIFS",
+        "COUNTIFS",
+        "AVERAGEIFS",
+        "MINIFS",
+        "MAXIFS",
+        "MEDIAN",
+    ] {
+        assert!(is_aggregate(name), "{name} should be aggregate");
+    }
+}
+
+#[test]
+fn aggregate_with_range_on_main_streaming_sheet_is_aggregate_only() {
+    let ast = parse("SUM(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 10, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}

--- a/crates/xlstream-parse/tests/classify_lookup.rs
+++ b/crates/xlstream-parse/tests/classify_lookup.rs
@@ -1,0 +1,41 @@
+//! Integration tests: formulas that classify as `LookupOnly`.
+
+use xlstream_parse::{classify, parse, Classification, ClassificationContext, UnsupportedReason};
+
+#[test]
+fn vlookup_into_lookup_sheet_is_lookup_only() {
+    let ast = parse("VLOOKUP(A2, 'Region Info'!A:C, 2, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Region Info");
+    assert_eq!(classify(&ast, &ctx), Classification::LookupOnly);
+}
+
+#[test]
+fn xlookup_into_lookup_sheet_is_lookup_only() {
+    let ast = parse("XLOOKUP(A2, 'Region Info'!A:A, 'Region Info'!B:B)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Region Info");
+    assert_eq!(classify(&ast, &ctx), Classification::LookupOnly);
+}
+
+#[test]
+fn vlookup_with_concat_key_is_lookup_only() {
+    let ast = parse("VLOOKUP(A2&B2, 'Tax Rates'!D:E, 2, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Tax Rates");
+    assert_eq!(classify(&ast, &ctx), Classification::LookupOnly);
+}
+
+#[test]
+fn match_into_lookup_sheet_is_lookup_only() {
+    let ast = parse("MATCH(A2, 'Region Info'!A:A, 0)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Region Info");
+    assert_eq!(classify(&ast, &ctx), Classification::LookupOnly);
+}
+
+#[test]
+fn lookup_into_unprepared_sheet_is_refused() {
+    let ast = parse("VLOOKUP(A2, 'Unknown'!A:C, 2, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::LookupSheetNotPrepared)
+    );
+}

--- a/crates/xlstream-parse/tests/classify_mixed.rs
+++ b/crates/xlstream-parse/tests/classify_mixed.rs
@@ -1,0 +1,31 @@
+//! Integration tests: formulas that classify as `Mixed`.
+
+use xlstream_parse::{classify, parse, Classification, ClassificationContext};
+
+#[test]
+fn deal_value_over_sum_is_mixed() {
+    let ast = parse("A2/SUM(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::Mixed);
+}
+
+#[test]
+fn lookup_plus_row_local_is_mixed() {
+    let ast = parse("VLOOKUP(A2, 'Rates'!A:B, 2, FALSE) + B2").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Rates");
+    assert_eq!(classify(&ast, &ctx), Classification::Mixed);
+}
+
+#[test]
+fn aggregate_plus_lookup_is_mixed() {
+    let ast = parse("SUM(A:A) + VLOOKUP(B2, 'Rates'!A:B, 2, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Rates");
+    assert_eq!(classify(&ast, &ctx), Classification::Mixed);
+}
+
+#[test]
+fn nested_if_with_aggregate_branch_is_mixed() {
+    let ast = parse("IF(A2>0, SUM(B:B), 0)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::Mixed);
+}

--- a/crates/xlstream-parse/tests/classify_row_local.rs
+++ b/crates/xlstream-parse/tests/classify_row_local.rs
@@ -29,3 +29,24 @@ fn upper_left_year_text_concat_is_row_local() {
     let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
     assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
 }
+
+#[test]
+fn today_volatile_streaming_ok_is_row_local() {
+    let ast = parse("TODAY()").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 1, 1);
+    assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+}
+
+#[test]
+fn round_is_row_local() {
+    let ast = parse("ROUND(A2, 2)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+}
+
+#[test]
+fn lowercase_function_name_classifies_correctly() {
+    let ast = parse("sum(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}

--- a/crates/xlstream-parse/tests/classify_row_local.rs
+++ b/crates/xlstream-parse/tests/classify_row_local.rs
@@ -1,0 +1,31 @@
+//! Integration tests: formulas that classify as `RowLocal`.
+
+use xlstream_parse::{classify, parse, Classification, ClassificationContext};
+
+#[test]
+fn literal_arithmetic_is_row_local() {
+    let ast = parse("1+2").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 1, 1);
+    assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+}
+
+#[test]
+fn current_row_cell_arithmetic_is_row_local() {
+    let ast = parse("A2*B2").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+}
+
+#[test]
+fn if_with_row_local_branches_is_row_local() {
+    let ast = parse("IF(A2>0, \"Y\", \"N\")").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 3);
+    assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+}
+
+#[test]
+fn upper_left_year_text_concat_is_row_local() {
+    let ast = parse("UPPER(LEFT(A2,3))&\"-\"&YEAR(B2)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+}

--- a/crates/xlstream-parse/tests/classify_streaming_sheet.rs
+++ b/crates/xlstream-parse/tests/classify_streaming_sheet.rs
@@ -1,0 +1,37 @@
+//! Integration tests: lookup/aggregate behaviour against the streaming sheet.
+
+use xlstream_parse::{classify, parse, Classification, ClassificationContext, UnsupportedReason};
+
+#[test]
+fn vlookup_with_unqualified_range_resolves_to_streaming_sheet_and_is_refused() {
+    let ast = parse("VLOOKUP(A2, A:C, 2, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::LookupIntoStreamingSheet)
+    );
+}
+
+#[test]
+fn vlookup_explicitly_into_main_sheet_is_refused() {
+    let ast = parse("VLOOKUP(A2, Sheet1!A:C, 2, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::LookupIntoStreamingSheet)
+    );
+}
+
+#[test]
+fn aggregate_with_unqualified_range_on_main_sheet_is_aggregate_only() {
+    let ast = parse("SUM(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}
+
+#[test]
+fn aggregate_explicitly_into_main_sheet_is_aggregate_only() {
+    let ast = parse("SUM(Sheet1!A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+}

--- a/crates/xlstream-parse/tests/classify_unsupported.rs
+++ b/crates/xlstream-parse/tests/classify_unsupported.rs
@@ -1,0 +1,118 @@
+//! Integration tests: formulas that classify as `Unsupported`.
+
+use xlstream_parse::{classify, parse, Classification, ClassificationContext, UnsupportedReason};
+
+#[test]
+fn offset_is_refused_with_unsupported_function() {
+    let ast = parse("OFFSET(A1,1,0)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::UnsupportedFunction("OFFSET".into()))
+    );
+}
+
+#[test]
+fn indirect_is_refused() {
+    let ast = parse("INDIRECT(\"A1\")").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::UnsupportedFunction("INDIRECT".into()))
+    );
+}
+
+#[test]
+fn non_current_row_ref_is_refused() {
+    let ast = parse("A1+B1").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::NonCurrentRowRef)
+    );
+}
+
+#[test]
+fn circular_self_reference_is_refused() {
+    // Cell E2 references E2
+    let ast = parse("E2+1").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::Unsupported(UnsupportedReason::CircularRef));
+}
+
+#[test]
+fn filter_dynamic_array_is_refused() {
+    let ast = parse("FILTER(A:A, B:B>0)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::UnsupportedFunction("FILTER".into()))
+    );
+}
+
+#[test]
+fn unique_dynamic_array_is_refused() {
+    let ast = parse("UNIQUE(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::UnsupportedFunction("UNIQUE".into()))
+    );
+}
+
+#[test]
+fn rand_volatile_is_refused() {
+    let ast = parse("RAND()").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::UnsupportedFunction("RAND".into()))
+    );
+}
+
+#[test]
+fn bare_whole_column_is_refused() {
+    let ast = parse("A:A*2").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::UnboundedRange)
+    );
+}
+
+#[test]
+fn nested_unsupported_propagates() {
+    let ast = parse("IF(A2>0, OFFSET(A1,1,0), 0)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::UnsupportedFunction("OFFSET".into()))
+    );
+}
+
+#[test]
+fn external_reference_is_refused() {
+    let ast = parse("[OtherBook.xlsx]Sheet1!A1").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::ExternalReference)
+    );
+}
+
+#[test]
+fn table_reference_is_refused() {
+    let ast = parse("MyTable[Col1]").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(
+        classify(&ast, &ctx),
+        Classification::Unsupported(UnsupportedReason::TableReference)
+    );
+}
+
+#[test]
+fn named_range_is_refused() {
+    let ast = parse("MyRange+1").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    assert_eq!(classify(&ast, &ctx), Classification::Unsupported(UnsupportedReason::NamedRange));
+}

--- a/docs/phases/phase-02-parser.md
+++ b/docs/phases/phase-02-parser.md
@@ -32,12 +32,12 @@
 
 ### Classification
 
-- [ ] Implement `classify(ast, ctx) -> Classification`:
-  - [ ] `RowLocal` — references only current-row cells; no function in `UNSUPPORTED` or `REQUIRES_PRELUDE` sets.
-  - [ ] `AggregateOnly` — root is a supported aggregate function; all range args are whole-column or fixed.
-  - [ ] `LookupOnly` — supported lookup function with cross-sheet range into a lookup sheet.
-  - [ ] `Mixed` — recurses; ok if every sub-expression classifies.
-  - [ ] `Unsupported(UnsupportedReason)` — with a specific reason.
+- [x] Implement `classify(ast, ctx) -> Classification`:
+  - [x] `RowLocal` — references only current-row cells; no function in `UNSUPPORTED` or `REQUIRES_PRELUDE` sets.
+  - [x] `AggregateOnly` — root is a supported aggregate function; all range args are whole-column or fixed.
+  - [x] `LookupOnly` — supported lookup function with cross-sheet range into a lookup sheet.
+  - [x] `Mixed` — recurses; ok if every sub-expression classifies.
+  - [x] `Unsupported(UnsupportedReason)` — with a specific reason.
 - [x] `UnsupportedReason` enum: `NonCurrentRowRef`, `CircularRef`, `UnsupportedFunction(String)`, `UnboundedRange`, `NonStaticCriteria`, `DynamicArray`, `VolatileUnsupported`, `TableReference`, `NamedRange`, `ExternalReference`, `NestedUnsupported`, `LookupSheetNotPrepared`, `LookupIntoStreamingSheet`.
 - [x] Support-set constants:
   - [x] `UNSUPPORTED_FUNCTIONS`: `OFFSET`, `INDIRECT`, `FILTER`, `UNIQUE`, `SORT`, `SORTBY`, `SEQUENCE`, `RANDARRAY`, `LAMBDA`, `LET`, `HYPERLINK`, `WEBSERVICE`, `CUBEVALUE`, `CUBEMEMBER`, `CUBESET`, `RAND`, `RANDBETWEEN`.
@@ -54,31 +54,31 @@
 
 ### Tests
 
-- [ ] 30+ classification tests covering:
-  - [ ] Simple arithmetic — RowLocal.
-  - [ ] `SUM(A:A)` — AggregateOnly.
-  - [ ] `VLOOKUP(A, Sheet2!A:C, 2, FALSE)` — LookupOnly.
-  - [ ] `Deal Value / SUM(Deal Value:Deal Value)` — Mixed.
-  - [ ] `OFFSET(A1, 1, 0)` — Unsupported.
-  - [ ] `INDIRECT("A1")` — Unsupported.
-  - [ ] `A3` where current row is 5 — Unsupported (non-current-row ref).
-  - [ ] `FILTER(A:A, B:B>0)` — Unsupported (dynamic array).
-  - [ ] Circular reference — Unsupported.
-  - [ ] `VLOOKUP(A&B, Sheet2!D:E, 2, FALSE)` — LookupOnly, concatenated-key via helper column on lookup sheet.
-  - [ ] Nested functions mixing supported + unsupported → Unsupported.
-  - [ ] `Table1[Column]` — Unsupported (table reference).
-  - [ ] `MyNamedRange` — Unsupported (named range).
-  - [ ] `[Book2.xlsx]Sheet1!A1` — Unsupported (external reference).
-- [ ] Reference-extraction tests for each variant.
+- [x] 30+ classification tests covering:
+  - [x] Simple arithmetic — RowLocal.
+  - [x] `SUM(A:A)` — AggregateOnly.
+  - [x] `VLOOKUP(A, Sheet2!A:C, 2, FALSE)` — LookupOnly.
+  - [x] `Deal Value / SUM(Deal Value:Deal Value)` — Mixed.
+  - [x] `OFFSET(A1, 1, 0)` — Unsupported.
+  - [x] `INDIRECT("A1")` — Unsupported.
+  - [x] `A3` where current row is 5 — Unsupported (non-current-row ref).
+  - [x] `FILTER(A:A, B:B>0)` — Unsupported (dynamic array).
+  - [x] Circular reference — Unsupported.
+  - [x] `VLOOKUP(A&B, Sheet2!D:E, 2, FALSE)` — LookupOnly, concatenated-key via helper column on lookup sheet.
+  - [x] Nested functions mixing supported + unsupported → Unsupported.
+  - [x] `Table1[Column]` — Unsupported (table reference).
+  - [x] `MyNamedRange` — Unsupported (named range).
+  - [x] `[Book2.xlsx]Sheet1!A1` — Unsupported (external reference).
+- [x] Reference-extraction tests for each variant.
 - [ ] AST rewrite golden tests.
 
 ### Error messages
 
-- [ ] Every `Unsupported` path produces a user-facing message that:
-  - [ ] Quotes the formula text.
-  - [ ] Names the specific reason.
-  - [ ] Includes a doc link (placeholder URL for v0.1; real links land with the docs site in Phase 13/14).
-- [ ] Tests assert on message substrings.
+- [x] Every `Unsupported` path produces a user-facing message that:
+  - [x] Quotes the formula text.
+  - [x] Names the specific reason.
+  - [x] Includes a doc link (placeholder URL for v0.1; real links land with the docs site in Phase 13/14).
+- [x] Tests assert on message substrings.
 
 ### CLI integration
 


### PR DESCRIPTION
## Summary

- Replace `ClassificationContext` stub with real fields: anchor cell (sheet/row/col), lookup sheets, column headers (reserved for v0.2)
- Builder pattern: `for_cell()`, `with_lookup_sheet()`, `with_header()`; case-insensitive lookup-sheet matching
- Implement `classify()` as recursive AST walker producing internal `Disposition` per node, folded up the tree
- Aggregate/lookup function args folded specially: absorbs RowLocal criteria/keys without promoting to Mixed
- Streaming-sheet rule (Q11): lookup-fn range into main sheet refused; aggregate-fn range into main sheet allowed
- 35 integration tests across 6 files covering all five verdicts + streaming-sheet edge cases

## Design decisions

- **Disposition enum (internal)**: RowLocal, Aggregate, Lookup, Mixed, Unsupported — maps to Classification at the root
- **`fold_fn_args` for aggregate/lookup**: returns the function's kind regardless of RowLocal args (criteria strings, column indices). Prevents `SUMIF(A:A, "EMEA", B:B)` from becoming Mixed
- **Parent context via `Option<FnKind>`**: Range disposition depends on whether it's inside an aggregate, lookup, or bare context
- **Case-insensitive `is_lookup_sheet`**: matches Excel's case-insensitive sheet name semantics
- **`UnsupportedFunction(name)` for all unsupported functions**: FILTER/RAND get the same variant as OFFSET — simpler, and the function name in the message is more useful than a category label

## Test plan

- [x] `make check` passes (fmt, clippy -D warnings, all tests, doc-tests)
- [x] 112 total tests for xlstream-parse (31 unit + 53 integration + 28 doc-tests)
- [x] 35 new classification integration tests across 6 files
- [x] Review: disposition folding rules match streaming-model.md
- [x] Review: `fold_fn_args` correctly absorbs RowLocal but propagates Unsupported
- [x] Review: streaming-sheet rule applies to lookup but not aggregate