### PR TITLE
xlstream-parse: add AST rewrite with PreludeRef/PreludeKey (phase 2 chunk 4)

### DIFF
--- a/crates/xlstream-parse/src/ast.rs
+++ b/crates/xlstream-parse/src/ast.rs
@@ -41,7 +41,10 @@ pub(crate) enum Node {
     /// Array constant `{1,2;3,4}`. `Vec` instead of `SmallVec` because
     /// inline `Node` storage would create a layout cycle.
     Array(Vec<Vec<Node>>),
-    // PreludeRef variant added in Chunk 4 (rewrite.rs).
+    /// A reference to a prelude-computed value (aggregate scalar or lookup
+    /// index). Inserted by [`crate::rewrite::rewrite`] after classification;
+    /// never produced by the parser.
+    PreludeRef(crate::rewrite::PreludeKey),
 }
 
 /// Parsed formula. Opaque by design — internals are crate-internal so we

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -347,7 +347,9 @@ pub fn classify(ast: &Ast, ctx: &ClassificationContext) -> Classification {
 
 fn disposition(node: &Node, ctx: &ClassificationContext, parent: Option<FnKind>) -> Disposition {
     match node {
-        Node::Literal(_) | Node::Text(_) | Node::Error(_) => Disposition::RowLocal,
+        Node::Literal(_) | Node::Text(_) | Node::Error(_) | Node::PreludeRef(_) => {
+            Disposition::RowLocal
+        }
         Node::Reference(r) => classify_reference(r, ctx, parent),
         Node::UnaryOp { expr, .. } => disposition(expr, ctx, parent),
         Node::BinaryOp { left, right, .. } => {

--- a/crates/xlstream-parse/src/lib.rs
+++ b/crates/xlstream-parse/src/lib.rs
@@ -24,9 +24,11 @@ mod ast;
 mod classify;
 mod parser;
 mod references;
+pub mod rewrite;
 pub mod sets;
 
 pub use ast::Ast;
 pub use classify::{classify, Classification, ClassificationContext, UnsupportedReason};
 pub use parser::parse;
 pub use references::{extract_references, Reference, References};
+pub use rewrite::{rewrite, AggKind, AggregateKey, LookupKey, LookupKind, PreludeKey};

--- a/crates/xlstream-parse/src/rewrite.rs
+++ b/crates/xlstream-parse/src/rewrite.rs
@@ -1,0 +1,349 @@
+//! AST rewrite: replace aggregate/lookup sub-expressions with
+//! [`PreludeRef`](crate::ast::Node::PreludeRef) nodes keyed by
+//! [`PreludeKey`].
+
+use crate::ast::{Ast, Node, NumLiteral};
+use crate::classify::{Classification, ClassificationContext};
+use crate::references::Reference;
+
+/// Which aggregate operation a prelude pass must compute.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::AggKind;
+/// let k = AggKind::Sum;
+/// assert_eq!(k, AggKind::Sum);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AggKind {
+    /// `SUM`
+    Sum,
+    /// `COUNT`
+    Count,
+    /// `COUNTA`
+    CountA,
+    /// `AVERAGE`
+    Average,
+    /// `MIN`
+    Min,
+    /// `MAX`
+    Max,
+    /// `PRODUCT`
+    Product,
+    /// `MEDIAN`
+    Median,
+}
+
+/// Which lookup strategy the prelude must prepare.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::LookupKind;
+/// let k = LookupKind::VLookup;
+/// assert_eq!(k, LookupKind::VLookup);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LookupKind {
+    /// `VLOOKUP`
+    VLookup,
+    /// `HLOOKUP`
+    HLookup,
+    /// `XLOOKUP`
+    XLookup,
+    /// `INDEX` + `MATCH` combo
+    IndexMatch,
+}
+
+/// Key identifying a single prelude-computed aggregate scalar.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::{AggKind, AggregateKey};
+/// let k = AggregateKey { kind: AggKind::Sum, sheet: None, column: 1 };
+/// assert_eq!(k.column, 1);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AggregateKey {
+    /// The aggregate function.
+    pub kind: AggKind,
+    /// Sheet name (`None` = current streaming sheet).
+    pub sheet: Option<String>,
+    /// 1-based column index.
+    pub column: u32,
+}
+
+/// Key identifying a prelude-loaded lookup index.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::{LookupKind, LookupKey};
+/// let k = LookupKey {
+///     kind: LookupKind::VLookup,
+///     sheet: "Region Info".into(),
+///     key_column: 1,
+///     value_column: 2,
+/// };
+/// assert_eq!(k.sheet, "Region Info");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LookupKey {
+    /// The lookup strategy.
+    pub kind: LookupKind,
+    /// Sheet name the lookup reads from.
+    pub sheet: String,
+    /// 1-based column used as the search key.
+    pub key_column: u32,
+    /// 1-based column from which the result value is returned.
+    pub value_column: u32,
+}
+
+/// Discriminant for prelude data: either an aggregate scalar or a lookup
+/// index.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::{AggKind, AggregateKey, PreludeKey};
+/// let pk = PreludeKey::Aggregate(AggregateKey {
+///     kind: AggKind::Sum,
+///     sheet: None,
+///     column: 1,
+/// });
+/// assert!(matches!(pk, PreludeKey::Aggregate(_)));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PreludeKey {
+    /// A prelude-computed aggregate scalar.
+    Aggregate(AggregateKey),
+    /// A prelude-loaded lookup index.
+    Lookup(LookupKey),
+}
+
+/// Rewrite an AST by replacing aggregate/lookup sub-expressions with
+/// [`Node::PreludeRef`] nodes.
+///
+/// Only rewrites formulas classified as `AggregateOnly`, `LookupOnly`, or
+/// `Mixed`. `RowLocal` and `Unsupported` pass through untouched.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::{classify, parse, rewrite, Classification, ClassificationContext};
+/// let ast = parse("SUM(A:A)").unwrap();
+/// let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+/// let verdict = classify(&ast, &ctx);
+/// let rewritten = rewrite(ast, &ctx, &verdict);
+/// assert!(format!("{rewritten:?}").contains("PreludeRef"));
+/// ```
+#[must_use]
+pub fn rewrite(ast: Ast, ctx: &ClassificationContext, verdict: &Classification) -> Ast {
+    match verdict {
+        Classification::Unsupported(_) | Classification::RowLocal => ast,
+        Classification::AggregateOnly | Classification::LookupOnly | Classification::Mixed => {
+            let new_root = rewrite_node(ast.root, ctx);
+            Ast { upstream: ast.upstream, root: new_root }
+        }
+    }
+}
+
+fn rewrite_node(node: Node, ctx: &ClassificationContext) -> Node {
+    match node {
+        Node::Function { ref name, ref args } => {
+            let upper = name.to_uppercase();
+            if crate::sets::is_aggregate(&upper) {
+                rewrite_aggregate(name, args, ctx)
+            } else if crate::sets::is_lookup(&upper) {
+                rewrite_lookup(name, args, ctx).unwrap_or_else(|| recurse_function(node, ctx))
+            } else {
+                recurse_function(node, ctx)
+            }
+        }
+        Node::BinaryOp { op, left, right } => Node::BinaryOp {
+            op,
+            left: Box::new(rewrite_node(*left, ctx)),
+            right: Box::new(rewrite_node(*right, ctx)),
+        },
+        Node::UnaryOp { op, expr } => {
+            Node::UnaryOp { op, expr: Box::new(rewrite_node(*expr, ctx)) }
+        }
+        Node::Array(rows) => Node::Array(
+            rows.into_iter()
+                .map(|row| row.into_iter().map(|n| rewrite_node(n, ctx)).collect())
+                .collect(),
+        ),
+        // Leaves pass through.
+        other @ (Node::Literal(_)
+        | Node::Text(_)
+        | Node::Error(_)
+        | Node::Reference(_)
+        | Node::PreludeRef(_)) => other,
+    }
+}
+
+fn recurse_function(node: Node, ctx: &ClassificationContext) -> Node {
+    match node {
+        Node::Function { name, args } => {
+            Node::Function { name, args: args.into_iter().map(|a| rewrite_node(a, ctx)).collect() }
+        }
+        other => other,
+    }
+}
+
+/// Try to extract an [`AggKind`] from a function name.
+fn agg_kind_for(name: &str) -> Option<AggKind> {
+    match name.to_uppercase().as_str() {
+        "SUM" | "SUMIF" | "SUMIFS" => Some(AggKind::Sum),
+        "COUNT" | "COUNTIF" | "COUNTIFS" => Some(AggKind::Count),
+        "COUNTA" => Some(AggKind::CountA),
+        "AVERAGE" | "AVERAGEIF" | "AVERAGEIFS" => Some(AggKind::Average),
+        "MIN" | "MINIFS" => Some(AggKind::Min),
+        "MAX" | "MAXIFS" => Some(AggKind::Max),
+        "PRODUCT" => Some(AggKind::Product),
+        "MEDIAN" => Some(AggKind::Median),
+        _ => None,
+    }
+}
+
+/// Try to build an [`AggregateKey`] from a single range reference node.
+fn aggregate_key_from_range(kind: AggKind, reference: &Reference) -> Option<AggregateKey> {
+    match reference {
+        Reference::Range { sheet, start_col: Some(sc), end_col: Some(ec), .. } if sc == ec => {
+            Some(AggregateKey { kind, sheet: sheet.clone(), column: *sc })
+        }
+        _ => None,
+    }
+}
+
+fn rewrite_aggregate(name: &str, args: &[Node], ctx: &ClassificationContext) -> Node {
+    let Some(kind) = agg_kind_for(name) else {
+        return recurse_function_owned(name, args, ctx);
+    };
+
+    // Single-arg whole-column: collapse the entire Function node.
+    if args.len() == 1 {
+        if let Some(key) = try_aggregate_key(kind, &args[0]) {
+            return Node::PreludeRef(PreludeKey::Aggregate(key));
+        }
+    }
+
+    // Multi-arg: keep Function node, replace range children with PreludeRef.
+    let new_args: Vec<Node> = args
+        .iter()
+        .map(|arg| {
+            if let Some(key) = try_aggregate_key(kind, arg) {
+                Node::PreludeRef(PreludeKey::Aggregate(key))
+            } else {
+                rewrite_node(arg.clone(), ctx)
+            }
+        })
+        .collect();
+    Node::Function { name: name.to_owned(), args: new_args }
+}
+
+fn try_aggregate_key(kind: AggKind, node: &Node) -> Option<AggregateKey> {
+    match node {
+        Node::Reference(r) => aggregate_key_from_range(kind, r),
+        _ => None,
+    }
+}
+
+fn recurse_function_owned(name: &str, args: &[Node], ctx: &ClassificationContext) -> Node {
+    Node::Function {
+        name: name.to_owned(),
+        args: args.iter().map(|a| rewrite_node(a.clone(), ctx)).collect(),
+    }
+}
+
+fn rewrite_lookup(name: &str, args: &[Node], ctx: &ClassificationContext) -> Option<Node> {
+    let upper = name.to_uppercase();
+    match upper.as_str() {
+        "VLOOKUP" => rewrite_vlookup(args, ctx),
+        "HLOOKUP" => rewrite_hlookup(args, ctx),
+        "XLOOKUP" => rewrite_xlookup(args, ctx),
+        _ => None,
+    }
+}
+
+/// `VLOOKUP(lookup_value, table_array, col_index_num, [range_lookup])`
+/// -- extract sheet + `key_column` from `table_array` (arg 1),
+/// `value_column` = `key_column` + `col_index_num` - 1 from arg 2.
+fn rewrite_vlookup(args: &[Node], _ctx: &ClassificationContext) -> Option<Node> {
+    if args.len() < 3 {
+        return None;
+    }
+    let (sheet, key_column, _end_col) = extract_range_info(&args[1])?;
+    let col_offset = extract_positive_u32(&args[2])?;
+    let value_column = key_column + col_offset - 1;
+    Some(Node::PreludeRef(PreludeKey::Lookup(LookupKey {
+        kind: LookupKind::VLookup,
+        sheet,
+        key_column,
+        value_column,
+    })))
+}
+
+/// `HLOOKUP(lookup_value, table_array, row_index_num, [range_lookup])`
+/// -- minimal handling: extract from range, use `row_index` as value offset.
+fn rewrite_hlookup(args: &[Node], _ctx: &ClassificationContext) -> Option<Node> {
+    if args.len() < 3 {
+        return None;
+    }
+    let (sheet, key_column, _end_col) = extract_range_info(&args[1])?;
+    let row_offset = extract_positive_u32(&args[2])?;
+    let value_column = key_column + row_offset - 1;
+    Some(Node::PreludeRef(PreludeKey::Lookup(LookupKey {
+        kind: LookupKind::HLookup,
+        sheet,
+        key_column,
+        value_column,
+    })))
+}
+
+/// `XLOOKUP(lookup_value, lookup_array, return_array, ...)`
+/// -- minimal: extract sheet + column from `lookup_array` (arg 1) and
+/// `return_array` (arg 2).
+fn rewrite_xlookup(args: &[Node], _ctx: &ClassificationContext) -> Option<Node> {
+    if args.len() < 3 {
+        return None;
+    }
+    let (sheet, key_column, _) = extract_range_info(&args[1])?;
+    let (_, value_column, _) = extract_range_info(&args[2])?;
+    Some(Node::PreludeRef(PreludeKey::Lookup(LookupKey {
+        kind: LookupKind::XLookup,
+        sheet,
+        key_column,
+        value_column,
+    })))
+}
+
+/// Extract `(sheet, start_col, end_col)` from a range reference node.
+fn extract_range_info(node: &Node) -> Option<(String, u32, u32)> {
+    match node {
+        Node::Reference(Reference::Range {
+            sheet, start_col: Some(sc), end_col: Some(ec), ..
+        }) => Some((sheet.clone().unwrap_or_default(), *sc, *ec)),
+        _ => None,
+    }
+}
+
+/// Extract a positive integer (>= 1) as `u32` from a numeric literal node.
+fn extract_positive_u32(node: &Node) -> Option<u32> {
+    match node {
+        Node::Literal(NumLiteral::Number(n)) => {
+            let rounded = n.round();
+            #[allow(clippy::float_cmp)]
+            if *n == rounded && rounded >= 1.0 && rounded <= f64::from(u32::MAX) {
+                // SAFETY: range-checked above — rounded is in [1.0, u32::MAX].
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                Some(rounded as u32)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}

--- a/crates/xlstream-parse/src/rewrite.rs
+++ b/crates/xlstream-parse/src/rewrite.rs
@@ -52,7 +52,7 @@ pub enum LookupKind {
     HLookup,
     /// `XLOOKUP`
     XLookup,
-    /// `INDEX` + `MATCH` combo
+    /// `INDEX` + `MATCH` combo (reserved for Phase 8; not constructed today).
     IndexMatch,
 }
 
@@ -77,6 +77,9 @@ pub struct AggregateKey {
 
 /// Key identifying a prelude-loaded lookup index.
 ///
+/// `key_index` and `value_index` are 1-based. For `VLookup`/`XLookup`
+/// they are column indices; for `HLookup` they are row indices.
+///
 /// # Examples
 ///
 /// ```
@@ -84,8 +87,8 @@ pub struct AggregateKey {
 /// let k = LookupKey {
 ///     kind: LookupKind::VLookup,
 ///     sheet: "Region Info".into(),
-///     key_column: 1,
-///     value_column: 2,
+///     key_index: 1,
+///     value_index: 2,
 /// };
 /// assert_eq!(k.sheet, "Region Info");
 /// ```
@@ -95,10 +98,10 @@ pub struct LookupKey {
     pub kind: LookupKind,
     /// Sheet name the lookup reads from.
     pub sheet: String,
-    /// 1-based column used as the search key.
-    pub key_column: u32,
-    /// 1-based column from which the result value is returned.
-    pub value_column: u32,
+    /// 1-based index of the search key (column for VLOOKUP, row for HLOOKUP).
+    pub key_index: u32,
+    /// 1-based index of the return value (column for VLOOKUP, row for HLOOKUP).
+    pub value_index: u32,
 }
 
 /// Discriminant for prelude data: either an aggregate scalar or a lookup
@@ -194,14 +197,19 @@ fn recurse_function(node: Node, ctx: &ClassificationContext) -> Node {
 }
 
 /// Try to extract an [`AggKind`] from a function name.
+///
+/// Conditional aggregates (SUMIF, COUNTIF, AVERAGEIF, *IFS) are
+/// excluded — they carry criteria the prelude can't discard. They fall
+/// through to `recurse_function_owned` and keep their Function node
+/// intact. Phase 7 handles them with per-criteria groupby tables.
 fn agg_kind_for(name: &str) -> Option<AggKind> {
     match name.to_uppercase().as_str() {
-        "SUM" | "SUMIF" | "SUMIFS" => Some(AggKind::Sum),
-        "COUNT" | "COUNTIF" | "COUNTIFS" => Some(AggKind::Count),
+        "SUM" => Some(AggKind::Sum),
+        "COUNT" => Some(AggKind::Count),
         "COUNTA" => Some(AggKind::CountA),
-        "AVERAGE" | "AVERAGEIF" | "AVERAGEIFS" => Some(AggKind::Average),
-        "MIN" | "MINIFS" => Some(AggKind::Min),
-        "MAX" | "MAXIFS" => Some(AggKind::Max),
+        "AVERAGE" => Some(AggKind::Average),
+        "MIN" => Some(AggKind::Min),
+        "MAX" => Some(AggKind::Max),
         "PRODUCT" => Some(AggKind::Product),
         "MEDIAN" => Some(AggKind::Median),
         _ => None,
@@ -281,8 +289,8 @@ fn rewrite_vlookup(args: &[Node], _ctx: &ClassificationContext) -> Option<Node> 
     Some(Node::PreludeRef(PreludeKey::Lookup(LookupKey {
         kind: LookupKind::VLookup,
         sheet,
-        key_column,
-        value_column,
+        key_index: key_column,
+        value_index: value_column,
     })))
 }
 
@@ -298,8 +306,8 @@ fn rewrite_hlookup(args: &[Node], _ctx: &ClassificationContext) -> Option<Node> 
     Some(Node::PreludeRef(PreludeKey::Lookup(LookupKey {
         kind: LookupKind::HLookup,
         sheet,
-        key_column,
-        value_column,
+        key_index: key_column,
+        value_index: value_column,
     })))
 }
 
@@ -315,8 +323,8 @@ fn rewrite_xlookup(args: &[Node], _ctx: &ClassificationContext) -> Option<Node> 
     Some(Node::PreludeRef(PreludeKey::Lookup(LookupKey {
         kind: LookupKind::XLookup,
         sheet,
-        key_column,
-        value_column,
+        key_index: key_column,
+        value_index: value_column,
     })))
 }
 

--- a/crates/xlstream-parse/tests/rewrite.rs
+++ b/crates/xlstream-parse/tests/rewrite.rs
@@ -135,16 +135,16 @@ fn nested_aggregates_both_collapse() {
 }
 
 #[test]
-fn vlookup_key_and_value_columns_are_correct() {
+fn vlookup_key_and_value_indices_are_correct() {
     // VLOOKUP(A2, 'Lookup'!A:D, 3, FALSE)
-    // key_column = 1 (A), value_column = 1 + 3 - 1 = 3
+    // key_index = 1 (A), value_index = 1 + 3 - 1 = 3
     let ast = parse("VLOOKUP(A2, 'Lookup'!A:D, 3, FALSE)").unwrap();
     let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Lookup");
     let verdict = classify(&ast, &ctx);
     let rewritten = rewrite(ast, &ctx, &verdict);
     let dbg = root_dbg(&rewritten);
-    assert!(dbg.contains("key_column: 1"), "expected key_column 1: {dbg}");
-    assert!(dbg.contains("value_column: 3"), "expected value_column 3: {dbg}");
+    assert!(dbg.contains("key_index: 1"), "expected key_index 1: {dbg}");
+    assert!(dbg.contains("value_index: 3"), "expected value_index 3: {dbg}");
 }
 
 #[test]
@@ -159,14 +159,14 @@ fn prelude_key_lookup_equality() {
     let a = PreludeKey::Lookup(LookupKey {
         kind: LookupKind::VLookup,
         sheet: "S".into(),
-        key_column: 1,
-        value_column: 2,
+        key_index: 1,
+        value_index: 2,
     });
     let b = PreludeKey::Lookup(LookupKey {
         kind: LookupKind::VLookup,
         sheet: "S".into(),
-        key_column: 1,
-        value_column: 2,
+        key_index: 1,
+        value_index: 2,
     });
     assert_eq!(a, b);
 }

--- a/crates/xlstream-parse/tests/rewrite.rs
+++ b/crates/xlstream-parse/tests/rewrite.rs
@@ -1,0 +1,172 @@
+//! Integration tests: AST rewrite golden tests.
+
+use xlstream_parse::{
+    classify, parse, rewrite, AggKind, AggregateKey, Classification, ClassificationContext,
+    LookupKey, LookupKind, PreludeKey,
+};
+
+/// Extract the `root: ...` portion of the `Ast` debug output, which is the
+/// rewritten mirror tree. The `upstream` field retains the original parse
+/// tree and must be ignored in rewrite assertions.
+fn root_dbg(ast: &xlstream_parse::Ast) -> String {
+    let full = format!("{ast:?}");
+    // Find "root: " and take everything after it (minus the trailing " }").
+    if let Some(idx) = full.find("root: ") {
+        let tail = &full[idx..];
+        // Strip outer trailing " }"
+        tail.strip_suffix(" }").unwrap_or(tail).to_owned()
+    } else {
+        full
+    }
+}
+
+#[test]
+fn sum_whole_column_collapses_to_prelude_ref() {
+    let ast = parse("SUM(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("PreludeRef"), "expected PreludeRef: {dbg}");
+    assert!(dbg.contains("Sum"), "expected Sum: {dbg}");
+    assert!(!dbg.contains("Function"), "expected no Function node in root: {dbg}");
+}
+
+#[test]
+fn deal_value_over_sum_collapses_only_the_aggregate() {
+    // A2/SUM(A:A) — BinaryOp preserved, inner becomes PreludeRef, Cell ref preserved.
+    let ast = parse("A2/SUM(A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    assert_eq!(verdict, Classification::Mixed);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("BinaryOp"), "expected BinaryOp: {dbg}");
+    assert!(dbg.contains("PreludeRef"), "expected PreludeRef: {dbg}");
+    assert!(dbg.contains("Cell"), "expected Cell ref: {dbg}");
+}
+
+#[test]
+fn unsupported_classifications_pass_through_untouched() {
+    let ast = parse("OFFSET(A1, 1, 0)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    assert!(matches!(verdict, Classification::Unsupported(_)));
+    let original_dbg = format!("{ast:?}");
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let rewritten_dbg = format!("{rewritten:?}");
+    assert_eq!(original_dbg, rewritten_dbg);
+}
+
+#[test]
+fn row_local_classifications_pass_through_untouched() {
+    let ast = parse("1+2").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    assert_eq!(verdict, Classification::RowLocal);
+    let original_dbg = format!("{ast:?}");
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let rewritten_dbg = format!("{rewritten:?}");
+    assert_eq!(original_dbg, rewritten_dbg);
+}
+
+#[test]
+fn vlookup_collapses_to_prelude_lookup() {
+    let ast = parse("VLOOKUP(A2, 'Region Info'!A:C, 2, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Region Info");
+    let verdict = classify(&ast, &ctx);
+    assert_eq!(verdict, Classification::LookupOnly);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("PreludeRef"), "expected PreludeRef: {dbg}");
+    assert!(dbg.contains("Lookup"), "expected Lookup variant: {dbg}");
+    assert!(dbg.contains("Region Info"), "expected sheet name: {dbg}");
+    assert!(dbg.contains("VLookup"), "expected VLookup kind: {dbg}");
+}
+
+#[test]
+fn multi_arg_aggregate_rewrites_only_range_children() {
+    // SUM(1, 2, A:A) — Function node preserved, PreludeRef for the range,
+    // literals preserved as-is.
+    let ast = parse("SUM(1, 2, A:A)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("Function"), "expected Function preserved: {dbg}");
+    assert!(dbg.contains("PreludeRef"), "expected PreludeRef for range: {dbg}");
+    assert!(dbg.contains("Number(1.0)"), "expected literal 1: {dbg}");
+    assert!(dbg.contains("Number(2.0)"), "expected literal 2: {dbg}");
+}
+
+#[test]
+fn count_whole_column_collapses_to_count_prelude_ref() {
+    let ast = parse("COUNT(B:B)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("PreludeRef"), "expected PreludeRef: {dbg}");
+    assert!(dbg.contains("Count"), "expected Count kind: {dbg}");
+}
+
+#[test]
+fn average_whole_column_collapses_to_average_prelude_ref() {
+    let ast = parse("AVERAGE(C:C)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("PreludeRef"), "expected PreludeRef: {dbg}");
+    assert!(dbg.contains("Average"), "expected Average kind: {dbg}");
+}
+
+#[test]
+fn nested_aggregates_both_collapse() {
+    let ast = parse("SUM(A:A)+COUNT(B:B)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+    let verdict = classify(&ast, &ctx);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("BinaryOp"), "expected BinaryOp: {dbg}");
+    assert!(dbg.contains("Sum"), "expected Sum: {dbg}");
+    assert!(dbg.contains("Count"), "expected Count: {dbg}");
+    assert!(!dbg.contains("Function"), "expected no Function nodes in root: {dbg}");
+}
+
+#[test]
+fn vlookup_key_and_value_columns_are_correct() {
+    // VLOOKUP(A2, 'Lookup'!A:D, 3, FALSE)
+    // key_column = 1 (A), value_column = 1 + 3 - 1 = 3
+    let ast = parse("VLOOKUP(A2, 'Lookup'!A:D, 3, FALSE)").unwrap();
+    let ctx = ClassificationContext::for_cell("Sheet1", 2, 5).with_lookup_sheet("Lookup");
+    let verdict = classify(&ast, &ctx);
+    let rewritten = rewrite(ast, &ctx, &verdict);
+    let dbg = root_dbg(&rewritten);
+    assert!(dbg.contains("key_column: 1"), "expected key_column 1: {dbg}");
+    assert!(dbg.contains("value_column: 3"), "expected value_column 3: {dbg}");
+}
+
+#[test]
+fn prelude_key_aggregate_equality() {
+    let a = PreludeKey::Aggregate(AggregateKey { kind: AggKind::Sum, sheet: None, column: 1 });
+    let b = PreludeKey::Aggregate(AggregateKey { kind: AggKind::Sum, sheet: None, column: 1 });
+    assert_eq!(a, b);
+}
+
+#[test]
+fn prelude_key_lookup_equality() {
+    let a = PreludeKey::Lookup(LookupKey {
+        kind: LookupKind::VLookup,
+        sheet: "S".into(),
+        key_column: 1,
+        value_column: 2,
+    });
+    let b = PreludeKey::Lookup(LookupKey {
+        kind: LookupKind::VLookup,
+        sheet: "S".into(),
+        key_column: 1,
+        value_column: 2,
+    });
+    assert_eq!(a, b);
+}

--- a/docs/phases/phase-02-parser.md
+++ b/docs/phases/phase-02-parser.md
@@ -47,10 +47,10 @@
 
 ### AST rewrite
 
-- [ ] After classification, rewrite the AST to replace supported aggregate/lookup sub-expressions with `PreludeRef(key)` nodes.
-- [ ] Add `AstNode::PreludeRef(PreludeKey)` variant.
-- [ ] `PreludeKey` encodes aggregate vs lookup plus parameters.
-- [ ] Rewriting is a pure function; golden tests for input → rewritten AST.
+- [x] After classification, rewrite the AST to replace supported aggregate/lookup sub-expressions with `PreludeRef(key)` nodes.
+- [x] Add `AstNode::PreludeRef(PreludeKey)` variant.
+- [x] `PreludeKey` encodes aggregate vs lookup plus parameters.
+- [x] Rewriting is a pure function; golden tests for input → rewritten AST.
 
 ### Tests
 
@@ -70,7 +70,7 @@
   - [x] `MyNamedRange` — Unsupported (named range).
   - [x] `[Book2.xlsx]Sheet1!A1` — Unsupported (external reference).
 - [x] Reference-extraction tests for each variant.
-- [ ] AST rewrite golden tests.
+- [x] AST rewrite golden tests.
 
 ### Error messages
 


### PR DESCRIPTION
## Summary

- Add `Node::PreludeRef(PreludeKey)` variant to the mirror AST tree
- Define `AggregateKey` (8 aggregate kinds), `LookupKey` (4 lookup kinds), `PreludeKey` enum
- Implement `rewrite(ast, ctx, verdict)` — pure function that substitutes supported aggregate/lookup sub-expressions with PreludeRef nodes
- Single-column aggregate functions collapse entirely to PreludeRef; multi-arg keep Function node but replace range children
- VLOOKUP/HLOOKUP/XLOOKUP collapse to PreludeRef::Lookup with sheet/key_column/value_column
- Unsupported/RowLocal classifications pass through untouched
- 12 golden integration tests + 6 doctests

## Design decisions

- **Q2 dispatch**: single-range aggregate (SUM(A:A)) → bare PreludeRef; multi-arg (SUM(1, 2, A:A)) → Function with PreludeRef children
- **Tuple-wrap-struct per Q5**: `PreludeKey::Aggregate(AggregateKey)` / `PreludeKey::Lookup(LookupKey)`
- **`ASTNode::fingerprint()`** (upstream parser.rs:1511) is the intended cache key for per-formula rewritten-AST cache in Phase 4 — not implemented here, called out for Phase 4
- **SUMIF/COUNTIF/*IFS**: not collapsed (conditional aggregates need groupby tables, out of scope for Phase 2 rewrite)

## Test plan

- [x] `make check` passes (fmt, clippy -D warnings, all tests, doc-tests)
- [x] 136 total tests for xlstream-parse
- [x] 12 new rewrite golden tests
- [x] Review: PreludeRef handled as leaf in all match arms
- [x] Review: rewrite is a pure function (no side effects)
- [x] Review: Unsupported/RowLocal correctly pass through