### PR TITLE
xlstream-cli: add classify subcommand for single-formula inspection (phase 2 chunk 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,7 @@ dependencies = [
  "xlstream-core",
  "xlstream-eval",
  "xlstream-io",
+ "xlstream-parse",
 ]
 
 [[package]]

--- a/crates/xlstream-cli/Cargo.toml
+++ b/crates/xlstream-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 [dependencies]
 xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
 xlstream-eval = { path = "../xlstream-eval", version = "0.1.0" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.1.0" }
 xlstream-io = { path = "../xlstream-io", version = "0.1.0" }
 clap.workspace = true
 tracing.workspace = true
@@ -27,3 +28,4 @@ tracing-subscriber.workspace = true
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
+cargo_common_metadata = "allow"

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -1,8 +1,4 @@
-//! xlstream development CLI. Phase 1 exposes a single `evaluate` subcommand
-//! that wires through to [`xlstream_eval::evaluate`] — which is itself a
-//! stub, so this binary currently exits with an `Internal("unimplemented
-//! ...")` error. Useful only to verify that `--help` works and the argument
-//! surface is correct.
+//! xlstream development CLI.
 
 #![warn(missing_docs, rust_2018_idioms, clippy::pedantic, clippy::cargo)]
 #![deny(
@@ -48,18 +44,40 @@ enum Command {
         #[arg(long, short = 'v')]
         verbose: bool,
     },
+    /// Parse and classify a single Excel formula expression.
+    Classify {
+        /// The formula text (without leading `=`).
+        formula: String,
+        /// Sheet name to use as the streaming sheet.
+        #[arg(long, default_value = "Sheet1")]
+        sheet: String,
+        /// 1-based row to use as the formula's anchor.
+        #[arg(long, default_value_t = 1)]
+        row: u32,
+        /// 1-based column to use as the formula's anchor.
+        #[arg(long, default_value_t = 1)]
+        col: u32,
+        /// Register a sheet as a prelude-loaded lookup sheet (repeatable).
+        #[arg(long = "lookup-sheet", value_name = "SHEET")]
+        lookup_sheets: Vec<String>,
+        /// Increase log verbosity.
+        #[arg(long, short = 'v')]
+        verbose: bool,
+    },
 }
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let filter = match &cli.command {
-        Command::Evaluate { verbose: true, .. } => "debug",
-        Command::Evaluate { verbose: false, .. } => "info",
+    let verbose = match &cli.command {
+        Command::Evaluate { verbose, .. } | Command::Classify { verbose, .. } => *verbose,
     };
 
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_new(filter).unwrap_or_else(|_| EnvFilter::new("info")))
+        .with_env_filter(
+            EnvFilter::try_new(if verbose { "debug" } else { "info" })
+                .unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .with_target(false)
         .init();
 
@@ -78,7 +96,51 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
             let _summary = xlstream_eval::evaluate(&input, &output, workers)?;
             Ok(())
         }
+        Command::Classify { formula, sheet, row, col, lookup_sheets, .. } => {
+            run_classify(&formula, &sheet, row, col, &lookup_sheets)
+        }
     }
+}
+
+#[allow(clippy::print_stdout)]
+fn run_classify(
+    formula: &str,
+    sheet: &str,
+    row: u32,
+    col: u32,
+    lookup_sheets: &[String],
+) -> Result<(), xlstream_core::XlStreamError> {
+    let ast = xlstream_parse::parse(formula).map_err(|e| match e {
+        xlstream_core::XlStreamError::FormulaParse { formula: f, message, position, .. } => {
+            xlstream_core::XlStreamError::FormulaParse {
+                address: format!("{sheet}!{}", col_to_a1(col, row)),
+                formula: f,
+                message,
+                position,
+            }
+        }
+        other => other,
+    })?;
+
+    let mut ctx = xlstream_parse::ClassificationContext::for_cell(sheet, row, col);
+    for s in lookup_sheets {
+        ctx = ctx.with_lookup_sheet(s);
+    }
+
+    let verdict = xlstream_parse::classify(&ast, &ctx);
+    println!("{formula}\t{verdict:?}");
+    Ok(())
+}
+
+fn col_to_a1(col: u32, row: u32) -> String {
+    let mut letters = String::new();
+    let mut c = col;
+    while c > 0 {
+        c -= 1;
+        letters.insert(0, (b'A' + u8::try_from(c % 26).unwrap_or(0)) as char);
+        c /= 26;
+    }
+    format!("{letters}{row}")
 }
 
 #[cfg(test)]
@@ -110,6 +172,48 @@ mod tests {
                 assert_eq!(workers, Some(4));
                 assert!(verbose);
             }
+            Command::Classify { .. } => panic!("expected Evaluate"),
         }
+    }
+
+    #[test]
+    fn classify_subcommand_parses_formula_arg_with_defaults() {
+        let cli = Cli::try_parse_from(["xlstream", "classify", "SUM(A:A)"]).unwrap();
+        match cli.command {
+            Command::Classify { formula, sheet, row, col, lookup_sheets, .. } => {
+                assert_eq!(formula, "SUM(A:A)");
+                assert_eq!(sheet, "Sheet1");
+                assert_eq!(row, 1);
+                assert_eq!(col, 1);
+                assert!(lookup_sheets.is_empty());
+            }
+            Command::Evaluate { .. } => panic!("expected Classify"),
+        }
+    }
+
+    #[test]
+    fn classify_subcommand_accepts_lookup_sheet_flag() {
+        let cli = Cli::try_parse_from([
+            "xlstream",
+            "classify",
+            "VLOOKUP(A1, 'Region Info'!A:C, 2, FALSE)",
+            "--lookup-sheet",
+            "Region Info",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Classify { lookup_sheets, .. } => {
+                assert_eq!(lookup_sheets, vec!["Region Info"]);
+            }
+            Command::Evaluate { .. } => panic!("expected Classify"),
+        }
+    }
+
+    #[test]
+    fn col_to_a1_converts_correctly() {
+        assert_eq!(col_to_a1(1, 1), "A1");
+        assert_eq!(col_to_a1(3, 5), "C5");
+        assert_eq!(col_to_a1(26, 1), "Z1");
+        assert_eq!(col_to_a1(27, 1), "AA1");
     }
 }

--- a/crates/xlstream-cli/tests/classify_smoke.rs
+++ b/crates/xlstream-cli/tests/classify_smoke.rs
@@ -1,0 +1,51 @@
+//! Smoke tests that run the compiled binary and check stdout.
+
+use std::process::Command;
+
+#[test]
+fn classify_smoke_aggregate_writes_to_stdout() {
+    let bin = env!("CARGO_BIN_EXE_xlstream");
+    let out = Command::new(bin).args(["classify", "SUM(A:A)"]).output().unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("AggregateOnly"), "expected AggregateOnly: {stdout}");
+}
+
+#[test]
+fn classify_smoke_unsupported_writes_to_stdout() {
+    let bin = env!("CARGO_BIN_EXE_xlstream");
+    let out = Command::new(bin).args(["classify", "OFFSET(A1, 1, 0)"]).output().unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Unsupported"), "expected Unsupported: {stdout}");
+}
+
+#[test]
+fn classify_smoke_lookup_with_registered_sheet() {
+    let bin = env!("CARGO_BIN_EXE_xlstream");
+    let out = Command::new(bin)
+        .args([
+            "classify",
+            "VLOOKUP(A2, 'Region Info'!A:C, 2, FALSE)",
+            "--row",
+            "2",
+            "--col",
+            "5",
+            "--lookup-sheet",
+            "Region Info",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("LookupOnly"), "expected LookupOnly: {stdout}");
+}
+
+#[test]
+fn classify_smoke_row_local_formula() {
+    let bin = env!("CARGO_BIN_EXE_xlstream");
+    let out = Command::new(bin).args(["classify", "1+2"]).output().unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("RowLocal"), "expected RowLocal: {stdout}");
+}

--- a/docs/phases/README.md
+++ b/docs/phases/README.md
@@ -1,6 +1,6 @@
 # Phases — roadmap
 
-> **Current phase: 2 — Parser integration.** See [`phase-02-parser.md`](phase-02-parser.md).
+> **Current phase: 3 — I/O layer.** See [`phase-03-io.md`](phase-03-io.md).
 
 ## How this works
 
@@ -57,7 +57,7 @@ Do NOT work multiple phases simultaneously. Do NOT skip checkboxes out of order 
 |---|---|---|---|
 | 0 | Foundation | [`phase-00-foundation.md`](phase-00-foundation.md) | ✓ complete |
 | 1 | Scaffolding | [`phase-01-scaffolding.md`](phase-01-scaffolding.md) | ✓ complete |
-| 2 | Parser integration | [`phase-02-parser.md`](phase-02-parser.md) | in progress |
+| 2 | Parser integration | [`phase-02-parser.md`](phase-02-parser.md) | ✓ complete |
 | 3 | I/O layer | [`phase-03-io.md`](phase-03-io.md) | not started |
 | 4 | Streaming core | [`phase-04-streaming-core.md`](phase-04-streaming-core.md) | not started |
 | 5 | Arithmetic, comparison, concat | [`phase-05-arithmetic.md`](phase-05-arithmetic.md) | not started |

--- a/docs/phases/phase-02-parser.md
+++ b/docs/phases/phase-02-parser.md
@@ -82,9 +82,7 @@
 
 ### CLI integration
 
-- [ ] `xlstream-cli classify "FORMULA"` parses and classifies a formula string passed as argument.
-- [ ] Useful smoke test for development: "what would xlstream do with this formula?"
-- [ ] File-level classification (`classify path.xlsx`) defers to Phase 3 when I/O is wired up.
+- [x] `xlstream-cli classify "<formula>"` parses + classifies a single formula string. Useful smoke test: "what would xlstream say about this expression?". File-level classification (`classify path.xlsx`) lands in Phase 3 with the I/O layer.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- Add `classify "<formula>"` subcommand to xlstream-cli
- Parses + classifies a single formula string, prints verdict to stdout
- Supports `--sheet`, `--row`, `--col` anchor overrides and repeatable `--lookup-sheet` flag
- No new crate dependencies beyond `xlstream-parse` (already in workspace)
- File-level classification (`classify path.xlsx`) defers to Phase 3 with `xlstream-io`
- Mark Phase 2 complete, promote Phase 3 in `docs/phases/README.md`

## Test plan

- [x] `make check` passes (fmt, clippy -D warnings, all tests, doc-tests)
- [x] 174 total workspace tests
- [x] 4 binary-exec smoke tests (aggregate, unsupported, lookup, row-local)
- [x] 4 unit tests (evaluate parse, classify parse, lookup-sheet flag, col_to_a1)
- [x] Review: `--lookup-sheet` correctly wired through to ClassificationContext
- [x] Review: error enrichment adds cell address per Q1 contract

## Phase 2 final status

All 6 chunks landed. Every checkbox in `docs/phases/phase-02-parser.md` is ticked.