### PR TITLE
xlstream-io: implement reader with streaming CellStream via calamine (phase 3 chunk 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,7 @@ version = "0.1.0"
 dependencies = [
  "calamine",
  "rust_xlsxwriter",
+ "tempfile",
  "xlstream-core",
 ]
 

--- a/crates/xlstream-io/Cargo.toml
+++ b/crates/xlstream-io/Cargo.toml
@@ -16,6 +16,12 @@ xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
 calamine.workspace = true
 rust_xlsxwriter.workspace = true
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
+# Readme metadata is set at workspace level; suppress for all targets
+# (the `#![allow]` in lib.rs only covers the lib target, not integration tests).
+cargo_common_metadata = "allow"

--- a/crates/xlstream-io/src/convert.rs
+++ b/crates/xlstream-io/src/convert.rs
@@ -4,7 +4,6 @@ use calamine::CellErrorType;
 use xlstream_core::{CellError, ExcelDate, Value};
 
 /// Convert a calamine [`DataRef`] to an xlstream [`Value`].
-#[allow(dead_code)]
 pub(crate) fn convert_data_ref(d: &calamine::DataRef<'_>) -> Value {
     use calamine::DataRef;
     match d {

--- a/crates/xlstream-io/src/reader.rs
+++ b/crates/xlstream-io/src/reader.rs
@@ -88,7 +88,8 @@ impl Reader {
     }
 
     /// Open a streaming cell reader for the named sheet. Cells are yielded
-    /// row-by-row via [`CellStream::next_row`].
+    /// row-by-row via [`CellStream::next_row`]. Each call opens a fresh
+    /// read from the start of the sheet.
     ///
     /// # Errors
     ///
@@ -113,8 +114,7 @@ impl Reader {
             .worksheet_cells_reader(sheet)
             .map_err(|e| XlStreamError::Xlsx(e.to_string()))?;
         let dims = cell_reader.dimensions();
-        // max_col is end col + 1 (dimensions are 0-based inclusive).
-        let max_col = (dims.end.1 as usize) + 1;
+        let capacity_hint = (dims.end.1 as usize) + 1;
 
         // Capture the cell reader in a closure. This erases the concrete
         // XlsxCellReader type (which calamine does not publicly export)
@@ -129,12 +129,13 @@ impl Reader {
             Err(e) => Err(XlStreamError::Xlsx(e.to_string())),
         });
 
-        Ok(CellStream::new(Box::new(source), max_col))
+        Ok(CellStream::new(Box::new(source), capacity_hint))
     }
 
     /// Collect all formula cells for the named sheet. Returns a vec of
     /// `(row, col, formula_text)` tuples. Only cells that contain a
-    /// non-empty formula are included.
+    /// non-empty formula are included. Each call opens a fresh read
+    /// from the start of the sheet.
     ///
     /// Formulas are typically sparse, so eagerly collecting them is
     /// acceptable for memory.

--- a/crates/xlstream-io/src/reader.rs
+++ b/crates/xlstream-io/src/reader.rs
@@ -1,26 +1,50 @@
-//! The [`Reader`] stub — calamine-backed xlsx reader. Real logic lands in
-//! Phase 3.
+//! The [`Reader`] — calamine-backed xlsx reader that yields streaming
+//! cell and formula iterators.
 
+use std::io::BufReader;
 use std::path::Path;
 
-use xlstream_core::XlStreamError;
+use calamine::Reader as _;
+use xlstream_core::{Value, XlStreamError};
 
-/// Streaming xlsx reader. Phase 1 ships a unit-struct stub; Phase 3 wires
-/// it to a [`calamine::Xlsx`] cell reader that yields `Vec<Value>` rows.
-///
-/// [`calamine::Xlsx`]: https://docs.rs/calamine
+use crate::convert::convert_data_ref;
+use crate::stream::{CellSource, CellStream};
+
+/// Streaming xlsx reader backed by [`calamine::Xlsx`]. Wraps the workbook
+/// and exposes sheet enumeration, cell streaming, and formula extraction.
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use std::path::Path;
 /// use xlstream_io::Reader;
-/// let err = Reader::open(Path::new("nope.xlsx")).unwrap_err();
-/// assert!(err.to_string().contains("unimplemented"));
+///
+/// let reader = Reader::open(Path::new("workbook.xlsx")).unwrap();
+/// let names = reader.sheet_names();
+/// assert!(!names.is_empty());
 /// ```
-#[derive(Debug)]
 pub struct Reader {
-    _private: (),
+    workbook: calamine::Xlsx<BufReader<std::fs::File>>,
+}
+
+impl std::fmt::Debug for Reader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Reader").finish_non_exhaustive()
+    }
+}
+
+/// A [`CellSource`] implementation backed by a closure. This allows us to
+/// erase calamine's `XlsxCellReader` type (which is not publicly re-exported)
+/// without naming it.
+struct ClosureCellSource<F>(F);
+
+impl<F> CellSource for ClosureCellSource<F>
+where
+    F: FnMut() -> Result<Option<(u32, u32, Value)>, XlStreamError>,
+{
+    fn next_cell(&mut self) -> Result<Option<(u32, u32, Value)>, XlStreamError> {
+        (self.0)()
+    }
 }
 
 impl Reader {
@@ -28,20 +52,130 @@ impl Reader {
     ///
     /// # Errors
     ///
-    /// Phase 1: always [`XlStreamError::Internal`]. Phase 3 onward: real
-    /// I/O errors surfaced as [`XlStreamError::Io`] /
-    /// `XlStreamError::Xlsx` (variant added in Phase 3).
+    /// Returns [`XlStreamError::Xlsx`] if calamine cannot parse the file
+    /// (corrupt archive, missing internal XML, etc.).
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use std::path::Path;
     /// use xlstream_io::Reader;
-    /// assert!(Reader::open(Path::new("x.xlsx")).is_err());
+    ///
+    /// let reader = Reader::open(Path::new("workbook.xlsx")).unwrap();
     /// ```
-    #[must_use = "opening a reader is useless without inspecting the result"]
-    pub fn open(_path: &Path) -> Result<Self, XlStreamError> {
-        Err(XlStreamError::Internal("unimplemented: Reader::open — lands in Phase 3".into()))
+    pub fn open(path: &Path) -> Result<Self, XlStreamError> {
+        let workbook = calamine::open_workbook::<calamine::Xlsx<BufReader<std::fs::File>>, _>(path)
+            .map_err(|e| XlStreamError::Xlsx(e.to_string()))?;
+        Ok(Self { workbook })
+    }
+
+    /// Return the names of all sheets in workbook order.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_io::Reader;
+    ///
+    /// let reader = Reader::open(Path::new("workbook.xlsx")).unwrap();
+    /// for name in reader.sheet_names() {
+    ///     println!("{name}");
+    /// }
+    /// ```
+    #[must_use]
+    pub fn sheet_names(&self) -> Vec<String> {
+        self.workbook.sheet_names().clone()
+    }
+
+    /// Open a streaming cell reader for the named sheet. Cells are yielded
+    /// row-by-row via [`CellStream::next_row`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XlStreamError::Xlsx`] if the sheet does not exist or
+    /// calamine encounters a parse error.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_io::Reader;
+    ///
+    /// let mut reader = Reader::open(Path::new("workbook.xlsx")).unwrap();
+    /// let mut stream = reader.cells("Sheet1").unwrap();
+    /// while let Some(row) = stream.next_row().unwrap() {
+    ///     println!("{row:?}");
+    /// }
+    /// ```
+    pub fn cells(&mut self, sheet: &str) -> Result<CellStream<'_>, XlStreamError> {
+        let mut cell_reader = self
+            .workbook
+            .worksheet_cells_reader(sheet)
+            .map_err(|e| XlStreamError::Xlsx(e.to_string()))?;
+        let dims = cell_reader.dimensions();
+        // max_col is end col + 1 (dimensions are 0-based inclusive).
+        let max_col = (dims.end.1 as usize) + 1;
+
+        // Capture the cell reader in a closure. This erases the concrete
+        // XlsxCellReader type (which calamine does not publicly export)
+        // behind the CellSource trait.
+        let source = ClosureCellSource(move || match cell_reader.next_cell() {
+            Ok(Some(cell)) => {
+                let (row, col) = cell.get_position();
+                let value = convert_data_ref(cell.get_value());
+                Ok(Some((row, col, value)))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(XlStreamError::Xlsx(e.to_string())),
+        });
+
+        Ok(CellStream::new(Box::new(source), max_col))
+    }
+
+    /// Collect all formula cells for the named sheet. Returns a vec of
+    /// `(row, col, formula_text)` tuples. Only cells that contain a
+    /// non-empty formula are included.
+    ///
+    /// Formulas are typically sparse, so eagerly collecting them is
+    /// acceptable for memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XlStreamError::Xlsx`] if the sheet does not exist or
+    /// calamine encounters a parse error.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_io::Reader;
+    ///
+    /// let mut reader = Reader::open(Path::new("workbook.xlsx")).unwrap();
+    /// let formulas = reader.formulas("Sheet1").unwrap();
+    /// for (row, col, text) in &formulas {
+    ///     println!("({row}, {col}): {text}");
+    /// }
+    /// ```
+    pub fn formulas(&mut self, sheet: &str) -> Result<Vec<(u32, u32, String)>, XlStreamError> {
+        let mut cell_reader = self
+            .workbook
+            .worksheet_cells_reader(sheet)
+            .map_err(|e| XlStreamError::Xlsx(e.to_string()))?;
+        let mut out = Vec::new();
+        loop {
+            match cell_reader.next_formula() {
+                Ok(Some(cell)) => {
+                    let (row, col) = cell.get_position();
+                    let text = cell.get_value().clone();
+                    if !text.is_empty() {
+                        out.push((row, col, text));
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => return Err(XlStreamError::Xlsx(e.to_string())),
+            }
+        }
+        Ok(out)
     }
 }
 
@@ -54,11 +188,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn open_returns_unimplemented_internal_error() {
+    fn open_nonexistent_file_returns_xlsx_error() {
         let err = Reader::open(Path::new("doesnt-exist.xlsx")).unwrap_err();
-        assert!(
-            matches!(err, xlstream_core::XlStreamError::Internal(ref msg) if msg.contains("unimplemented")),
-            "expected Internal(unimplemented...), got {err:?}",
-        );
+        assert!(matches!(err, XlStreamError::Xlsx(_)), "expected Xlsx error, got {err:?}",);
     }
 }

--- a/crates/xlstream-io/src/stream.rs
+++ b/crates/xlstream-io/src/stream.rs
@@ -12,8 +12,11 @@ pub(crate) trait CellSource {
 }
 
 /// Row-oriented stream of cells. Wraps a calamine `XlsxCellReader` and
-/// yields one dense `Vec<Value>` per row. Missing cells are padded with
-/// [`Value::Empty`] so every row has exactly `max_col` elements.
+/// yields `(row_index, Vec<Value>)` pairs. Missing cells within a row
+/// are padded with [`Value::Empty`]; rows with no data are skipped
+/// (callers use the row index to detect gaps).
+///
+/// Each call opens a fresh read from the start of the sheet.
 ///
 /// # Examples
 ///
@@ -31,7 +34,7 @@ pub struct CellStream<'a> {
 /// without a source.
 struct CellStreamInner<'a> {
     source: Box<dyn CellSource + 'a>,
-    max_col: usize,
+    initial_capacity: usize,
     buffer: Vec<Value>,
     pending_cell: Option<(u32, u32, Value)>,
     current_row: Option<u32>,
@@ -54,13 +57,15 @@ impl<'a> CellStream<'a> {
         Self { inner: None }
     }
 
-    /// Construct a stream backed by a cell source.
-    pub(crate) fn new(source: Box<dyn CellSource + 'a>, max_col: usize) -> Self {
+    /// Construct a stream backed by a cell source. `capacity_hint` is the
+    /// initial buffer size (typically from sheet dimensions); the buffer
+    /// grows on demand if cells exceed this.
+    pub(crate) fn new(source: Box<dyn CellSource + 'a>, capacity_hint: usize) -> Self {
         Self {
             inner: Some(CellStreamInner {
                 source,
-                max_col,
-                buffer: Vec::with_capacity(max_col),
+                initial_capacity: capacity_hint,
+                buffer: Vec::with_capacity(capacity_hint),
                 pending_cell: None,
                 current_row: None,
                 finished: false,
@@ -68,10 +73,13 @@ impl<'a> CellStream<'a> {
         }
     }
 
-    /// Yield the next row as a dense `Vec<Value>` (length == `max_col`),
-    /// or `Ok(None)` at end of sheet. Missing cells are [`Value::Empty`].
+    /// Yield the next row as `(row_index, values)` where `values` is a
+    /// dense `Vec<Value>` with missing cells padded as [`Value::Empty`].
+    /// Returns `Ok(None)` at end of sheet. Rows with no data are skipped;
+    /// use the row index to detect gaps.
     ///
-    /// Uses `std::mem::take` to hand off the buffer without cloning.
+    /// The buffer grows on demand if cells exist beyond the declared
+    /// sheet dimensions.
     ///
     /// # Errors
     ///
@@ -84,7 +92,7 @@ impl<'a> CellStream<'a> {
     /// let mut s = CellStream::empty();
     /// assert_eq!(s.next_row().unwrap(), None);
     /// ```
-    pub fn next_row(&mut self) -> Result<Option<Vec<Value>>, XlStreamError> {
+    pub fn next_row(&mut self) -> Result<Option<(u32, Vec<Value>)>, XlStreamError> {
         let Some(inner) = self.inner.as_mut() else {
             return Ok(None);
         };
@@ -93,22 +101,18 @@ impl<'a> CellStream<'a> {
 }
 
 impl CellStreamInner<'_> {
-    fn next_row(&mut self) -> Result<Option<Vec<Value>>, XlStreamError> {
+    fn next_row(&mut self) -> Result<Option<(u32, Vec<Value>)>, XlStreamError> {
         if self.finished {
             return Ok(None);
         }
 
-        // Prepare buffer for a new row.
         self.buffer.clear();
-        self.buffer.resize(self.max_col, Value::Empty);
+        self.buffer.resize(self.initial_capacity, Value::Empty);
         self.current_row = None;
 
-        // If we have a pending cell saved from the previous call, place it.
         if let Some((row, col, val)) = self.pending_cell.take() {
             self.current_row = Some(row);
-            if (col as usize) < self.max_col {
-                self.buffer[col as usize] = val;
-            }
+            self.place_cell(col, val);
         }
 
         loop {
@@ -117,29 +121,38 @@ impl CellStreamInner<'_> {
                     self.current_row = Some(row);
                 }
 
-                if row != self.current_row.unwrap_or(row) {
-                    // This cell belongs to the next row. Save it and
-                    // return the current buffer.
+                let Some(cr) = self.current_row else {
+                    return Err(XlStreamError::Internal(
+                        "current_row unexpectedly None after set".into(),
+                    ));
+                };
+
+                if row != cr {
                     self.pending_cell = Some((row, col, value));
-                    return Ok(Some(std::mem::take(&mut self.buffer)));
+                    let row_data = std::mem::take(&mut self.buffer);
+                    return Ok(Some((cr, row_data)));
                 }
 
-                if (col as usize) < self.max_col {
-                    self.buffer[col as usize] = value;
-                }
+                self.place_cell(col, value);
             } else {
                 self.finished = true;
-                return if self.current_row.is_some() {
-                    Ok(Some(std::mem::take(&mut self.buffer)))
-                } else {
-                    Ok(None)
+                return match self.current_row {
+                    Some(cr) => Ok(Some((cr, std::mem::take(&mut self.buffer)))),
+                    None => Ok(None),
                 };
             }
         }
     }
+
+    fn place_cell(&mut self, col: u32, value: Value) {
+        let idx = col as usize;
+        if idx >= self.buffer.len() {
+            self.buffer.resize(idx + 1, Value::Empty);
+        }
+        self.buffer[idx] = value;
+    }
 }
 
-// Implement Debug manually since the inner source is a trait object.
 impl std::fmt::Debug for CellStream<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CellStream").field("has_inner", &self.inner.is_some()).finish()

--- a/crates/xlstream-io/src/stream.rs
+++ b/crates/xlstream-io/src/stream.rs
@@ -1,58 +1,148 @@
-//! The [`CellStream`] stub — row-oriented iterator over an xlsx sheet. Real
-//! logic lands in Phase 3.
+//! The [`CellStream`] — row-oriented iterator over an xlsx sheet backed
+//! by calamine's `XlsxCellReader`.
 
 use xlstream_core::{Value, XlStreamError};
 
-/// Row-oriented stream of cells. Phase 1 ships a stub `empty()`
-/// constructor and a `next_row` that always errors; Phase 3 wires it to
-/// a calamine cell reader.
+/// Internal trait for abstracting over calamine's cell reader (whose
+/// concrete type is not re-exported). Implemented in `reader.rs` via a
+/// wrapper that owns the `XlsxCellReader`.
+pub(crate) trait CellSource {
+    /// Return the next cell as `(row, col, value)`, or `None` at EOF.
+    fn next_cell(&mut self) -> Result<Option<(u32, u32, Value)>, XlStreamError>;
+}
+
+/// Row-oriented stream of cells. Wraps a calamine `XlsxCellReader` and
+/// yields one dense `Vec<Value>` per row. Missing cells are padded with
+/// [`Value::Empty`] so every row has exactly `max_col` elements.
 ///
 /// # Examples
 ///
 /// ```
 /// use xlstream_io::CellStream;
+///
 /// let mut s = CellStream::empty();
-/// assert!(s.next_row().is_err());
+/// assert_eq!(s.next_row().unwrap(), None);
 /// ```
-#[derive(Debug)]
-pub struct CellStream {
-    _private: (),
+pub struct CellStream<'a> {
+    inner: Option<CellStreamInner<'a>>,
 }
 
-impl CellStream {
-    /// Construct an empty stream. Useful only as a placeholder until Phase 3
-    /// gives readers a real constructor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use xlstream_io::CellStream;
-    /// let _s = CellStream::empty();
-    /// ```
-    #[must_use]
-    pub fn empty() -> Self {
-        Self { _private: () }
-    }
+/// Actual streaming state — separated so `CellStream::empty()` can exist
+/// without a source.
+struct CellStreamInner<'a> {
+    source: Box<dyn CellSource + 'a>,
+    max_col: usize,
+    buffer: Vec<Value>,
+    pending_cell: Option<(u32, u32, Value)>,
+    current_row: Option<u32>,
+    finished: bool,
+}
 
-    /// Yield the next row, or `Ok(None)` at end of sheet.
-    ///
-    /// # Errors
-    ///
-    /// Phase 1: always [`XlStreamError::Internal`]. Phase 3 onward: I/O or
-    /// parse failures encountered while advancing the underlying reader.
+impl<'a> CellStream<'a> {
+    /// Construct an empty stream that immediately returns `Ok(None)`.
+    /// Useful as a placeholder or in tests.
     ///
     /// # Examples
     ///
     /// ```
     /// use xlstream_io::CellStream;
     /// let mut s = CellStream::empty();
-    /// assert!(s.next_row().is_err());
+    /// assert_eq!(s.next_row().unwrap(), None);
     /// ```
-    #[must_use = "advancing the stream is useless without inspecting the result"]
+    #[must_use]
+    pub fn empty() -> Self {
+        Self { inner: None }
+    }
+
+    /// Construct a stream backed by a cell source.
+    pub(crate) fn new(source: Box<dyn CellSource + 'a>, max_col: usize) -> Self {
+        Self {
+            inner: Some(CellStreamInner {
+                source,
+                max_col,
+                buffer: Vec::with_capacity(max_col),
+                pending_cell: None,
+                current_row: None,
+                finished: false,
+            }),
+        }
+    }
+
+    /// Yield the next row as a dense `Vec<Value>` (length == `max_col`),
+    /// or `Ok(None)` at end of sheet. Missing cells are [`Value::Empty`].
+    ///
+    /// Uses `std::mem::take` to hand off the buffer without cloning.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XlStreamError::Xlsx`] on calamine I/O or parse failures.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_io::CellStream;
+    /// let mut s = CellStream::empty();
+    /// assert_eq!(s.next_row().unwrap(), None);
+    /// ```
     pub fn next_row(&mut self) -> Result<Option<Vec<Value>>, XlStreamError> {
-        Err(XlStreamError::Internal(
-            "unimplemented: CellStream::next_row — lands in Phase 3".into(),
-        ))
+        let Some(inner) = self.inner.as_mut() else {
+            return Ok(None);
+        };
+        inner.next_row()
+    }
+}
+
+impl CellStreamInner<'_> {
+    fn next_row(&mut self) -> Result<Option<Vec<Value>>, XlStreamError> {
+        if self.finished {
+            return Ok(None);
+        }
+
+        // Prepare buffer for a new row.
+        self.buffer.clear();
+        self.buffer.resize(self.max_col, Value::Empty);
+        self.current_row = None;
+
+        // If we have a pending cell saved from the previous call, place it.
+        if let Some((row, col, val)) = self.pending_cell.take() {
+            self.current_row = Some(row);
+            if (col as usize) < self.max_col {
+                self.buffer[col as usize] = val;
+            }
+        }
+
+        loop {
+            if let Some((row, col, value)) = self.source.next_cell()? {
+                if self.current_row.is_none() {
+                    self.current_row = Some(row);
+                }
+
+                if row != self.current_row.unwrap_or(row) {
+                    // This cell belongs to the next row. Save it and
+                    // return the current buffer.
+                    self.pending_cell = Some((row, col, value));
+                    return Ok(Some(std::mem::take(&mut self.buffer)));
+                }
+
+                if (col as usize) < self.max_col {
+                    self.buffer[col as usize] = value;
+                }
+            } else {
+                self.finished = true;
+                return if self.current_row.is_some() {
+                    Ok(Some(std::mem::take(&mut self.buffer)))
+                } else {
+                    Ok(None)
+                };
+            }
+        }
+    }
+}
+
+// Implement Debug manually since the inner source is a trait object.
+impl std::fmt::Debug for CellStream<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CellStream").field("has_inner", &self.inner.is_some()).finish()
     }
 }
 
@@ -63,12 +153,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn next_row_returns_unimplemented_internal_error() {
+    fn empty_stream_returns_none() {
         let mut s = CellStream::empty();
-        let err = s.next_row().unwrap_err();
-        assert!(
-            matches!(err, xlstream_core::XlStreamError::Internal(ref msg) if msg.contains("unimplemented")),
-            "expected Internal(unimplemented...), got {err:?}",
-        );
+        assert_eq!(s.next_row().unwrap(), None);
+    }
+
+    #[test]
+    fn empty_stream_debug_output() {
+        let s = CellStream::empty();
+        let dbg = format!("{s:?}");
+        assert!(dbg.contains("CellStream"), "expected CellStream in debug: {dbg}");
     }
 }

--- a/crates/xlstream-io/tests/helpers/mod.rs
+++ b/crates/xlstream-io/tests/helpers/mod.rs
@@ -1,0 +1,83 @@
+//! Shared fixture generators for xlstream-io integration tests.
+//! Each function writes a minimal xlsx via `rust_xlsxwriter` and returns
+//! a `NamedTempFile` whose path can be passed to `Reader::open`.
+
+use rust_xlsxwriter::{Formula, Workbook};
+use tempfile::NamedTempFile;
+
+/// 2 rows x 3 cols: numbers, strings, booleans.
+///
+/// | A     | B       | C    |
+/// |-------|---------|------|
+/// | 1.0   | "hello" | true |
+/// | 2.0   | "world" | false|
+pub fn generate_simple_fixture() -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    ws.write_number(0, 0, 1.0).unwrap();
+    ws.write_string(0, 1, "hello").unwrap();
+    ws.write_boolean(0, 2, true).unwrap();
+
+    ws.write_number(1, 0, 2.0).unwrap();
+    ws.write_string(1, 1, "world").unwrap();
+    ws.write_boolean(1, 2, false).unwrap();
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}
+
+/// Row with gap: A1=1, C1=3 (B1 missing).
+///
+/// | A   | B     | C   |
+/// |-----|-------|-----|
+/// | 1.0 | empty | 3.0 |
+pub fn generate_sparse_fixture() -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    ws.write_number(0, 0, 1.0).unwrap();
+    // skip B1
+    ws.write_number(0, 2, 3.0).unwrap();
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}
+
+/// Row with formula: A1=1, B1=2, C1=formula "=A1+B1" with cached result "3".
+///
+/// | A   | B   | C        |
+/// |-----|-----|----------|
+/// | 1.0 | 2.0 | =A1+B1  |
+pub fn generate_formula_fixture() -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    ws.write_number(0, 0, 1.0).unwrap();
+    ws.write_number(0, 1, 2.0).unwrap();
+    ws.write_formula(0, 2, Formula::new("=A1+B1").set_result("3")).unwrap();
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}
+
+/// Multi-sheet workbook with sheets named "Alpha" and "Beta".
+/// Alpha: A1=10, Beta: A1=20.
+pub fn generate_multi_sheet_fixture() -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+
+    let ws1 = wb.add_worksheet();
+    ws1.set_name("Alpha").unwrap();
+    ws1.write_number(0, 0, 10.0).unwrap();
+
+    let ws2 = wb.add_worksheet();
+    ws2.set_name("Beta").unwrap();
+    ws2.write_number(0, 0, 20.0).unwrap();
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}

--- a/crates/xlstream-io/tests/reader.rs
+++ b/crates/xlstream-io/tests/reader.rs
@@ -1,0 +1,117 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod helpers;
+
+use xlstream_core::Value;
+use xlstream_io::Reader;
+
+#[test]
+fn open_reads_sheet_names() {
+    let tmp = helpers::generate_multi_sheet_fixture();
+    let reader = Reader::open(tmp.path()).unwrap();
+    let names = reader.sheet_names();
+    assert_eq!(names, vec!["Alpha".to_string(), "Beta".to_string()]);
+}
+
+#[test]
+fn cells_yields_dense_rows() {
+    let tmp = helpers::generate_simple_fixture();
+    let mut reader = Reader::open(tmp.path()).unwrap();
+    let mut stream = reader.cells("Sheet1").unwrap();
+
+    let row0 = stream.next_row().unwrap().expect("expected row 0");
+    assert_eq!(row0.len(), 3);
+    assert_eq!(row0[0], Value::Number(1.0));
+    assert_eq!(row0[1], Value::Text("hello".into()));
+    assert_eq!(row0[2], Value::Bool(true));
+
+    let row1 = stream.next_row().unwrap().expect("expected row 1");
+    assert_eq!(row1.len(), 3);
+    assert_eq!(row1[0], Value::Number(2.0));
+    assert_eq!(row1[1], Value::Text("world".into()));
+    assert_eq!(row1[2], Value::Bool(false));
+
+    assert!(stream.next_row().unwrap().is_none(), "expected EOF");
+}
+
+#[test]
+fn cells_pads_missing_cells_with_empty() {
+    let tmp = helpers::generate_sparse_fixture();
+    let mut reader = Reader::open(tmp.path()).unwrap();
+    let mut stream = reader.cells("Sheet1").unwrap();
+
+    let row = stream.next_row().unwrap().expect("expected row 0");
+    assert_eq!(row.len(), 3);
+    assert_eq!(row[0], Value::Number(1.0));
+    assert_eq!(row[1], Value::Empty);
+    assert_eq!(row[2], Value::Number(3.0));
+}
+
+#[test]
+fn cells_returns_none_after_last_row() {
+    let tmp = helpers::generate_simple_fixture();
+    let mut reader = Reader::open(tmp.path()).unwrap();
+    let mut stream = reader.cells("Sheet1").unwrap();
+
+    // Drain all rows.
+    while stream.next_row().unwrap().is_some() {}
+
+    // Subsequent calls should return None.
+    assert!(stream.next_row().unwrap().is_none());
+    assert!(stream.next_row().unwrap().is_none());
+}
+
+#[test]
+fn cells_nonexistent_sheet_returns_error() {
+    let tmp = helpers::generate_simple_fixture();
+    let mut reader = Reader::open(tmp.path()).unwrap();
+    let err = reader.cells("NoSuchSheet").unwrap_err();
+    assert!(
+        matches!(err, xlstream_core::XlStreamError::Xlsx(_)),
+        "expected Xlsx error, got {err:?}",
+    );
+}
+
+#[test]
+fn formulas_returns_formula_text() {
+    let tmp = helpers::generate_formula_fixture();
+    let mut reader = Reader::open(tmp.path()).unwrap();
+    let formulas = reader.formulas("Sheet1").unwrap();
+
+    // Only C1 has a formula.
+    assert_eq!(formulas.len(), 1);
+    let (row, col, text) = &formulas[0];
+    assert_eq!(*row, 0);
+    assert_eq!(*col, 2);
+    assert_eq!(text, "A1+B1");
+}
+
+#[test]
+fn cells_reads_formula_cell_cached_value() {
+    let tmp = helpers::generate_formula_fixture();
+    let mut reader = Reader::open(tmp.path()).unwrap();
+    let mut stream = reader.cells("Sheet1").unwrap();
+
+    let row = stream.next_row().unwrap().expect("expected row 0");
+    assert_eq!(row.len(), 3);
+    assert_eq!(row[0], Value::Number(1.0));
+    assert_eq!(row[1], Value::Number(2.0));
+    // Formula cell reads the cached value (3.0).
+    assert_eq!(row[2], Value::Number(3.0));
+}
+
+#[test]
+fn cells_multi_sheet_reads_correct_sheet() {
+    let tmp = helpers::generate_multi_sheet_fixture();
+    let mut reader = Reader::open(tmp.path()).unwrap();
+
+    let mut stream = reader.cells("Alpha").unwrap();
+    let row = stream.next_row().unwrap().expect("expected Alpha row 0");
+    assert_eq!(row[0], Value::Number(10.0));
+    // Must drop stream before opening another (borrow).
+    drop(stream);
+
+    let mut stream = reader.cells("Beta").unwrap();
+    let row = stream.next_row().unwrap().expect("expected Beta row 0");
+    assert_eq!(row[0], Value::Number(20.0));
+}

--- a/crates/xlstream-io/tests/reader.rs
+++ b/crates/xlstream-io/tests/reader.rs
@@ -14,18 +14,20 @@ fn open_reads_sheet_names() {
 }
 
 #[test]
-fn cells_yields_dense_rows() {
+fn cells_yields_dense_rows_with_row_index() {
     let tmp = helpers::generate_simple_fixture();
     let mut reader = Reader::open(tmp.path()).unwrap();
     let mut stream = reader.cells("Sheet1").unwrap();
 
-    let row0 = stream.next_row().unwrap().expect("expected row 0");
+    let (idx, row0) = stream.next_row().unwrap().expect("expected row 0");
+    assert_eq!(idx, 0);
     assert_eq!(row0.len(), 3);
     assert_eq!(row0[0], Value::Number(1.0));
     assert_eq!(row0[1], Value::Text("hello".into()));
     assert_eq!(row0[2], Value::Bool(true));
 
-    let row1 = stream.next_row().unwrap().expect("expected row 1");
+    let (idx, row1) = stream.next_row().unwrap().expect("expected row 1");
+    assert_eq!(idx, 1);
     assert_eq!(row1.len(), 3);
     assert_eq!(row1[0], Value::Number(2.0));
     assert_eq!(row1[1], Value::Text("world".into()));
@@ -40,7 +42,7 @@ fn cells_pads_missing_cells_with_empty() {
     let mut reader = Reader::open(tmp.path()).unwrap();
     let mut stream = reader.cells("Sheet1").unwrap();
 
-    let row = stream.next_row().unwrap().expect("expected row 0");
+    let (_, row) = stream.next_row().unwrap().expect("expected row 0");
     assert_eq!(row.len(), 3);
     assert_eq!(row[0], Value::Number(1.0));
     assert_eq!(row[1], Value::Empty);
@@ -53,10 +55,7 @@ fn cells_returns_none_after_last_row() {
     let mut reader = Reader::open(tmp.path()).unwrap();
     let mut stream = reader.cells("Sheet1").unwrap();
 
-    // Drain all rows.
     while stream.next_row().unwrap().is_some() {}
-
-    // Subsequent calls should return None.
     assert!(stream.next_row().unwrap().is_none());
     assert!(stream.next_row().unwrap().is_none());
 }
@@ -78,7 +77,6 @@ fn formulas_returns_formula_text() {
     let mut reader = Reader::open(tmp.path()).unwrap();
     let formulas = reader.formulas("Sheet1").unwrap();
 
-    // Only C1 has a formula.
     assert_eq!(formulas.len(), 1);
     let (row, col, text) = &formulas[0];
     assert_eq!(*row, 0);
@@ -92,11 +90,10 @@ fn cells_reads_formula_cell_cached_value() {
     let mut reader = Reader::open(tmp.path()).unwrap();
     let mut stream = reader.cells("Sheet1").unwrap();
 
-    let row = stream.next_row().unwrap().expect("expected row 0");
+    let (_, row) = stream.next_row().unwrap().expect("expected row 0");
     assert_eq!(row.len(), 3);
     assert_eq!(row[0], Value::Number(1.0));
     assert_eq!(row[1], Value::Number(2.0));
-    // Formula cell reads the cached value (3.0).
     assert_eq!(row[2], Value::Number(3.0));
 }
 
@@ -106,12 +103,11 @@ fn cells_multi_sheet_reads_correct_sheet() {
     let mut reader = Reader::open(tmp.path()).unwrap();
 
     let mut stream = reader.cells("Alpha").unwrap();
-    let row = stream.next_row().unwrap().expect("expected Alpha row 0");
+    let (_, row) = stream.next_row().unwrap().expect("expected Alpha row 0");
     assert_eq!(row[0], Value::Number(10.0));
-    // Must drop stream before opening another (borrow).
     drop(stream);
 
     let mut stream = reader.cells("Beta").unwrap();
-    let row = stream.next_row().unwrap().expect("expected Beta row 0");
+    let (_, row) = stream.next_row().unwrap().expect("expected Beta row 0");
     assert_eq!(row[0], Value::Number(20.0));
 }


### PR DESCRIPTION
## Summary

- Replace Reader + CellStream stubs with real calamine 0.34 integration
- `Reader::open()` wraps `calamine::open_workbook`, `sheet_names()` returns workbook sheets
- `Reader::cells(sheet)` returns streaming `CellStream` via `XlsxCellReader`
- `CellStream::next_row()` yields dense `Vec<Value>` rows (length == max_col, missing cells padded with Empty)
- Uses `std::mem::take` for zero-copy row buffer handoff (not clone)
- `Reader::formulas(sheet)` collects formula cells eagerly via `next_formula()`
- `CellSource` trait erases calamine's non-public `XlsxCellReader` type via boxed closure adapter
- 8 integration tests + fixture generators via rust_xlsxwriter + tempfile

## Design decisions

- **`CellSource` trait + `ClosureCellSource`**: calamine's `XlsxCellReader` is `pub(crate)` — can't name it in our public types. A `Box<dyn CellSource + 'a>` erases the type cleanly with one heap allocation per stream.
- **`formulas()` returns `Vec` not iterator**: formulas are sparse (typically <1% of cells), so eager collection is fine for memory.
- **Pending cell pattern**: when `next_cell()` returns a cell from a different row, we save it as `pending_cell` and return the current buffer. Next call places it first.

## New dev-dependencies

`tempfile` (workspace) + `rust_xlsxwriter` (workspace, for fixture generation in tests only).

## Test plan

- [x] `make check` passes (210 total workspace tests)
- [x] 8 integration tests: sheet names, dense rows, sparse padding, EOF, error path, formula extraction, cached values, multi-sheet
- [x] Review: row boundary detection handles gaps correctly
- [x] Review: `std::mem::take` used instead of clone