### PR TITLE
xlstream-io: implement writer with constant_memory mode (phase 3 chunk 2)

### DIFF
--- a/crates/xlstream-io/src/convert.rs
+++ b/crates/xlstream-io/src/convert.rs
@@ -33,7 +33,6 @@ fn convert_cell_error(e: &CellErrorType) -> CellError {
 }
 
 /// Render a [`CellError`] as the Excel error string.
-#[allow(dead_code)]
 pub(crate) fn cell_error_to_excel_string(e: CellError) -> &'static str {
     match e {
         CellError::Div0 => "#DIV/0!",
@@ -47,7 +46,6 @@ pub(crate) fn cell_error_to_excel_string(e: CellError) -> &'static str {
 }
 
 /// Render a [`Value`] as a result string for `Formula::set_result()`.
-#[allow(dead_code)]
 pub(crate) fn value_to_result_string(val: &Value) -> String {
     match val {
         Value::Number(n) => format!("{n}"),

--- a/crates/xlstream-io/src/lib.rs
+++ b/crates/xlstream-io/src/lib.rs
@@ -24,9 +24,11 @@
 
 pub(crate) mod convert;
 mod reader;
+mod sheet_handle;
 mod stream;
 mod writer;
 
 pub use reader::Reader;
+pub use sheet_handle::SheetHandle;
 pub use stream::CellStream;
 pub use writer::Writer;

--- a/crates/xlstream-io/src/sheet_handle.rs
+++ b/crates/xlstream-io/src/sheet_handle.rs
@@ -1,0 +1,164 @@
+//! The [`SheetHandle`] — a mutable reference to a `rust_xlsxwriter::Worksheet`
+//! with row-order enforcement for constant-memory mode.
+
+use rust_xlsxwriter::{Format, Formula, Worksheet};
+use xlstream_core::{Value, XlStreamError};
+
+use crate::convert::{cell_error_to_excel_string, value_to_result_string};
+
+/// Wraps a mutable reference to a [`Worksheet`] and enforces strictly-increasing
+/// row indices, which is required by `rust_xlsxwriter`'s constant-memory mode.
+///
+/// Obtain a handle via [`Writer::add_sheet`](crate::Writer::add_sheet).
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::Path;
+/// use xlstream_core::Value;
+/// use xlstream_io::Writer;
+///
+/// let mut w = Writer::create(Path::new("out.xlsx")).unwrap();
+/// let mut sh = w.add_sheet("Data").unwrap();
+/// sh.write_row(0, &[Value::Number(1.0), Value::Text("hi".into())]).unwrap();
+/// ```
+pub struct SheetHandle<'a> {
+    worksheet: &'a mut Worksheet,
+    last_row: Option<u32>,
+    date_format: Format,
+}
+
+impl<'a> SheetHandle<'a> {
+    /// Create a new handle wrapping the given worksheet.
+    pub(crate) fn new(worksheet: &'a mut Worksheet) -> Self {
+        let date_format = Format::new().set_num_format("yyyy-mm-dd");
+        Self { worksheet, last_row: None, date_format }
+    }
+
+    /// Write a row of values at the given `row_idx`.
+    ///
+    /// Row indices must be strictly increasing — writing row 3 after row 5
+    /// returns [`XlStreamError::Internal`]. This pre-check prevents
+    /// `rust_xlsxwriter`'s `RowColumnOrderError` from firing in
+    /// constant-memory mode.
+    ///
+    /// # Errors
+    ///
+    /// - [`XlStreamError::Internal`] if `row_idx` is not strictly greater than
+    ///   the previous row written.
+    /// - [`XlStreamError::XlsxWrite`] if the underlying write fails.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_core::Value;
+    /// use xlstream_io::Writer;
+    ///
+    /// let mut w = Writer::create(Path::new("out.xlsx")).unwrap();
+    /// let mut sh = w.add_sheet("Sheet1").unwrap();
+    /// sh.write_row(0, &[Value::Number(42.0)]).unwrap();
+    /// sh.write_row(1, &[Value::Text("ok".into())]).unwrap();
+    /// ```
+    pub fn write_row(&mut self, row_idx: u32, values: &[Value]) -> Result<(), XlStreamError> {
+        self.enforce_row_order(row_idx)?;
+
+        for (col_offset, val) in values.iter().enumerate() {
+            let col = u16::try_from(col_offset).map_err(|_| {
+                XlStreamError::Internal(format!("column index {col_offset} exceeds u16::MAX"))
+            })?;
+            self.write_value(row_idx, col, val)?;
+        }
+        Ok(())
+    }
+
+    /// Write a formula cell with a cached result value.
+    ///
+    /// The cached result is embedded so that applications that don't
+    /// recalculate (e.g. preview tools) show the correct value.
+    ///
+    /// # Errors
+    ///
+    /// - [`XlStreamError::XlsxWrite`] if the underlying write fails.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_core::Value;
+    /// use xlstream_io::Writer;
+    ///
+    /// let mut w = Writer::create(Path::new("out.xlsx")).unwrap();
+    /// let mut sh = w.add_sheet("Sheet1").unwrap();
+    /// sh.write_row(0, &[Value::Number(1.0), Value::Number(2.0)]).unwrap();
+    /// sh.write_formula(0, 2, "=A1+B1", &Value::Number(3.0)).unwrap();
+    /// ```
+    pub fn write_formula(
+        &mut self,
+        row: u32,
+        col: u16,
+        formula: &str,
+        cached: &Value,
+    ) -> Result<(), XlStreamError> {
+        let cached_str = value_to_result_string(cached);
+        let f = Formula::new(formula).set_result(&cached_str);
+        self.worksheet
+            .write_formula(row, col, f)
+            .map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Enforce strictly-increasing row order.
+    fn enforce_row_order(&mut self, row_idx: u32) -> Result<(), XlStreamError> {
+        if let Some(last) = self.last_row {
+            if row_idx <= last {
+                return Err(XlStreamError::Internal(format!(
+                    "row index {row_idx} is not strictly greater than last written row {last}"
+                )));
+            }
+        }
+        self.last_row = Some(row_idx);
+        Ok(())
+    }
+
+    /// Dispatch a single [`Value`] to the appropriate `rust_xlsxwriter` write
+    /// method.
+    fn write_value(&mut self, row: u32, col: u16, val: &Value) -> Result<(), XlStreamError> {
+        match val {
+            Value::Number(n) => {
+                self.worksheet
+                    .write_number(row, col, *n)
+                    .map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+            }
+            Value::Integer(i) => {
+                #[allow(clippy::cast_precision_loss)]
+                let n = *i as f64;
+                self.worksheet
+                    .write_number(row, col, n)
+                    .map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+            }
+            Value::Text(s) => {
+                self.worksheet
+                    .write_string(row, col, &**s)
+                    .map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+            }
+            Value::Bool(b) => {
+                self.worksheet
+                    .write_boolean(row, col, *b)
+                    .map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+            }
+            Value::Date(d) => {
+                self.worksheet
+                    .write_number_with_format(row, col, d.serial, &self.date_format)
+                    .map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+            }
+            Value::Error(e) => {
+                self.worksheet
+                    .write_string(row, col, cell_error_to_excel_string(*e))
+                    .map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+            }
+            Value::Empty => { /* leave cell default */ }
+        }
+        Ok(())
+    }
+}

--- a/crates/xlstream-io/src/writer.rs
+++ b/crates/xlstream-io/src/writer.rs
@@ -1,45 +1,111 @@
-//! The [`Writer`] stub — `rust_xlsxwriter`-backed xlsx writer. Real logic
-//! lands in Phase 3.
+//! The [`Writer`] — `rust_xlsxwriter`-backed xlsx writer in constant-memory
+//! mode. Writes are streamed row-by-row; the workbook is flushed on
+//! [`Writer::finish`].
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use rust_xlsxwriter::Workbook;
 use xlstream_core::XlStreamError;
 
-/// Streaming xlsx writer. Phase 1 ships a unit-struct stub; Phase 3 wires
-/// it to a `rust_xlsxwriter::Workbook` in constant-memory mode.
+use crate::sheet_handle::SheetHandle;
+
+/// Streaming xlsx writer backed by [`rust_xlsxwriter::Workbook`] in
+/// constant-memory mode. Rows must be written in strictly-increasing order
+/// per sheet — the [`SheetHandle`] returned by [`Writer::add_sheet`]
+/// enforces this at runtime.
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use std::path::Path;
+/// use xlstream_core::Value;
 /// use xlstream_io::Writer;
-/// let err = Writer::create(Path::new("out.xlsx")).unwrap_err();
-/// assert!(err.to_string().contains("unimplemented"));
+///
+/// let mut w = Writer::create(Path::new("out.xlsx")).unwrap();
+/// let mut sh = w.add_sheet("Sheet1").unwrap();
+/// sh.write_row(0, &[Value::Number(1.0), Value::Text("hello".into())]).unwrap();
+/// drop(sh);
+/// w.finish().unwrap();
 /// ```
-#[derive(Debug)]
 pub struct Writer {
-    _private: (),
+    workbook: Workbook,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for Writer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Writer").field("path", &self.path).finish_non_exhaustive()
+    }
 }
 
 impl Writer {
     /// Create a new xlsx file ready to accept streamed rows.
     ///
+    /// The file at `path` is not written until [`Writer::finish`] is called.
+    ///
     /// # Errors
     ///
-    /// Phase 1: always [`XlStreamError::Internal`]. Phase 3 onward: real
-    /// errors surfaced as [`XlStreamError::Io`] / `XlStreamError::XlsxWrite`
-    /// (variant added in Phase 3).
+    /// Currently infallible, but returns `Result` for forward-compat with
+    /// path validation or directory-creation logic.
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use std::path::Path;
     /// use xlstream_io::Writer;
-    /// assert!(Writer::create(Path::new("x.xlsx")).is_err());
+    ///
+    /// let w = Writer::create(Path::new("out.xlsx")).unwrap();
     /// ```
-    #[must_use = "creating a writer is useless without inspecting the result"]
-    pub fn create(_path: &Path) -> Result<Self, XlStreamError> {
-        Err(XlStreamError::Internal("unimplemented: Writer::create — lands in Phase 3".into()))
+    pub fn create(path: &Path) -> Result<Self, XlStreamError> {
+        let workbook = Workbook::new();
+        Ok(Self { workbook, path: path.to_path_buf() })
+    }
+
+    /// Add a new worksheet in constant-memory mode and return a
+    /// [`SheetHandle`] for writing rows. The handle borrows `self` mutably,
+    /// so only one sheet can be written at a time — drop or rebind the
+    /// handle before adding another sheet.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XlStreamError::XlsxWrite`] if `rust_xlsxwriter` rejects the
+    /// sheet name (too long, duplicate, invalid characters, etc.).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_io::Writer;
+    ///
+    /// let mut w = Writer::create(Path::new("out.xlsx")).unwrap();
+    /// let sh = w.add_sheet("Data").unwrap();
+    /// drop(sh);
+    /// ```
+    pub fn add_sheet(&mut self, name: &str) -> Result<SheetHandle<'_>, XlStreamError> {
+        let ws = self.workbook.add_worksheet_with_constant_memory();
+        ws.set_name(name).map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+        Ok(SheetHandle::new(ws))
+    }
+
+    /// Flush all buffered data and write the xlsx file to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XlStreamError::XlsxWrite`] if `rust_xlsxwriter` fails to
+    /// serialise or write the file.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_io::Writer;
+    ///
+    /// let w = Writer::create(Path::new("out.xlsx")).unwrap();
+    /// w.finish().unwrap();
+    /// ```
+    pub fn finish(mut self) -> Result<(), XlStreamError> {
+        self.workbook.save(&self.path).map_err(|e| XlStreamError::XlsxWrite(e.to_string()))?;
+        Ok(())
     }
 }
 
@@ -52,11 +118,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn create_returns_unimplemented_internal_error() {
-        let err = Writer::create(Path::new("out.xlsx")).unwrap_err();
-        assert!(
-            matches!(err, xlstream_core::XlStreamError::Internal(ref msg) if msg.contains("unimplemented")),
-            "expected Internal(unimplemented...), got {err:?}",
-        );
+    fn create_returns_ok() {
+        let w = Writer::create(Path::new("out.xlsx"));
+        assert!(w.is_ok());
+    }
+
+    #[test]
+    fn debug_includes_path() {
+        let w = Writer::create(Path::new("test.xlsx")).unwrap();
+        let dbg = format!("{w:?}");
+        assert!(dbg.contains("test.xlsx"), "debug missing path: {dbg}");
     }
 }

--- a/crates/xlstream-io/tests/writer.rs
+++ b/crates/xlstream-io/tests/writer.rs
@@ -1,0 +1,199 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+#[allow(dead_code)]
+mod helpers;
+
+use xlstream_core::{CellError, ExcelDate, Value, XlStreamError};
+use xlstream_io::{Reader, Writer};
+
+/// Write mixed values, re-read with Reader, verify round-trip.
+#[test]
+fn write_creates_readable_xlsx() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let path = tmp.path();
+
+    let mut w = Writer::create(path).unwrap();
+    let mut sh = w.add_sheet("Sheet1").unwrap();
+    sh.write_row(0, &[Value::Number(1.0), Value::Text("hello".into()), Value::Bool(true)]).unwrap();
+    sh.write_row(1, &[Value::Number(2.0), Value::Text("world".into()), Value::Bool(false)])
+        .unwrap();
+    drop(sh);
+    w.finish().unwrap();
+
+    let mut reader = Reader::open(path).unwrap();
+    let names = reader.sheet_names();
+    assert_eq!(names, vec!["Sheet1".to_string()]);
+
+    let mut stream = reader.cells("Sheet1").unwrap();
+    let (idx, row0) = stream.next_row().unwrap().expect("expected row 0");
+    assert_eq!(idx, 0);
+    assert_eq!(row0[0], Value::Number(1.0));
+    assert_eq!(row0[1], Value::Text("hello".into()));
+    assert_eq!(row0[2], Value::Bool(true));
+
+    let (idx, row1) = stream.next_row().unwrap().expect("expected row 1");
+    assert_eq!(idx, 1);
+    assert_eq!(row1[0], Value::Number(2.0));
+    assert_eq!(row1[1], Value::Text("world".into()));
+    assert_eq!(row1[2], Value::Bool(false));
+
+    assert!(stream.next_row().unwrap().is_none());
+}
+
+/// Writing row 3 after row 5 must produce an error.
+#[test]
+fn write_row_enforces_increasing_row_index() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut w = Writer::create(tmp.path()).unwrap();
+    let mut sh = w.add_sheet("Sheet1").unwrap();
+
+    sh.write_row(5, &[Value::Number(1.0)]).unwrap();
+    let err = sh.write_row(3, &[Value::Number(2.0)]).unwrap_err();
+    assert!(
+        matches!(err, XlStreamError::Internal(ref msg) if msg.contains("not strictly greater")),
+        "expected Internal error about row order, got {err:?}",
+    );
+}
+
+/// Writing the same row index twice must also fail.
+#[test]
+fn write_row_rejects_duplicate_row_index() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut w = Writer::create(tmp.path()).unwrap();
+    let mut sh = w.add_sheet("Sheet1").unwrap();
+
+    sh.write_row(0, &[Value::Number(1.0)]).unwrap();
+    let err = sh.write_row(0, &[Value::Number(2.0)]).unwrap_err();
+    assert!(matches!(err, XlStreamError::Internal(_)), "expected Internal error, got {err:?}",);
+}
+
+/// Write a formula with cached result, re-read, verify the cached value.
+#[test]
+fn write_formula_sets_cached_result() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let path = tmp.path();
+
+    let mut w = Writer::create(path).unwrap();
+    let mut sh = w.add_sheet("Sheet1").unwrap();
+    sh.write_row(0, &[Value::Number(1.0), Value::Number(2.0)]).unwrap();
+    sh.write_formula(0, 2, "=A1+B1", &Value::Number(3.0)).unwrap();
+    drop(sh);
+    w.finish().unwrap();
+
+    let mut reader = Reader::open(path).unwrap();
+    let mut stream = reader.cells("Sheet1").unwrap();
+    let (_, row) = stream.next_row().unwrap().expect("expected row 0");
+
+    assert_eq!(row[0], Value::Number(1.0));
+    assert_eq!(row[1], Value::Number(2.0));
+    // Cached formula result should read back as the number 3
+    assert_eq!(row[2], Value::Number(3.0));
+}
+
+/// Write one row containing every Value variant, re-read and verify.
+#[test]
+fn write_all_value_types() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let path = tmp.path();
+
+    let values = vec![
+        Value::Number(9.81),
+        Value::Integer(42),
+        Value::Text("text".into()),
+        Value::Bool(true),
+        Value::Date(ExcelDate { serial: 44927.0 }),
+        Value::Error(CellError::Div0),
+        Value::Empty,
+    ];
+
+    let mut w = Writer::create(path).unwrap();
+    let mut sh = w.add_sheet("Sheet1").unwrap();
+    sh.write_row(0, &values).unwrap();
+    drop(sh);
+    w.finish().unwrap();
+
+    let mut reader = Reader::open(path).unwrap();
+    let mut stream = reader.cells("Sheet1").unwrap();
+    let (_, row) = stream.next_row().unwrap().expect("expected row 0");
+
+    // Number
+    assert_eq!(row[0], Value::Number(9.81));
+    // Integer written as f64
+    assert_eq!(row[1], Value::Number(42.0));
+    // Text
+    assert_eq!(row[2], Value::Text("text".into()));
+    // Bool
+    assert_eq!(row[3], Value::Bool(true));
+    // Date — comes back as Number (the serial) since calamine sees the
+    // formatted number. The exact type depends on calamine's detection,
+    // but the serial value must be preserved.
+    match &row[4] {
+        Value::Number(n) => assert!((*n - 44927.0).abs() < 0.001, "expected ~44927, got {n}"),
+        Value::Date(d) => {
+            assert!((d.serial - 44927.0).abs() < 0.001, "expected ~44927, got {}", d.serial);
+        }
+        other => panic!("expected Number or Date for date cell, got {other:?}"),
+    }
+    // Error written as string
+    assert_eq!(row[5], Value::Text("#DIV/0!".into()));
+    // Empty — the row may be shorter (trailing empties trimmed) or padded
+    assert!(
+        row.len() <= 6 || row[6] == Value::Empty,
+        "expected Empty or absent trailing cell, got {:?}",
+        row.get(6),
+    );
+}
+
+/// Write a row with Empty values, verify they read back as Empty.
+#[test]
+fn write_empty_cells_are_skipped() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let path = tmp.path();
+
+    let mut w = Writer::create(path).unwrap();
+    let mut sh = w.add_sheet("Sheet1").unwrap();
+    // A=1.0, B=Empty, C=3.0
+    sh.write_row(0, &[Value::Number(1.0), Value::Empty, Value::Number(3.0)]).unwrap();
+    drop(sh);
+    w.finish().unwrap();
+
+    let mut reader = Reader::open(path).unwrap();
+    let mut stream = reader.cells("Sheet1").unwrap();
+    let (_, row) = stream.next_row().unwrap().expect("expected row 0");
+
+    assert_eq!(row[0], Value::Number(1.0));
+    assert_eq!(row[1], Value::Empty);
+    assert_eq!(row[2], Value::Number(3.0));
+}
+
+/// Add 2 sheets, write to both, verify round-trip.
+#[test]
+fn multi_sheet_write() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let path = tmp.path();
+
+    let mut w = Writer::create(path).unwrap();
+
+    let mut sh1 = w.add_sheet("Alpha").unwrap();
+    sh1.write_row(0, &[Value::Number(10.0)]).unwrap();
+    drop(sh1);
+
+    let mut sh2 = w.add_sheet("Beta").unwrap();
+    sh2.write_row(0, &[Value::Number(20.0)]).unwrap();
+    drop(sh2);
+
+    w.finish().unwrap();
+
+    let mut reader = Reader::open(path).unwrap();
+    let names = reader.sheet_names();
+    assert_eq!(names, vec!["Alpha".to_string(), "Beta".to_string()]);
+
+    let mut stream = reader.cells("Alpha").unwrap();
+    let (_, row) = stream.next_row().unwrap().expect("Alpha row 0");
+    assert_eq!(row[0], Value::Number(10.0));
+    drop(stream);
+
+    let mut stream = reader.cells("Beta").unwrap();
+    let (_, row) = stream.next_row().unwrap().expect("Beta row 0");
+    assert_eq!(row[0], Value::Number(20.0));
+}


### PR DESCRIPTION
## Summary

- Replace Writer stub with real rust_xlsxwriter 0.94 integration in constant_memory mode
- `SheetHandle` wraps `&mut Worksheet` with strictly-increasing row-order enforcement
- Value dispatch: Number, Integer (as f64), Text, Bool, Date (serial + date format), Error (as string), Empty (skip)
- `write_formula()` uses `Formula::new().set_result()` for cached values
- `finish()` saves workbook to disk
- 7 integration tests + 2 unit tests

## Design decisions

- **Row-order pre-check in SheetHandle**: prevents rust_xlsxwriter's `RowColumnOrderError` by checking before the write call, producing a clearer `XlStreamError::Internal` message
- **Date as serial number + format**: `write_number_with_format(row, col, serial, &date_format)` — simpler than ExcelDateTime conversion and preserves the serial exactly
- **Error cells as strings**: rust_xlsxwriter has no error-cell API; writing "#DIV/0!" etc. as strings is the standard workaround

## Test plan

- [x] `make check` passes (212 total workspace tests)
- [x] Round-trip test: write → Reader::open → verify values
- [x] Row-order enforcement: row 5 then row 3 → error; duplicate row → error
- [x] Formula caching verified via re-read
- [x] All 7 Value variants written and verified
- [ ] Review: Date serial round-trip preserves precision
- [ ] Review: SheetHandle lifetime correctly ties to Writer borrow