### PR TITLE
xlstream-io: add error path tests (phase 3 chunk 4)

### DIFF
--- a/crates/xlstream-io/tests/error_paths.rs
+++ b/crates/xlstream-io/tests/error_paths.rs
@@ -1,0 +1,56 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Error-path integration tests for Reader and Writer.
+
+use std::path::Path;
+
+use xlstream_core::XlStreamError;
+use xlstream_io::Reader;
+
+#[test]
+fn open_nonexistent_file_returns_xlsx_error() {
+    let err = Reader::open(Path::new("/tmp/xlstream_does_not_exist_9999.xlsx")).unwrap_err();
+    assert!(
+        matches!(err, XlStreamError::Xlsx(_)),
+        "expected Xlsx error for missing file, got {err:?}",
+    );
+}
+
+#[test]
+fn open_malformed_file_returns_xlsx_error() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), b"this is not a valid xlsx file").unwrap();
+    let err = Reader::open(tmp.path()).unwrap_err();
+    assert!(
+        matches!(err, XlStreamError::Xlsx(_)),
+        "expected Xlsx error for malformed file, got {err:?}",
+    );
+}
+
+#[test]
+fn open_empty_file_returns_xlsx_error() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let err = Reader::open(tmp.path()).unwrap_err();
+    assert!(
+        matches!(err, XlStreamError::Xlsx(_)),
+        "expected Xlsx error for empty file, got {err:?}",
+    );
+}
+
+#[test]
+fn cells_nonexistent_sheet_returns_xlsx_error() {
+    let tmp = {
+        let mut wb = rust_xlsxwriter::Workbook::new();
+        let ws = wb.add_worksheet();
+        ws.write_number(0, 0, 1.0).unwrap();
+        let f = tempfile::NamedTempFile::new().unwrap();
+        wb.save(f.path()).unwrap();
+        f
+    };
+    let mut reader = Reader::open(tmp.path()).unwrap();
+    let err = reader.cells("NoSuchSheet").unwrap_err();
+    assert!(
+        matches!(err, XlStreamError::Xlsx(_)),
+        "expected Xlsx error for nonexistent sheet, got {err:?}",
+    );
+}

--- a/docs/phases/phase-03-io.md
+++ b/docs/phases/phase-03-io.md
@@ -64,9 +64,9 @@
 
 ### Error paths
 
-- [ ] File not found → `XlStreamError::Io`.
-- [ ] Malformed xlsx → `XlStreamError::Xlsx`.
-- [ ] Writing out of order → `XlStreamError::Internal` (constant-memory constraint).
+- [x] File not found → `XlStreamError::Xlsx` (calamine wraps the I/O error).
+- [x] Malformed xlsx → `XlStreamError::Xlsx`.
+- [x] Writing out of order → `XlStreamError::Internal` (constant-memory constraint).
 
 ### Performance smoke
 


### PR DESCRIPTION
## Summary

- 4 error-path integration tests: file not found, malformed xlsx, empty file, nonexistent sheet
- All return `XlStreamError::Xlsx` (calamine wraps I/O errors internally)
- Write out-of-order already covered in writer.rs (Chunk 2)
- Phase doc error path boxes ticked

## Note on file-not-found

Phase doc originally said file not found → `XlStreamError::Io`. In practice calamine wraps the `io::Error` inside its own `XlsxError`, so our string-wrapper approach maps it to `XlStreamError::Xlsx`. Updated the phase doc to reflect this.

## Test plan

- [x] `make check` passes (224 total workspace tests)
- [x] 4 new error-path tests