### PR TITLE
xlstream-eval: add interpreter, row scope, prelude stub, topo sort (phase 4 chunk 1)

### DIFF
--- a/crates/xlstream-eval/src/interp.rs
+++ b/crates/xlstream-eval/src/interp.rs
@@ -1,0 +1,192 @@
+//! [`Interpreter`] — formula evaluator. Walks the AST via [`NodeView`] and
+//! resolves values against the current row.
+
+use xlstream_core::{CellError, Value};
+use xlstream_parse::{NodeRef, NodeView};
+
+use crate::prelude::Prelude;
+use crate::scope::RowScope;
+
+/// Formula evaluator. Walks the AST via [`NodeView`] and resolves values
+/// against the current row scope.
+///
+/// Phase 4 handles literals and same-row cell references only. Operators
+/// and functions return `#VALUE!`; they land in Phase 5+.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::Value;
+/// use xlstream_eval::{Interpreter, Prelude, RowScope};
+/// use xlstream_parse::parse;
+///
+/// let prelude = Prelude::empty();
+/// let interp = Interpreter::new(&prelude);
+/// let ast = parse("42").unwrap();
+/// let scope = RowScope::new(&[], 1);
+/// assert_eq!(interp.eval(ast.root(), &scope), Value::Number(42.0));
+/// ```
+pub struct Interpreter<'ctx> {
+    _prelude: &'ctx Prelude,
+}
+
+impl<'ctx> Interpreter<'ctx> {
+    /// Build an interpreter backed by the given prelude data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_eval::{Interpreter, Prelude};
+    /// let prelude = Prelude::empty();
+    /// let _interp = Interpreter::new(&prelude);
+    /// ```
+    #[must_use]
+    pub fn new(prelude: &'ctx Prelude) -> Self {
+        Self { _prelude: prelude }
+    }
+
+    /// Evaluate a single AST node against the current row.
+    ///
+    /// Returns a [`Value`]. Never errors at the library level — unsupported
+    /// constructs produce cell-level errors (`#VALUE!`, `#REF!`, `#NAME?`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_core::Value;
+    /// use xlstream_eval::{Interpreter, Prelude, RowScope};
+    /// use xlstream_parse::parse;
+    ///
+    /// let prelude = Prelude::empty();
+    /// let interp = Interpreter::new(&prelude);
+    /// let ast = parse("TRUE").unwrap();
+    /// let scope = RowScope::new(&[], 0);
+    /// assert_eq!(interp.eval(ast.root(), &scope), Value::Bool(true));
+    /// ```
+    #[must_use]
+    pub fn eval(&self, node: NodeRef<'_>, scope: &RowScope<'_>) -> Value {
+        match node.view() {
+            NodeView::Number(n) => Value::Number(n),
+            NodeView::Bool(b) => Value::Bool(b),
+            NodeView::Text(s) => Value::Text(s.into()),
+            NodeView::Error(e) => Value::Error(e),
+
+            // Cell ref: classifier guaranteed same-row. Use col only.
+            NodeView::CellRef { col, .. } => scope.get(col),
+
+            // Ranges outside functions -> #REF!
+            NodeView::RangeRef { .. } => Value::Error(CellError::Ref),
+
+            // Named/External/Table -> #NAME?
+            NodeView::NamedRef(_) | NodeView::ExternalRef { .. } | NodeView::TableRef { .. } => {
+                Value::Error(CellError::Name)
+            }
+
+            // Phase 5+: operators and functions
+            NodeView::BinaryOp { .. } | NodeView::UnaryOp { .. } | NodeView::Function { .. } => {
+                Value::Error(CellError::Value)
+            }
+
+            NodeView::Array { .. } | NodeView::PreludeRef(_) => Value::Error(CellError::Value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::float_cmp)]
+
+    use xlstream_core::{CellError, Value};
+    use xlstream_parse::parse;
+
+    use super::*;
+
+    fn make_interp(prelude: &Prelude) -> Interpreter<'_> {
+        Interpreter::new(prelude)
+    }
+
+    #[test]
+    fn eval_number_literal() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        let ast = parse("42").unwrap();
+        let scope = RowScope::new(&[], 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Number(42.0));
+    }
+
+    #[test]
+    fn eval_text_literal() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        let ast = parse("\"hello\"").unwrap();
+        let scope = RowScope::new(&[], 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Text("hello".into()));
+    }
+
+    #[test]
+    fn eval_bool_literal() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        let ast = parse("TRUE").unwrap();
+        let scope = RowScope::new(&[], 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Bool(true));
+    }
+
+    #[test]
+    fn eval_error_literal() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        let ast = parse("#REF!").unwrap();
+        let scope = RowScope::new(&[], 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Error(CellError::Ref));
+    }
+
+    #[test]
+    fn eval_cell_ref_returns_row_value() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        // A1 parses as col=1, row=1
+        let ast = parse("A1").unwrap();
+        let row = vec![Value::Number(99.0), Value::Text("x".into())];
+        let scope = RowScope::new(&row, 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Number(99.0));
+    }
+
+    #[test]
+    fn eval_cell_ref_out_of_bounds() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        // Z1 = col 26, row 1 — well beyond a 2-element row.
+        let ast = parse("Z1").unwrap();
+        let row = vec![Value::Number(1.0), Value::Number(2.0)];
+        let scope = RowScope::new(&row, 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Error(CellError::Ref),);
+    }
+
+    #[test]
+    fn eval_function_returns_value_error() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        let ast = parse("SUM(A1:A10)").unwrap();
+        let scope = RowScope::new(&[], 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Error(CellError::Value),);
+    }
+
+    #[test]
+    fn eval_binary_op_returns_value_error() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        let ast = parse("1+2").unwrap();
+        let scope = RowScope::new(&[], 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Error(CellError::Value),);
+    }
+
+    #[test]
+    fn eval_unary_op_returns_value_error() {
+        let prelude = Prelude::empty();
+        let interp = make_interp(&prelude);
+        let ast = parse("-5").unwrap();
+        let scope = RowScope::new(&[], 0);
+        assert_eq!(interp.eval(ast.root(), &scope), Value::Error(CellError::Value),);
+    }
+}

--- a/crates/xlstream-eval/src/lib.rs
+++ b/crates/xlstream-eval/src/lib.rs
@@ -23,5 +23,13 @@
 #![allow(clippy::multiple_crate_versions)]
 
 mod evaluate;
+mod interp;
+mod prelude;
+mod scope;
+pub mod topo;
 
 pub use evaluate::{evaluate, EvaluateSummary};
+pub use interp::Interpreter;
+pub use prelude::Prelude;
+pub use scope::RowScope;
+pub use topo::topo_sort;

--- a/crates/xlstream-eval/src/prelude.rs
+++ b/crates/xlstream-eval/src/prelude.rs
@@ -1,0 +1,48 @@
+//! [`Prelude`] — data computed before the row-streaming pass.
+//!
+//! Empty in Phase 4. Phase 7 adds aggregate scalars, Phase 8 adds lookup
+//! indexes.
+
+/// Prelude data computed before the row-streaming pass.
+///
+/// Constructed once after the prelude pass (pass 1) completes, then shared
+/// immutably with every row evaluation during pass 2.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_eval::Prelude;
+/// let p = Prelude::empty();
+/// drop(p);
+/// ```
+pub struct Prelude {
+    _private: (),
+}
+
+impl Prelude {
+    /// Build an empty prelude. Used in Phase 4 tests and as the default
+    /// when no aggregates or lookups are needed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_eval::Prelude;
+    /// let _ = Prelude::empty();
+    /// ```
+    #[must_use]
+    pub fn empty() -> Self {
+        Self { _private: () }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    #[test]
+    fn empty_prelude_constructs() {
+        let _ = Prelude::empty();
+    }
+}

--- a/crates/xlstream-eval/src/scope.rs
+++ b/crates/xlstream-eval/src/scope.rs
@@ -1,0 +1,135 @@
+//! [`RowScope`] — current row's cell values, accessible by 1-based column
+//! index.
+
+use xlstream_core::{CellError, Value};
+
+/// Current row's cell values, accessible by 1-based column index.
+///
+/// The evaluator constructs one `RowScope` per streamed row and passes it
+/// into [`Interpreter::eval`](crate::Interpreter::eval) for each formula
+/// cell. All cell references resolved during the row pass go through
+/// [`get`](RowScope::get).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::Value;
+/// use xlstream_eval::RowScope;
+/// let row = vec![Value::Number(10.0), Value::Text("hi".into())];
+/// let scope = RowScope::new(&row, 2);
+/// assert_eq!(scope.get(1), Value::Number(10.0));
+/// assert_eq!(scope.get(3), Value::Error(xlstream_core::CellError::Ref));
+/// ```
+pub struct RowScope<'row> {
+    values: &'row [Value],
+    row_idx: u32,
+}
+
+impl<'row> RowScope<'row> {
+    /// Build a scope over the given row values at 0-based row index
+    /// `row_idx`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_core::Value;
+    /// use xlstream_eval::RowScope;
+    /// let row = vec![Value::Number(1.0)];
+    /// let scope = RowScope::new(&row, 0);
+    /// assert_eq!(scope.row_idx(), 0);
+    /// ```
+    #[must_use]
+    pub fn new(values: &'row [Value], row_idx: u32) -> Self {
+        Self { values, row_idx }
+    }
+
+    /// Get cell value by 1-based column index. Out of bounds returns
+    /// `#REF!`.
+    ///
+    /// Note: clones the `Value`. `Number`/`Bool`/`Empty`/`Error` are cheap
+    /// (Copy-like). `Text(Box<str>)` clones the heap string — accepted
+    /// tech debt for Phase 10.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_core::{CellError, Value};
+    /// use xlstream_eval::RowScope;
+    /// let row = vec![Value::Bool(true)];
+    /// let scope = RowScope::new(&row, 0);
+    /// assert_eq!(scope.get(1), Value::Bool(true));
+    /// assert_eq!(scope.get(2), Value::Error(CellError::Ref));
+    /// ```
+    #[must_use]
+    pub fn get(&self, col: u32) -> Value {
+        if col == 0 {
+            return Value::Error(CellError::Ref);
+        }
+        let idx = (col as usize) - 1;
+        self.values.get(idx).cloned().unwrap_or(Value::Error(CellError::Ref))
+    }
+
+    /// 0-based row index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_eval::RowScope;
+    /// let scope = RowScope::new(&[], 7);
+    /// assert_eq!(scope.row_idx(), 7);
+    /// ```
+    #[must_use]
+    pub fn row_idx(&self) -> u32 {
+        self.row_idx
+    }
+
+    /// Borrow the underlying values slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_core::Value;
+    /// use xlstream_eval::RowScope;
+    /// let row = vec![Value::Empty];
+    /// let scope = RowScope::new(&row, 0);
+    /// assert_eq!(scope.values().len(), 1);
+    /// ```
+    #[must_use]
+    pub fn values(&self) -> &[Value] {
+        self.values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use xlstream_core::{CellError, Value};
+
+    use super::*;
+
+    #[test]
+    fn get_returns_value_at_index() {
+        let row = vec![Value::Number(1.0), Value::Text("two".into()), Value::Bool(false)];
+        let scope = RowScope::new(&row, 0);
+        assert_eq!(scope.get(1), Value::Number(1.0));
+        assert_eq!(scope.get(2), Value::Text("two".into()));
+        assert_eq!(scope.get(3), Value::Bool(false));
+    }
+
+    #[test]
+    fn get_out_of_bounds_returns_ref_error() {
+        let row = vec![Value::Number(1.0)];
+        let scope = RowScope::new(&row, 0);
+        assert_eq!(scope.get(2), Value::Error(CellError::Ref));
+        assert_eq!(scope.get(100), Value::Error(CellError::Ref));
+    }
+
+    #[test]
+    fn get_col_zero_returns_ref_error() {
+        let row = vec![Value::Number(1.0)];
+        let scope = RowScope::new(&row, 0);
+        // col 0 is invalid — columns are 1-based.
+        assert_eq!(scope.get(0), Value::Error(CellError::Ref));
+    }
+}

--- a/crates/xlstream-eval/src/topo.rs
+++ b/crates/xlstream-eval/src/topo.rs
@@ -1,0 +1,168 @@
+//! Topological sort for formula column evaluation order.
+//!
+//! Uses Kahn's algorithm on the formula-to-formula dependency graph.
+//! Data columns (non-formula) are free — they're already in the row.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::BuildHasher;
+
+use xlstream_core::XlStreamError;
+
+/// Build evaluation order for formula columns using Kahn's algorithm.
+///
+/// `formula_deps`: `(col_index, vec_of_col_indices_it_references)`.
+/// `formula_cols`: set of columns that contain formulas.
+///
+/// Only formula-to-formula edges matter. References to data columns are
+/// free (already in the row) and are filtered out.
+///
+/// # Errors
+///
+/// Returns [`XlStreamError::CircularReference`] if the DAG has a cycle.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashSet;
+/// use xlstream_eval::topo_sort;
+/// let deps = vec![(1u32, vec![0u32]), (2, vec![1])];
+/// let formula_cols: HashSet<u32> = [1, 2].into_iter().collect();
+/// let order = topo_sort(&deps, &formula_cols).unwrap();
+/// assert_eq!(order, vec![1, 2]);
+/// ```
+pub fn topo_sort<S: BuildHasher>(
+    formula_deps: &[(u32, Vec<u32>)],
+    formula_cols: &HashSet<u32, S>,
+) -> Result<Vec<u32>, XlStreamError> {
+    // Initialise in-degree for every formula column.
+    let mut in_degree: HashMap<u32, usize> = formula_cols.iter().map(|&c| (c, 0)).collect();
+    let mut successors: HashMap<u32, Vec<u32>> = HashMap::new();
+
+    for (col, deps) in formula_deps {
+        for &dep in deps {
+            if formula_cols.contains(&dep) {
+                *in_degree.entry(*col).or_insert(0) += 1;
+                successors.entry(dep).or_default().push(*col);
+            }
+        }
+    }
+
+    // Seed queue with zero-degree nodes, sorted for determinism.
+    let mut initial: Vec<u32> =
+        in_degree.iter().filter(|(_, &deg)| deg == 0).map(|(&col, _)| col).collect();
+    initial.sort_unstable();
+
+    let mut queue: VecDeque<u32> = VecDeque::from(initial);
+    let mut order = Vec::with_capacity(formula_cols.len());
+
+    while let Some(col) = queue.pop_front() {
+        order.push(col);
+        if let Some(succs) = successors.get(&col) {
+            // Sort successors for deterministic ordering when multiple
+            // nodes become ready at the same time.
+            let mut sorted_succs: Vec<u32> = succs.clone();
+            sorted_succs.sort_unstable();
+            for s in sorted_succs {
+                if let Some(deg) = in_degree.get_mut(&s) {
+                    *deg -= 1;
+                    if *deg == 0 {
+                        queue.push_back(s);
+                    }
+                }
+            }
+        }
+    }
+
+    if order.len() != formula_cols.len() {
+        let mut remaining: Vec<String> = formula_cols
+            .iter()
+            .filter(|c| !order.contains(c))
+            .map(|c| format!("col {c}"))
+            .collect();
+        remaining.sort();
+        return Err(XlStreamError::CircularReference { cells: remaining });
+    }
+
+    Ok(order)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use std::collections::HashSet;
+
+    use xlstream_core::XlStreamError;
+
+    use super::*;
+
+    #[test]
+    fn linear_chain() {
+        // col 0 = data, col 1 (formula) deps col 0, col 2 (formula) deps col 1
+        let deps = vec![(1u32, vec![0u32]), (2, vec![1])];
+        let formula_cols: HashSet<u32> = [1, 2].into_iter().collect();
+        let order = topo_sort(&deps, &formula_cols).unwrap();
+        assert_eq!(order, vec![1, 2]);
+    }
+
+    #[test]
+    fn diamond() {
+        // A(0) = data, B(1) deps A, C(2) deps A, D(3) deps B+C
+        let deps = vec![(1u32, vec![0u32]), (2, vec![0]), (3, vec![1, 2])];
+        let formula_cols: HashSet<u32> = [1, 2, 3].into_iter().collect();
+        let order = topo_sort(&deps, &formula_cols).unwrap();
+        // B and C before D; sorted tie-breaking gives [1, 2, 3]
+        let d_pos = order.iter().position(|&c| c == 3).unwrap();
+        let b_pos = order.iter().position(|&c| c == 1).unwrap();
+        let c_pos = order.iter().position(|&c| c == 2).unwrap();
+        assert!(b_pos < d_pos, "B must come before D");
+        assert!(c_pos < d_pos, "C must come before D");
+    }
+
+    #[test]
+    fn cycle_returns_error() {
+        // B deps C, C deps B — cycle
+        let deps = vec![(1u32, vec![2u32]), (2, vec![1])];
+        let formula_cols: HashSet<u32> = [1, 2].into_iter().collect();
+        let err = topo_sort(&deps, &formula_cols).unwrap_err();
+        assert!(
+            matches!(err, XlStreamError::CircularReference { .. }),
+            "expected CircularReference, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn independent_columns() {
+        // Two formula columns with no inter-formula deps
+        let deps = vec![(1u32, vec![0u32]), (2, vec![0])];
+        let formula_cols: HashSet<u32> = [1, 2].into_iter().collect();
+        let order = topo_sort(&deps, &formula_cols).unwrap();
+        assert_eq!(order.len(), 2);
+        assert!(order.contains(&1));
+        assert!(order.contains(&2));
+    }
+
+    #[test]
+    fn single_formula_column() {
+        let deps = vec![(1u32, vec![0u32])];
+        let formula_cols: HashSet<u32> = [1].into_iter().collect();
+        let order = topo_sort(&deps, &formula_cols).unwrap();
+        assert_eq!(order, vec![1]);
+    }
+
+    #[test]
+    fn empty_input() {
+        let deps: Vec<(u32, Vec<u32>)> = vec![];
+        let formula_cols: HashSet<u32> = HashSet::new();
+        let order = topo_sort(&deps, &formula_cols).unwrap();
+        assert!(order.is_empty());
+    }
+
+    #[test]
+    fn self_cycle_returns_error() {
+        let deps = vec![(1u32, vec![1u32])];
+        let formula_cols: HashSet<u32> = [1].into_iter().collect();
+        let err = topo_sort(&deps, &formula_cols).unwrap_err();
+        assert!(matches!(err, XlStreamError::CircularReference { .. }));
+    }
+}


### PR DESCRIPTION
## Summary

- `Interpreter` matches on `NodeView` — resolves literals + cell refs, returns `Value::Error(CellError::Value)` for functions/operators (Phase 5+). Holds `&Prelude` ready for Phase 7.
- `RowScope` provides 1-based column lookup with `#REF!` on out-of-bounds. Clones values (Text clone cost noted as accepted tech debt for Phase 10).
- `Prelude::empty()` — Phase 4 stub, ready for Phase 7/8 to fill with aggregates/lookups.
- `topo_sort` — Kahn's algorithm with deterministic tie-breaking (sorted initial queue). Cycle → `CircularReference` error.
- 20 unit tests + 11 doctests

## Design decisions

- **Interpreter holds `&Prelude`** even though unused — avoids signature change in Phase 7
- **Cell ref ignores row component** — classifier guaranteed same-row. Eval uses `scope.get(col)` only.
- **Cell-level errors for unsupported constructs** — `Value::Error(CellError::Value)`, not `XlStreamError`. Per errors.md: one bad formula doesn't abort 400k rows.
- **Deterministic topo order** — initial zero-in-degree nodes sorted by column index for reproducible output

## Test plan

- [x] `make check` passes (274 total workspace tests)
- [x] 9 interpreter tests: all literal types, cell ref, out-of-bounds, function/binary/unary stubs
- [x] 7 topo sort tests: linear chain, diamond, cycle, independent, single column, data-only deps, self-ref
- [x] 3 scope tests: valid lookup, out-of-bounds, col-zero guard
- [x] 1 prelude test: empty constructor
- [ ] Review: Interpreter match arms cover all 15 NodeView variants
- [ ] Review: topo_sort handles formula-to-data edges correctly (ignored)