### PR TITLE
xlstream-eval: add evaluate() pipeline driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,8 @@ dependencies = [
 name = "xlstream-eval"
 version = "0.1.0"
 dependencies = [
+ "rust_xlsxwriter",
+ "tempfile",
  "tracing",
  "xlstream-core",
  "xlstream-io",

--- a/crates/xlstream-core/src/address.rs
+++ b/crates/xlstream-core/src/address.rs
@@ -1,0 +1,22 @@
+/// Convert 1-based column and row numbers to A1 notation (e.g. col=3, row=2 → "C2").
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::col_row_to_a1;
+/// assert_eq!(col_row_to_a1(1, 1), "A1");
+/// assert_eq!(col_row_to_a1(3, 5), "C5");
+/// assert_eq!(col_row_to_a1(27, 1), "AA1");
+/// ```
+#[must_use]
+pub fn col_row_to_a1(col: u32, row: u32) -> String {
+    let mut letters = String::new();
+    let mut c = col;
+    while c > 0 {
+        c -= 1;
+        let ch = char::from(b'A' + u8::try_from(c % 26).unwrap_or(0));
+        letters.insert(0, ch);
+        c /= 26;
+    }
+    format!("{letters}{row}")
+}

--- a/crates/xlstream-core/src/lib.rs
+++ b/crates/xlstream-core/src/lib.rs
@@ -21,11 +21,13 @@
 )]
 #![allow(clippy::module_name_repetitions, clippy::cargo_common_metadata)]
 
+mod address;
 mod cell_error;
 mod date;
 mod error;
 mod value;
 
+pub use address::col_row_to_a1;
 pub use cell_error::CellError;
 pub use date::ExcelDate;
 pub use error::XlStreamError;

--- a/crates/xlstream-eval/Cargo.toml
+++ b/crates/xlstream-eval/Cargo.toml
@@ -17,6 +17,11 @@ xlstream-parse = { path = "../xlstream-parse", version = "0.1.0" }
 xlstream-io = { path = "../xlstream-io", version = "0.1.0" }
 tracing.workspace = true
 
+[dev-dependencies]
+tempfile = { workspace = true }
+rust_xlsxwriter = { workspace = true }
+
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
+cargo_common_metadata = "allow"

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Instant;
 
-use xlstream_core::{Value, XlStreamError};
+use xlstream_core::{col_row_to_a1, Value, XlStreamError};
 use xlstream_io::{Reader, Writer};
 use xlstream_parse::{
     classify, extract_references, parse, Ast, Classification, ClassificationContext, Reference,
@@ -199,20 +199,6 @@ fn build_eval_plan(
     Ok((topo_order, col_asts))
 }
 
-/// Convert 1-based column + row to A1 notation (e.g. col=3, row=2 → "C2").
-#[must_use]
-fn col_row_to_a1(col: u32, row: u32) -> String {
-    let mut letters = String::new();
-    let mut c = col;
-    while c > 0 {
-        c -= 1;
-        let ch = char::from(b'A' + u8::try_from(c % 26).unwrap_or(0));
-        letters.insert(0, ch);
-        c /= 26;
-    }
-    format!("{letters}{row}")
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -225,19 +211,6 @@ mod tests {
         assert_eq!(s.rows_processed, 0);
         assert_eq!(s.formulas_evaluated, 0);
         assert_eq!(s.duration, std::time::Duration::ZERO);
-    }
-
-    #[test]
-    fn col_row_to_a1_single_letter() {
-        assert_eq!(col_row_to_a1(1, 1), "A1");
-        assert_eq!(col_row_to_a1(3, 5), "C5");
-        assert_eq!(col_row_to_a1(26, 1), "Z1");
-    }
-
-    #[test]
-    fn col_row_to_a1_two_letters() {
-        assert_eq!(col_row_to_a1(27, 1), "AA1");
-        assert_eq!(col_row_to_a1(28, 2), "AB2");
     }
 
     #[test]

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -1,12 +1,21 @@
-//! The [`evaluate`] entry point and [`EvaluateSummary`] return type. Phase
-//! 1 stubs only; real streaming logic lands in Phase 4.
+//! The [`evaluate`] entry point and [`EvaluateSummary`] return type.
 
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::time::Instant;
 
-use xlstream_core::XlStreamError;
+use xlstream_core::{Value, XlStreamError};
+use xlstream_io::{Reader, Writer};
+use xlstream_parse::{
+    classify, extract_references, parse, Ast, Classification, ClassificationContext, Reference,
+};
 
-/// Summary of a completed evaluation. Returned by [`evaluate`] once the
-/// whole workbook has been streamed through.
+use crate::interp::Interpreter;
+use crate::prelude::Prelude;
+use crate::scope::RowScope;
+use crate::topo::topo_sort;
+
+/// Summary of a completed evaluation run.
 ///
 /// # Examples
 ///
@@ -14,69 +23,227 @@ use xlstream_core::XlStreamError;
 /// use xlstream_eval::EvaluateSummary;
 /// let s = EvaluateSummary::default();
 /// assert_eq!(s.rows_processed, 0);
+/// assert_eq!(s.formulas_evaluated, 0);
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EvaluateSummary {
-    /// Number of rows processed across every sheet (sum).
-    pub rows_processed: u32,
-    /// Wall-clock duration of the evaluation, in milliseconds.
-    pub duration_ms: u64,
-    /// Peak resident-set size observed during the run, in bytes.
-    pub peak_rss_bytes: u64,
+    /// Total rows written across all sheets (including header rows).
+    pub rows_processed: u64,
+    /// Total formula cells evaluated.
+    pub formulas_evaluated: u64,
+    /// Wall-clock duration of the full evaluation run.
+    pub duration: std::time::Duration,
 }
 
-/// Evaluate every formula in `input`, write the results to `output`, and
-/// return an [`EvaluateSummary`].
+/// Evaluate every formula in `input`, write results to `output`, and return
+/// an [`EvaluateSummary`].
 ///
-/// `workers` selects the level of row-level parallelism: `None` lets the
-/// engine auto-choose (typically the rayon global pool); `Some(n)` pins
-/// to `n` workers. Phase 1 ignores the argument; Phase 10 wires it up.
+/// Finds the first sheet that contains formulas, classifies them, builds an
+/// intra-row topo evaluation order, then streams rows through the interpreter
+/// and writes results. All other sheets are copied verbatim.
+///
+/// `workers` is reserved for Phase 10 row parallelism; currently ignored.
 ///
 /// # Errors
 ///
-/// Phase 1: always [`XlStreamError::Internal`]. Phase 4 onward: any of the
-/// library-level error variants.
+/// - [`XlStreamError::Xlsx`] if `input` cannot be opened or parsed.
+/// - [`XlStreamError::XlsxWrite`] if `output` cannot be written.
+/// - [`XlStreamError::FormulaParse`] if a formula cannot be parsed.
+/// - [`XlStreamError::Unsupported`] if a formula cannot be streamed.
+/// - [`XlStreamError::CircularReference`] if formula columns form a cycle.
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use std::path::Path;
 /// use xlstream_eval::evaluate;
-/// let err = evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), None).unwrap_err();
-/// assert!(err.to_string().contains("unimplemented"));
+/// let err = evaluate(Path::new("missing.xlsx"), Path::new("out.xlsx"), None).unwrap_err();
+/// assert!(matches!(err, xlstream_core::XlStreamError::Xlsx(_)));
 /// ```
 #[must_use = "evaluation results must be inspected for errors"]
 pub fn evaluate(
-    _input: &Path,
-    _output: &Path,
+    input: &Path,
+    output: &Path,
     _workers: Option<usize>,
 ) -> Result<EvaluateSummary, XlStreamError> {
-    tracing::trace!("xlstream-eval::evaluate stub called");
-    Err(XlStreamError::Internal("unimplemented: evaluate — lands in Phase 4".into()))
+    let start = Instant::now();
+
+    let mut reader = Reader::open(input)?;
+    let sheet_names = reader.sheet_names();
+
+    // Find first sheet with formulas.
+    let mut main_sheet: Option<String> = None;
+    let mut main_formulas: Vec<(u32, u32, String)> = Vec::new();
+    for name in &sheet_names {
+        let formulas = reader.formulas(name)?;
+        if !formulas.is_empty() {
+            main_sheet = Some(name.clone());
+            main_formulas = formulas;
+            break;
+        }
+    }
+
+    // Parse + classify formula columns; build topo order.
+    let (topo_order, col_asts) = if let Some(ref main) = main_sheet {
+        build_eval_plan(main, &main_formulas)?
+    } else {
+        (Vec::new(), HashMap::new())
+    };
+
+    let prelude = Prelude::empty();
+    let interp = Interpreter::new(&prelude);
+    let mut writer = Writer::create(output)?;
+    let mut rows_processed: u64 = 0;
+    let mut formulas_evaluated: u64 = 0;
+
+    for name in &sheet_names {
+        let mut sh = writer.add_sheet(name)?;
+        let mut stream = reader.cells(name)?;
+        let is_main = main_sheet.as_deref() == Some(name.as_str());
+        let mut header_pending = is_main;
+
+        while let Some((row_idx, mut row_values)) = stream.next_row()? {
+            if header_pending {
+                // First row of the main sheet is headers — write verbatim.
+                sh.write_row(row_idx, &row_values)?;
+                header_pending = false;
+                rows_processed += 1;
+                continue;
+            }
+
+            if is_main {
+                for &fcol in &topo_order {
+                    let Some(ast) = col_asts.get(&fcol) else {
+                        continue;
+                    };
+                    let fcol_idx = fcol as usize;
+                    if fcol_idx >= row_values.len() {
+                        row_values.resize(fcol_idx + 1, Value::Empty);
+                    }
+                    // Inner block ensures the immutable borrow of row_values
+                    // through RowScope is released before the mutation below.
+                    let result = {
+                        let scope = RowScope::new(&row_values, row_idx);
+                        interp.eval(ast.root(), &scope)
+                    };
+                    row_values[fcol_idx] = result;
+                    formulas_evaluated += 1;
+                }
+            }
+
+            sh.write_row(row_idx, &row_values)?;
+            rows_processed += 1;
+        }
+
+        drop(sh);
+    }
+
+    writer.finish()?;
+
+    Ok(EvaluateSummary { rows_processed, formulas_evaluated, duration: start.elapsed() })
+}
+
+/// Parse + classify all formula columns for `main_sheet`. Returns the
+/// topo-sorted column evaluation order and the per-column [`Ast`] cache.
+fn build_eval_plan(
+    main_sheet: &str,
+    all_formulas: &[(u32, u32, String)],
+) -> Result<(Vec<u32>, HashMap<u32, Ast>), XlStreamError> {
+    // First occurrence per column (0-based col → (0-based row, formula text)).
+    let mut col_formula: HashMap<u32, (u32, String)> = HashMap::new();
+    for (row, col, text) in all_formulas {
+        col_formula.entry(*col).or_insert_with(|| (*row, text.clone()));
+    }
+
+    let mut col_asts: HashMap<u32, Ast> = HashMap::new();
+    for (&col, (row, text)) in &col_formula {
+        // calamine strips the leading '='; strip defensively to handle either.
+        let formula_str = text.strip_prefix('=').unwrap_or(text.as_str());
+        let ast = parse(formula_str)?;
+
+        // Classify at first-occurrence position (convert 0-based to 1-based).
+        let ctx = ClassificationContext::for_cell(main_sheet, row + 1, col + 1);
+        if let Classification::Unsupported(ref reason) = classify(&ast, &ctx) {
+            return Err(XlStreamError::Unsupported {
+                address: format!("{}!{}", main_sheet, col_row_to_a1(col + 1, row + 1)),
+                formula: text.clone(),
+                reason: reason.to_string(),
+                doc_link: reason.doc_link(),
+            });
+        }
+        col_asts.insert(col, ast);
+    }
+
+    // Build intra-row dependency graph; extract formula-column-to-formula-column edges.
+    let formula_cols: HashSet<u32> = col_asts.keys().copied().collect();
+    let deps: Vec<(u32, Vec<u32>)> = col_asts
+        .iter()
+        .map(|(&col, ast)| {
+            let refs = extract_references(ast);
+            let dep_cols: Vec<u32> = refs
+                .cells
+                .iter()
+                .filter_map(|r| match r {
+                    Reference::Cell { col: ref_col, .. } => {
+                        // Convert 1-based reference to 0-based column index.
+                        Some(ref_col.saturating_sub(1))
+                    }
+                    _ => None,
+                })
+                .collect();
+            (col, dep_cols)
+        })
+        .collect();
+
+    let topo_order = topo_sort(&deps, &formula_cols)?;
+    Ok((topo_order, col_asts))
+}
+
+/// Convert 1-based column + row to A1 notation (e.g. col=3, row=2 → "C2").
+#[must_use]
+fn col_row_to_a1(col: u32, row: u32) -> String {
+    let mut letters = String::new();
+    let mut c = col;
+    while c > 0 {
+        c -= 1;
+        let ch = char::from(b'A' + u8::try_from(c % 26).unwrap_or(0));
+        letters.insert(0, ch);
+        c /= 26;
+    }
+    format!("{letters}{row}")
 }
 
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-    use std::path::Path;
-
     use super::*;
 
     #[test]
-    fn evaluate_returns_unimplemented_internal_error() {
-        let err = evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), None).unwrap_err();
-        assert!(
-            matches!(err, xlstream_core::XlStreamError::Internal(ref msg) if msg.contains("unimplemented")),
-            "expected Internal(unimplemented...), got {err:?}",
-        );
+    fn summary_default_fields_are_zero() {
+        let s = EvaluateSummary::default();
+        assert_eq!(s.rows_processed, 0);
+        assert_eq!(s.formulas_evaluated, 0);
+        assert_eq!(s.duration, std::time::Duration::ZERO);
     }
 
     #[test]
-    fn summary_fields_default_to_zero() {
-        let s = EvaluateSummary::default();
-        assert_eq!(s.rows_processed, 0);
-        assert_eq!(s.duration_ms, 0);
-        assert_eq!(s.peak_rss_bytes, 0);
+    fn col_row_to_a1_single_letter() {
+        assert_eq!(col_row_to_a1(1, 1), "A1");
+        assert_eq!(col_row_to_a1(3, 5), "C5");
+        assert_eq!(col_row_to_a1(26, 1), "Z1");
+    }
+
+    #[test]
+    fn col_row_to_a1_two_letters() {
+        assert_eq!(col_row_to_a1(27, 1), "AA1");
+        assert_eq!(col_row_to_a1(28, 2), "AB2");
+    }
+
+    #[test]
+    fn evaluate_nonexistent_file_returns_xlsx_error() {
+        let err = evaluate(Path::new("this_file_does_not_exist.xlsx"), Path::new("out.xlsx"), None)
+            .unwrap_err();
+        assert!(matches!(err, XlStreamError::Xlsx(_)), "expected Xlsx error, got {err:?}");
     }
 }

--- a/crates/xlstream-eval/tests/eval_end_to_end.rs
+++ b/crates/xlstream-eval/tests/eval_end_to_end.rs
@@ -1,0 +1,139 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::float_cmp,
+    clippy::cast_precision_loss,
+    clippy::needless_range_loop
+)]
+
+mod helpers;
+
+use xlstream_core::{Value, XlStreamError};
+use xlstream_eval::evaluate;
+use xlstream_io::Reader;
+
+fn read_all_rows(reader: &mut Reader, sheet: &str) -> Vec<(u32, Vec<Value>)> {
+    let mut stream = reader.cells(sheet).unwrap();
+    let mut rows = Vec::new();
+    while let Some(row) = stream.next_row().unwrap() {
+        rows.push(row);
+    }
+    rows
+}
+
+// ---------------------------------------------------------------------------
+// Cell reference resolution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cell_ref_formula_resolves_to_col_a_value() {
+    let input = helpers::generate_cell_ref_fixture(3);
+    let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+
+    let summary = evaluate(input.path(), output.path(), None).unwrap();
+    // 1 header + 3 data rows
+    assert_eq!(summary.rows_processed, 4, "rows_processed mismatch");
+    // 3 rows × 1 formula column
+    assert_eq!(summary.formulas_evaluated, 3, "formulas_evaluated mismatch");
+
+    let mut reader = Reader::open(output.path()).unwrap();
+    let rows = read_all_rows(&mut reader, "Sheet1");
+    assert_eq!(rows.len(), 4);
+
+    // Header row unchanged.
+    assert_eq!(rows[0].0, 0);
+    assert_eq!(rows[0].1[0], Value::Text("A".into()));
+    assert_eq!(rows[0].1[2], Value::Text("C".into()));
+
+    // Data rows: col C (index 2) must equal col A (index 0).
+    for i in 1..=3usize {
+        assert_eq!(rows[i].1[2], rows[i].1[0], "row {i}: col C should equal col A");
+        assert_eq!(rows[i].1[0], Value::Number(i as f64 * 10.0), "row {i}: col A value mismatch");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Chained formula columns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chained_formula_cols_resolve_in_order() {
+    let input = helpers::generate_chained_formula_fixture(3);
+    let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+
+    let summary = evaluate(input.path(), output.path(), None).unwrap();
+    assert!(summary.rows_processed > 0);
+    // 3 rows × 2 formula columns
+    assert_eq!(summary.formulas_evaluated, 6, "formulas_evaluated mismatch");
+
+    let mut reader = Reader::open(output.path()).unwrap();
+    let rows = read_all_rows(&mut reader, "Sheet1");
+
+    for i in 1..=3usize {
+        let expected = Value::Number(i as f64 * 10.0);
+        // col C = =A{row} → should equal col A
+        assert_eq!(rows[i].1[2], expected, "row {i}: col C mismatch");
+        // col D = =C{row} → should equal col C = col A
+        assert_eq!(rows[i].1[3], expected, "row {i}: col D mismatch");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// No-formula passthrough
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_formula_sheet_passes_through_unchanged() {
+    let input = helpers::generate_no_formula_fixture(3);
+    let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+
+    evaluate(input.path(), output.path(), None).unwrap();
+
+    let mut reader = Reader::open(output.path()).unwrap();
+    let rows = read_all_rows(&mut reader, "Sheet1");
+    assert_eq!(rows.len(), 3);
+    for (i, (_, row)) in rows.iter().enumerate() {
+        assert_eq!(row[0], Value::Number((i + 1) as f64));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn evaluate_nonexistent_input_returns_xlsx_error() {
+    let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let err = evaluate(
+        std::path::Path::new("nonexistent_file_that_does_not_exist.xlsx"),
+        output.path(),
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(err, XlStreamError::Xlsx(_)), "expected Xlsx error, got {err:?}");
+}
+
+#[test]
+fn unsupported_formula_returns_unsupported_error() {
+    let input = helpers::generate_unsupported_formula_fixture();
+    let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let err = evaluate(input.path(), output.path(), None).unwrap_err();
+    assert!(
+        matches!(err, XlStreamError::Unsupported { .. }),
+        "expected Unsupported error, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// EvaluateSummary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_duration_is_nonzero_after_real_eval() {
+    let input = helpers::generate_cell_ref_fixture(5);
+    let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+    let summary = evaluate(input.path(), output.path(), None).unwrap();
+    // Duration should be at least 1 ns for any real I/O.
+    assert!(summary.duration.as_nanos() > 0, "duration should be nonzero after evaluation");
+}

--- a/crates/xlstream-eval/tests/helpers/mod.rs
+++ b/crates/xlstream-eval/tests/helpers/mod.rs
@@ -1,0 +1,119 @@
+//! Shared fixture generators for xlstream-eval integration tests.
+//!
+//! Uses raw `rust_xlsxwriter::Workbook` (non-constant-memory mode) so that
+//! formula cells and data cells can be written in arbitrary order within a
+//! row without triggering the row-order enforcement in `SheetHandle`.
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use rust_xlsxwriter::{Formula, Workbook};
+use tempfile::NamedTempFile;
+
+/// Generates a fixture with header row `[A, B, C]` plus `n_rows` data rows.
+///
+/// - Col A: `i * 10.0` (data)
+/// - Col B: `i * 20.0` (data)
+/// - Col C: formula `=A{excel_row}` (references col A of same row)
+///
+/// After evaluation col C should equal col A.
+#[allow(dead_code)]
+pub fn generate_cell_ref_fixture(n_rows: usize) -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    // Header row (calamine row 0 = Excel row 1).
+    ws.write_string(0, 0, "A").unwrap();
+    ws.write_string(0, 1, "B").unwrap();
+    ws.write_string(0, 2, "C").unwrap();
+
+    for i in 0..n_rows {
+        let row = (i + 1) as u32; // calamine 0-based row index; row 0 is headers
+        let a_val = (i + 1) as f64 * 10.0;
+        let b_val = (i + 1) as f64 * 20.0;
+        // Excel row number = calamine row + 1 (Excel is 1-based).
+        // Formula in calamine row `row` should reference Excel row `row+1`.
+        let formula = format!("=A{}", row + 1);
+
+        ws.write_number(row, 0, a_val).unwrap();
+        ws.write_number(row, 1, b_val).unwrap();
+        ws.write_formula(row, 2, Formula::new(&formula).set_result(a_val.to_string())).unwrap();
+    }
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}
+
+/// Fixture with two chained formula columns.
+///
+/// Header `[A, B, C, D]`. Col C = `=A{row}`, col D = `=C{row}`.
+/// After evaluation: C = A, D = A (D resolves through C).
+#[allow(dead_code)]
+pub fn generate_chained_formula_fixture(n_rows: usize) -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    ws.write_string(0, 0, "A").unwrap();
+    ws.write_string(0, 1, "B").unwrap();
+    ws.write_string(0, 2, "C").unwrap();
+    ws.write_string(0, 3, "D").unwrap();
+
+    for i in 0..n_rows {
+        let row = (i + 1) as u32;
+        let a_val = (i + 1) as f64 * 10.0;
+        let excel_row = row + 1;
+
+        ws.write_number(row, 0, a_val).unwrap();
+        ws.write_number(row, 1, a_val * 2.0).unwrap();
+        ws.write_formula(
+            row,
+            2,
+            Formula::new(format!("=A{excel_row}")).set_result(a_val.to_string()),
+        )
+        .unwrap();
+        ws.write_formula(
+            row,
+            3,
+            Formula::new(format!("=C{excel_row}")).set_result(a_val.to_string()),
+        )
+        .unwrap();
+    }
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}
+
+/// Fixture with no formula cells — plain data only.
+///
+/// Single sheet, `n_rows` rows, one column: values `1.0, 2.0, ...`.
+#[allow(dead_code)]
+pub fn generate_no_formula_fixture(n_rows: usize) -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    for i in 0..n_rows {
+        ws.write_number(i as u32, 0, (i + 1) as f64).unwrap();
+    }
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}
+
+/// Fixture with an unsupported formula (`OFFSET`, which is refused at
+/// classification time).
+#[allow(dead_code)]
+pub fn generate_unsupported_formula_fixture() -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    ws.write_string(0, 0, "A").unwrap();
+    ws.write_string(0, 1, "B").unwrap();
+    // Row 1: col B has OFFSET, which is unsupported.
+    ws.write_number(1, 0, 10.0).unwrap();
+    ws.write_formula(1, 1, Formula::new("=OFFSET(A1,0,0)").set_result("10")).unwrap();
+
+    wb.save(tmp.path()).unwrap();
+    tmp
+}


### PR DESCRIPTION
## Problem
The evaluate() entry point existed as a stub — no pipeline logic, no formula eval, and EvaluateSummary was missing key fields.

## Solution
Wire the full read → classify → topo sort → stream rows → eval → write pipeline, backed by end-to-end integration tests.

## Changes
- Rewrite `EvaluateSummary`: replace placeholder fields with `rows_processed`, `formulas_evaluated`, `duration`
- Implement `evaluate()`: find first formula sheet, build eval plan, stream all sheets through writer, eval formula cols in topo order per row
- Add `build_eval_plan()`: dedupe formulas by column, parse, classify, extract intra-row deps, topo sort
- Add `col_row_to_a1()` helper for `Unsupported` error addresses
- Add integration tests: cell refs, chained formulas, passthrough, error cases, summary fields
- Add fixture generators in `tests/helpers`

## Test plan
- [x] `make check` passes (fmt + clippy + all tests + doctests)
- [x] Cell ref resolution: col C = `=A{row}` evaluates to col A value
- [x] Chained formulas: col D = `=C{row}` chains through col C to col A
- [x] No-formula sheet passes through unchanged
- [x] Missing input → `XlStreamError::Xlsx`
- [x] OFFSET formula → `XlStreamError::Unsupported`