### PR TITLE
xlstream-eval: add bounded range expansion for IRR, NPV, CONCAT, TEXTJOIN, NETWORKDAYS, WORKDAY

### DIFF
--- a/crates/xlstream-eval/src/builtins/date.rs
+++ b/crates/xlstream-eval/src/builtins/date.rs
@@ -342,23 +342,37 @@ pub(crate) fn builtin_datedif(args: &[Value]) -> Value {
 }
 
 /// `NETWORKDAYS(start, end, holidays?)` — count working days between
-/// start and end (inclusive), skipping weekends.
+/// start and end (inclusive), skipping weekends and holidays (stateful).
 ///
-/// v0.1: holidays argument is accepted but ignored with a warning.
-pub(crate) fn builtin_networkdays(args: &[Value]) -> Value {
+/// The optional 3rd arg is expanded via `expand_range` to collect
+/// holiday date serials.
+pub(crate) fn builtin_networkdays(
+    args: &[NodeRef<'_>],
+    interp: &Interpreter<'_>,
+    scope: &RowScope<'_>,
+) -> Value {
     if args.len() < 2 || args.len() > 3 {
         return Value::Error(CellError::Value);
     }
-    let start_serial = match date_serial(&args[0]) {
+    let start_val = interp.eval(args[0], scope);
+    let start_serial = match date_serial(&start_val) {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let end_serial = match date_serial(&args[1]) {
+    let end_val = interp.eval(args[1], scope);
+    let end_serial = match date_serial(&end_val) {
         Ok(s) => s,
         Err(e) => return e,
     };
+
+    let mut holidays = std::collections::HashSet::new();
     if args.len() == 3 {
-        tracing::warn!("NETWORKDAYS: holidays argument ignored in v0.1");
+        for v in super::expand_range(args[2], interp, scope) {
+            if let Ok(s) = date_serial(&v) {
+                #[allow(clippy::cast_possible_truncation)]
+                holidays.insert(s.floor() as i64);
+            }
+        }
     }
 
     #[allow(clippy::cast_possible_truncation)]
@@ -373,7 +387,7 @@ pub(crate) fn builtin_networkdays(args: &[Value]) -> Value {
         #[allow(clippy::cast_precision_loss)]
         let wd = ExcelDate::from_serial(day as f64).weekday();
         // 0=Sun, 6=Sat — skip weekends
-        if wd != 0 && wd != 6 {
+        if wd != 0 && wd != 6 && !holidays.contains(&day) {
             count += 1;
         }
     }
@@ -382,18 +396,26 @@ pub(crate) fn builtin_networkdays(args: &[Value]) -> Value {
     Value::Number((count * sign) as f64)
 }
 
-/// `WORKDAY(start, days, holidays?)` — date after N working days.
+/// `WORKDAY(start, days, holidays?)` — date after N working days
+/// (stateful).
 ///
-/// v0.1: holidays argument is accepted but ignored with a warning.
-pub(crate) fn builtin_workday(args: &[Value]) -> Value {
+/// The optional 3rd arg is expanded via `expand_range` to collect
+/// holiday date serials.
+pub(crate) fn builtin_workday(
+    args: &[NodeRef<'_>],
+    interp: &Interpreter<'_>,
+    scope: &RowScope<'_>,
+) -> Value {
     if args.len() < 2 || args.len() > 3 {
         return Value::Error(CellError::Value);
     }
-    let start_serial = match date_serial(&args[0]) {
+    let start_val = interp.eval(args[0], scope);
+    let start_serial = match date_serial(&start_val) {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let work_days = match coerce::to_number(&args[1]) {
+    let days_val = interp.eval(args[1], scope);
+    let work_days = match coerce::to_number(&days_val) {
         Ok(n) => {
             #[allow(clippy::cast_possible_truncation)]
             let d = n as i64;
@@ -401,8 +423,15 @@ pub(crate) fn builtin_workday(args: &[Value]) -> Value {
         }
         Err(e) => return Value::Error(e),
     };
+
+    let mut holidays = std::collections::HashSet::new();
     if args.len() == 3 {
-        tracing::warn!("WORKDAY: holidays argument ignored in v0.1");
+        for v in super::expand_range(args[2], interp, scope) {
+            if let Ok(s) = date_serial(&v) {
+                #[allow(clippy::cast_possible_truncation)]
+                holidays.insert(s.floor() as i64);
+            }
+        }
     }
 
     #[allow(clippy::cast_possible_truncation)]
@@ -414,7 +443,7 @@ pub(crate) fn builtin_workday(args: &[Value]) -> Value {
         current += step;
         #[allow(clippy::cast_precision_loss)]
         let wd = ExcelDate::from_serial(current as f64).weekday();
-        if wd != 0 && wd != 6 {
+        if wd != 0 && wd != 6 && !holidays.contains(&current) {
             remaining -= 1;
         }
     }
@@ -888,63 +917,54 @@ mod tests {
 
     // ===== NETWORKDAYS =====
 
+    /// Helper: evaluate a formula string using the interpreter and return result.
+    fn eval_formula(formula: &str) -> Value {
+        let prelude = crate::Prelude::empty();
+        let interp = crate::Interpreter::new(&prelude);
+        let ast = xlstream_parse::parse(formula).unwrap();
+        let scope = crate::RowScope::new(&[], 1);
+        interp.eval(ast.root(), &scope)
+    }
+
     #[test]
     fn networkdays_one_week() {
         // Mon Jan 5, 2026 to Fri Jan 9, 2026 = 5 working days
-        let start = ExcelDate::from_ymd(2026, 1, 5);
-        let end = ExcelDate::from_ymd(2026, 1, 9);
-        assert_eq!(
-            builtin_networkdays(&[Value::Date(start), Value::Date(end)]),
-            Value::Number(5.0)
-        );
+        let start = ExcelDate::from_ymd(2026, 1, 5).serial;
+        let end = ExcelDate::from_ymd(2026, 1, 9).serial;
+        let result = eval_formula(&format!("NETWORKDAYS({start},{end})"));
+        assert_eq!(result, Value::Number(5.0));
     }
 
     #[test]
     fn networkdays_includes_weekends() {
         // Mon Jan 5 to Mon Jan 12 = 6 working days (skip Sat+Sun)
-        let start = ExcelDate::from_ymd(2026, 1, 5);
-        let end = ExcelDate::from_ymd(2026, 1, 12);
-        assert_eq!(
-            builtin_networkdays(&[Value::Date(start), Value::Date(end)]),
-            Value::Number(6.0)
-        );
+        let start = ExcelDate::from_ymd(2026, 1, 5).serial;
+        let end = ExcelDate::from_ymd(2026, 1, 12).serial;
+        let result = eval_formula(&format!("NETWORKDAYS({start},{end})"));
+        assert_eq!(result, Value::Number(6.0));
     }
 
     #[test]
     fn networkdays_same_day_weekday() {
-        let mon = ExcelDate::from_ymd(2026, 1, 5);
-        assert_eq!(builtin_networkdays(&[Value::Date(mon), Value::Date(mon)]), Value::Number(1.0));
+        let mon = ExcelDate::from_ymd(2026, 1, 5).serial;
+        let result = eval_formula(&format!("NETWORKDAYS({mon},{mon})"));
+        assert_eq!(result, Value::Number(1.0));
     }
 
     #[test]
     fn networkdays_same_day_weekend() {
         // Jan 3, 2026 = Saturday
-        let sat = ExcelDate::from_ymd(2026, 1, 3);
-        assert_eq!(builtin_networkdays(&[Value::Date(sat), Value::Date(sat)]), Value::Number(0.0));
-    }
-
-    #[test]
-    fn networkdays_wrong_arg_count() {
-        assert_eq!(builtin_networkdays(&[Value::Number(44927.0)]), Value::Error(CellError::Value));
-    }
-
-    #[test]
-    fn networkdays_error_propagation() {
-        assert_eq!(
-            builtin_networkdays(&[Value::Error(CellError::Na), Value::Number(44927.0)]),
-            Value::Error(CellError::Na)
-        );
+        let sat = ExcelDate::from_ymd(2026, 1, 3).serial;
+        let result = eval_formula(&format!("NETWORKDAYS({sat},{sat})"));
+        assert_eq!(result, Value::Number(0.0));
     }
 
     #[test]
     fn networkdays_reverse_order_negative() {
-        // Reversed: end < start yields negative count
-        let start = ExcelDate::from_ymd(2026, 1, 9);
-        let end = ExcelDate::from_ymd(2026, 1, 5);
-        assert_eq!(
-            builtin_networkdays(&[Value::Date(start), Value::Date(end)]),
-            Value::Number(-5.0)
-        );
+        let start = ExcelDate::from_ymd(2026, 1, 9).serial;
+        let end = ExcelDate::from_ymd(2026, 1, 5).serial;
+        let result = eval_formula(&format!("NETWORKDAYS({start},{end})"));
+        assert_eq!(result, Value::Number(-5.0));
     }
 
     // ===== WORKDAY =====
@@ -952,8 +972,8 @@ mod tests {
     #[test]
     fn workday_positive_days() {
         // Mon Jan 5, 2026 + 5 working days = Mon Jan 12
-        let start = ExcelDate::from_ymd(2026, 1, 5);
-        let result = builtin_workday(&[Value::Date(start), Value::Number(5.0)]);
+        let start = ExcelDate::from_ymd(2026, 1, 5).serial;
+        let result = eval_formula(&format!("WORKDAY({start},5)"));
         if let Value::Date(d) = result {
             assert_eq!(d.year_month_day(), (2026, 1, 12));
         } else {
@@ -964,8 +984,8 @@ mod tests {
     #[test]
     fn workday_negative_days() {
         // Mon Jan 12, 2026 - 5 working days = Mon Jan 5
-        let start = ExcelDate::from_ymd(2026, 1, 12);
-        let result = builtin_workday(&[Value::Date(start), Value::Number(-5.0)]);
+        let start = ExcelDate::from_ymd(2026, 1, 12).serial;
+        let result = eval_formula(&format!("WORKDAY({start},-5)"));
         if let Value::Date(d) = result {
             assert_eq!(d.year_month_day(), (2026, 1, 5));
         } else {
@@ -975,8 +995,8 @@ mod tests {
 
     #[test]
     fn workday_zero_days() {
-        let start = ExcelDate::from_ymd(2026, 1, 5);
-        let result = builtin_workday(&[Value::Date(start), Value::Number(0.0)]);
+        let start = ExcelDate::from_ymd(2026, 1, 5).serial;
+        let result = eval_formula(&format!("WORKDAY({start},0)"));
         if let Value::Date(d) = result {
             assert_eq!(d.year_month_day(), (2026, 1, 5));
         } else {
@@ -987,26 +1007,13 @@ mod tests {
     #[test]
     fn workday_skips_weekends() {
         // Fri Jan 9, 2026 + 1 working day = Mon Jan 12
-        let start = ExcelDate::from_ymd(2026, 1, 9);
-        let result = builtin_workday(&[Value::Date(start), Value::Number(1.0)]);
+        let start = ExcelDate::from_ymd(2026, 1, 9).serial;
+        let result = eval_formula(&format!("WORKDAY({start},1)"));
         if let Value::Date(d) = result {
             assert_eq!(d.year_month_day(), (2026, 1, 12));
         } else {
             panic!("expected Date, got {result:?}");
         }
-    }
-
-    #[test]
-    fn workday_wrong_arg_count() {
-        assert_eq!(builtin_workday(&[Value::Number(44927.0)]), Value::Error(CellError::Value));
-    }
-
-    #[test]
-    fn workday_error_propagation() {
-        assert_eq!(
-            builtin_workday(&[Value::Error(CellError::Div0), Value::Number(1.0)]),
-            Value::Error(CellError::Div0)
-        );
     }
 
     // ===== date_serial helper =====

--- a/crates/xlstream-eval/src/builtins/financial.rs
+++ b/crates/xlstream-eval/src/builtins/financial.rs
@@ -1,9 +1,14 @@
 //! Financial builtin functions (Phase 9, Chunk 3).
 //!
 //! Standard time-value-of-money formulas: PMT, PV, FV, NPV, IRR, RATE.
-//! All take `&[Value]` and return `Value`.
+//! Pure builtins take `&[Value]` and return `Value`.
+//! Stateful builtins (IRR, NPV) take AST nodes for range expansion.
 
 use xlstream_core::{coerce, CellError, Value};
+use xlstream_parse::NodeRef;
+
+use crate::interp::Interpreter;
+use crate::scope::RowScope;
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -208,44 +213,25 @@ pub fn builtin_fv(args: &[Value]) -> Value {
 // NPV
 // ---------------------------------------------------------------------------
 
-/// `NPV(rate, value1, value2, ...)` — net present value.
+/// Compute NPV from a rate and cashflow slice.
 ///
 /// Discounts each cashflow at `rate`, starting at period 1.
-/// Requires at least one cashflow argument.
 ///
 /// # Examples
 ///
 /// ```
 /// use xlstream_core::Value;
-/// use xlstream_eval::builtins::financial::builtin_npv;
-/// let result = builtin_npv(&[
-///     Value::Number(0.10),
-///     Value::Number(-1000.0),
-///     Value::Number(300.0),
-///     Value::Number(400.0),
-///     Value::Number(500.0),
-/// ]);
+/// use xlstream_eval::builtins::financial::npv_from_values;
+/// let result = npv_from_values(0.10, &[-1000.0, 300.0, 400.0, 500.0]);
 /// match result {
 ///     Value::Number(n) => assert!((n - (-19.12)).abs() < 1.0),
 ///     _ => panic!("expected Number"),
 /// }
 /// ```
 #[must_use]
-pub fn builtin_npv(args: &[Value]) -> Value {
-    if args.len() < 2 {
-        return Value::Error(CellError::Value);
-    }
-    let rate = match num_arg(args, 0) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
-
+pub fn npv_from_values(rate: f64, cashflows: &[f64]) -> Value {
     let mut npv = 0.0;
-    for (i, v) in args[1..].iter().enumerate() {
-        let cf = match coerce::to_number(v) {
-            Ok(n) => n,
-            Err(e) => return Value::Error(e),
-        };
+    for (i, &cf) in cashflows.iter().enumerate() {
         #[allow(clippy::cast_precision_loss)]
         let period = (i + 1) as f64;
         npv += cf / (1.0 + rate).powf(period);
@@ -253,62 +239,61 @@ pub fn builtin_npv(args: &[Value]) -> Value {
     finite_or_num(npv)
 }
 
+/// `NPV(rate, value1, value2, ...)` — net present value (stateful).
+///
+/// Evaluates the rate arg normally, then expands remaining args via
+/// `expand_range` to support bounded range references.
+pub(crate) fn builtin_npv(
+    args: &[NodeRef<'_>],
+    interp: &Interpreter<'_>,
+    scope: &RowScope<'_>,
+) -> Value {
+    if args.len() < 2 {
+        return Value::Error(CellError::Value);
+    }
+    let rate_val = interp.eval(args[0], scope);
+    let rate = match coerce::to_number(&rate_val) {
+        Ok(v) => v,
+        Err(e) => return Value::Error(e),
+    };
+
+    let mut cashflows = Vec::new();
+    for &arg in &args[1..] {
+        for v in super::expand_range(arg, interp, scope) {
+            match coerce::to_number(&v) {
+                Ok(n) => cashflows.push(n),
+                Err(e) => return Value::Error(e),
+            }
+        }
+    }
+
+    npv_from_values(rate, &cashflows)
+}
+
 // ---------------------------------------------------------------------------
 // IRR
 // ---------------------------------------------------------------------------
 
-/// `IRR(value1, value2, ..., guess?)` — internal rate of return.
+/// Compute IRR from a cashflow slice using Newton-Raphson iteration.
 ///
-/// Uses Newton-Raphson iteration (up to 100 iterations, 1e-10 threshold).
-/// All arguments except the optional last `guess` are cashflows.
-/// Default guess is 0.1.
+/// Up to 100 iterations, 1e-10 threshold. Default guess is 0.1.
 ///
 /// Returns `#NUM!` if values don't contain both positive and negative
 /// cashflows, or if the iteration doesn't converge.
-///
-/// v0.1 limitation: cashflows are flat args, not range-based.
 ///
 /// # Examples
 ///
 /// ```
 /// use xlstream_core::Value;
-/// use xlstream_eval::builtins::financial::builtin_irr;
-/// let result = builtin_irr(&[
-///     Value::Number(-1000.0),
-///     Value::Number(300.0),
-///     Value::Number(400.0),
-///     Value::Number(500.0),
-///     Value::Number(200.0),
-/// ]);
+/// use xlstream_eval::builtins::financial::irr_from_cashflows;
+/// let result = irr_from_cashflows(&[-1000.0, 300.0, 400.0, 500.0, 200.0]);
 /// match result {
 ///     Value::Number(n) => assert!((n - 0.1532).abs() < 0.01),
 ///     _ => panic!("expected Number"),
 /// }
 /// ```
 #[must_use]
-pub fn builtin_irr(args: &[Value]) -> Value {
-    if args.len() < 2 {
-        return Value::Error(CellError::Value);
-    }
-
-    // Collect all numeric args. The last arg *might* be a guess
-    // if it's provided alongside the cashflows. We treat all args
-    // as cashflows — if the user wants a custom guess, they pass
-    // it as the last arg and we detect the "guess" heuristic:
-    // actually, IRR(values, guess) in Excel takes a range + guess.
-    // In our flat model, we use a simple convention: if there are
-    // >= 3 args, the last arg could be a guess. But since we can't
-    // distinguish, we just treat all args as cashflows with default
-    // guess 0.1.
-    let mut cashflows = Vec::with_capacity(args.len());
-    for v in args {
-        let cf = match coerce::to_number(v) {
-            Ok(n) => n,
-            Err(e) => return Value::Error(e),
-        };
-        cashflows.push(cf);
-    }
-
+pub fn irr_from_cashflows(cashflows: &[f64]) -> Value {
     if cashflows.len() < 2 {
         return Value::Error(CellError::Num);
     }
@@ -350,6 +335,32 @@ pub fn builtin_irr(args: &[Value]) -> Value {
     }
 
     Value::Error(CellError::Num)
+}
+
+/// `IRR(values, guess?)` — internal rate of return (stateful).
+///
+/// Expands all args via `expand_range` to collect cashflows, then
+/// delegates to [`irr_from_cashflows`].
+pub(crate) fn builtin_irr(
+    args: &[NodeRef<'_>],
+    interp: &Interpreter<'_>,
+    scope: &RowScope<'_>,
+) -> Value {
+    if args.is_empty() {
+        return Value::Error(CellError::Value);
+    }
+
+    let mut cashflows = Vec::new();
+    for &arg in args {
+        for v in super::expand_range(arg, interp, scope) {
+            match coerce::to_number(&v) {
+                Ok(n) => cashflows.push(n),
+                Err(e) => return Value::Error(e),
+            }
+        }
+    }
+
+    irr_from_cashflows(&cashflows)
 }
 
 // ---------------------------------------------------------------------------
@@ -677,13 +688,7 @@ mod tests {
     #[test]
     fn npv_basic() {
         // NPV(0.10, -1000, 300, 400, 500) ~ -19.12
-        let result = builtin_npv(&[
-            Value::Number(0.10),
-            Value::Number(-1000.0),
-            Value::Number(300.0),
-            Value::Number(400.0),
-            Value::Number(500.0),
-        ]);
+        let result = npv_from_values(0.10, &[-1000.0, 300.0, 400.0, 500.0]);
         match result {
             Value::Number(n) => assert!((n - (-19.12)).abs() < 1.0),
             other => panic!("expected Number, got {other:?}"),
@@ -693,12 +698,7 @@ mod tests {
     #[test]
     fn npv_positive_project() {
         // NPV(0.05, -1000, 600, 600) > 0
-        let result = builtin_npv(&[
-            Value::Number(0.05),
-            Value::Number(-1000.0),
-            Value::Number(600.0),
-            Value::Number(600.0),
-        ]);
+        let result = npv_from_values(0.05, &[-1000.0, 600.0, 600.0]);
         match result {
             Value::Number(n) => assert!(n > 0.0),
             other => panic!("expected Number, got {other:?}"),
@@ -708,29 +708,11 @@ mod tests {
     #[test]
     fn npv_zero_rate() {
         // NPV(0, 100, 200, 300) = 600
-        let result = builtin_npv(&[
-            Value::Number(0.0),
-            Value::Number(100.0),
-            Value::Number(200.0),
-            Value::Number(300.0),
-        ]);
+        let result = npv_from_values(0.0, &[100.0, 200.0, 300.0]);
         match result {
             Value::Number(n) => assert!((n - 600.0).abs() < 0.01),
             other => panic!("expected Number, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn npv_error_propagation() {
-        assert_eq!(
-            builtin_npv(&[Value::Number(0.10), Value::Error(CellError::Na)]),
-            Value::Error(CellError::Na)
-        );
-    }
-
-    #[test]
-    fn npv_too_few_args() {
-        assert_eq!(builtin_npv(&[Value::Number(0.10)]), Value::Error(CellError::Value));
     }
 
     // ===== IRR =====
@@ -738,13 +720,7 @@ mod tests {
     #[test]
     fn irr_convergence() {
         // IRR(-1000, 300, 400, 500, 200) ~ 0.1532
-        let result = builtin_irr(&[
-            Value::Number(-1000.0),
-            Value::Number(300.0),
-            Value::Number(400.0),
-            Value::Number(500.0),
-            Value::Number(200.0),
-        ]);
+        let result = irr_from_cashflows(&[-1000.0, 300.0, 400.0, 500.0, 200.0]);
         match result {
             Value::Number(n) => assert!((n - 0.1532).abs() < 0.01),
             other => panic!("expected Number, got {other:?}"),
@@ -754,7 +730,7 @@ mod tests {
     #[test]
     fn irr_simple_doubling() {
         // IRR(-100, 200) = 1.0 (100% return)
-        let result = builtin_irr(&[Value::Number(-100.0), Value::Number(200.0)]);
+        let result = irr_from_cashflows(&[-100.0, 200.0]);
         match result {
             Value::Number(n) => assert!((n - 1.0).abs() < 0.01),
             other => panic!("expected Number, got {other:?}"),
@@ -763,32 +739,17 @@ mod tests {
 
     #[test]
     fn irr_no_sign_change_returns_num_error() {
-        // All positive cashflows — no valid IRR
-        assert_eq!(
-            builtin_irr(&[Value::Number(100.0), Value::Number(200.0), Value::Number(300.0)]),
-            Value::Error(CellError::Num)
-        );
+        assert_eq!(irr_from_cashflows(&[100.0, 200.0, 300.0]), Value::Error(CellError::Num));
     }
 
     #[test]
     fn irr_all_negative_returns_num_error() {
-        assert_eq!(
-            builtin_irr(&[Value::Number(-100.0), Value::Number(-200.0)]),
-            Value::Error(CellError::Num)
-        );
+        assert_eq!(irr_from_cashflows(&[-100.0, -200.0]), Value::Error(CellError::Num));
     }
 
     #[test]
-    fn irr_too_few_args() {
-        assert_eq!(builtin_irr(&[Value::Number(-100.0)]), Value::Error(CellError::Value));
-    }
-
-    #[test]
-    fn irr_error_propagation() {
-        assert_eq!(
-            builtin_irr(&[Value::Error(CellError::Na), Value::Number(100.0)]),
-            Value::Error(CellError::Na)
-        );
+    fn irr_too_few_cashflows_returns_num_error() {
+        assert_eq!(irr_from_cashflows(&[-100.0]), Value::Error(CellError::Num));
     }
 
     // ===== RATE =====

--- a/crates/xlstream-eval/src/builtins/mod.rs
+++ b/crates/xlstream-eval/src/builtins/mod.rs
@@ -28,6 +28,54 @@ fn eval_args(args: &[NodeRef<'_>], interp: &Interpreter<'_>, scope: &RowScope<'_
     args.iter().map(|a| interp.eval(*a, scope)).collect()
 }
 
+/// Expand a single AST node into a `Vec<Value>`.
+///
+/// For `RangeRef` nodes this resolves from lookup sheets or the prelude
+/// bounded range cache. For any other node it evaluates normally and
+/// returns a single-element vec.
+pub(crate) fn expand_range(
+    node: NodeRef<'_>,
+    interp: &Interpreter<'_>,
+    scope: &RowScope<'_>,
+) -> Vec<Value> {
+    use xlstream_core::CellError;
+    use xlstream_parse::NodeView;
+
+    match node.view() {
+        NodeView::RangeRef { sheet, start_row, end_row, start_col, .. } => {
+            let sc = start_col.unwrap_or(1);
+
+            // Try lookup sheet (already fully loaded).
+            if let Some(sheet_name) = sheet {
+                if let Some(ls) = interp.prelude().lookup_sheet(sheet_name) {
+                    let sr = start_row.map_or(0, |r| (r - 1) as usize);
+                    let er = end_row.map_or(ls.num_rows().saturating_sub(1), |r| (r - 1) as usize);
+                    let col = (sc - 1) as usize;
+                    return (sr..=er)
+                        .map(|r| ls.cell(r, col).cloned().unwrap_or(Value::Empty))
+                        .collect();
+                }
+            }
+
+            // Fall back to cached bounded range (main sheet).
+            if let (Some(sr), Some(er)) = (start_row, end_row) {
+                let key = crate::prelude::BoundedRangeKey {
+                    sheet: sheet.map(ToString::to_string),
+                    col: sc,
+                    start_row: sr,
+                    end_row: er,
+                };
+                if let Some(values) = interp.prelude().get_cached_range(&key) {
+                    return values.clone();
+                }
+            }
+
+            vec![Value::Error(CellError::Ref)]
+        }
+        _ => vec![interp.eval(node, scope)],
+    }
+}
+
 /// Look up `name` (case-insensitive) and call the matching builtin.
 ///
 /// Returns `None` for unknown functions — the caller decides the fallback.
@@ -73,8 +121,8 @@ pub(crate) fn dispatch(
         "EDATE" => Some(date::builtin_edate(&eval_args(args, interp, scope))),
         "EOMONTH" => Some(date::builtin_eomonth(&eval_args(args, interp, scope))),
         "DATEDIF" => Some(date::builtin_datedif(&eval_args(args, interp, scope))),
-        "NETWORKDAYS" => Some(date::builtin_networkdays(&eval_args(args, interp, scope))),
-        "WORKDAY" => Some(date::builtin_workday(&eval_args(args, interp, scope))),
+        "NETWORKDAYS" => Some(date::builtin_networkdays(args, interp, scope)),
+        "WORKDAY" => Some(date::builtin_workday(args, interp, scope)),
         // -- string builtins (pure, eager eval) --
         "LEFT" => Some(string::builtin_left(&eval_args(args, interp, scope))),
         "RIGHT" => Some(string::builtin_right(&eval_args(args, interp, scope))),
@@ -85,8 +133,8 @@ pub(crate) fn dispatch(
         "PROPER" => Some(string::builtin_proper(&eval_args(args, interp, scope))),
         "TRIM" => Some(string::builtin_trim(&eval_args(args, interp, scope))),
         "CLEAN" => Some(string::builtin_clean(&eval_args(args, interp, scope))),
-        "CONCAT" | "CONCATENATE" => Some(string::builtin_concat(&eval_args(args, interp, scope))),
-        "TEXTJOIN" => Some(string::builtin_textjoin(&eval_args(args, interp, scope))),
+        "CONCAT" | "CONCATENATE" => Some(string::builtin_concat(args, interp, scope)),
+        "TEXTJOIN" => Some(string::builtin_textjoin(args, interp, scope)),
         "FIND" => Some(string::builtin_find(&eval_args(args, interp, scope))),
         "SEARCH" => Some(string::builtin_search(&eval_args(args, interp, scope))),
         "SUBSTITUTE" => Some(string::builtin_substitute(&eval_args(args, interp, scope))),
@@ -133,8 +181,8 @@ pub(crate) fn dispatch(
         "PMT" => Some(financial::builtin_pmt(&eval_args(args, interp, scope))),
         "PV" => Some(financial::builtin_pv(&eval_args(args, interp, scope))),
         "FV" => Some(financial::builtin_fv(&eval_args(args, interp, scope))),
-        "NPV" => Some(financial::builtin_npv(&eval_args(args, interp, scope))),
-        "IRR" => Some(financial::builtin_irr(&eval_args(args, interp, scope))),
+        "NPV" => Some(financial::builtin_npv(args, interp, scope)),
+        "IRR" => Some(financial::builtin_irr(args, interp, scope)),
         "RATE" => Some(financial::builtin_rate(&eval_args(args, interp, scope))),
         _ => None,
     }

--- a/crates/xlstream-eval/src/builtins/string.rs
+++ b/crates/xlstream-eval/src/builtins/string.rs
@@ -228,48 +228,69 @@ pub(crate) fn builtin_clean(args: &[Value]) -> Value {
 // CONCAT / CONCATENATE / TEXTJOIN
 // ---------------------------------------------------------------------------
 
-/// `CONCAT(a, b, ...)` — join arguments as text. Zero args returns `#VALUE!`.
-pub(crate) fn builtin_concat(args: &[Value]) -> Value {
+/// `CONCAT(a, b, ...)` / `CONCATENATE(a, b, ...)` — join arguments as
+/// text (stateful).
+///
+/// Expands range arguments via `expand_range`. Zero args returns
+/// `#VALUE!`.
+pub(crate) fn builtin_concat(
+    args: &[xlstream_parse::NodeRef<'_>],
+    interp: &crate::interp::Interpreter<'_>,
+    scope: &crate::scope::RowScope<'_>,
+) -> Value {
     if args.is_empty() {
         return Value::Error(CellError::Value);
     }
     let mut result = String::new();
-    for v in args {
-        if let Value::Error(e) = v {
-            return Value::Error(*e);
+    for &arg in args {
+        for v in super::expand_range(arg, interp, scope) {
+            if let Value::Error(e) = v {
+                return Value::Error(e);
+            }
+            result.push_str(&coerce::to_text(&v));
         }
-        result.push_str(&coerce::to_text(v));
     }
     Value::Text(result.into())
 }
 
-/// `TEXTJOIN(delim, ignore_empty, val1, val2, ...)` — join with delimiter.
+/// `TEXTJOIN(delim, ignore_empty, val1, val2, ...)` — join with delimiter
+/// (stateful).
 ///
-/// When `ignore_empty` is true, skips both `Value::Empty` and empty
-/// strings `""`.
-pub(crate) fn builtin_textjoin(args: &[Value]) -> Value {
+/// Evaluates first 2 args normally (delim + `ignore_empty`), then expands
+/// remaining args via `expand_range`.
+pub(crate) fn builtin_textjoin(
+    args: &[xlstream_parse::NodeRef<'_>],
+    interp: &crate::interp::Interpreter<'_>,
+    scope: &crate::scope::RowScope<'_>,
+) -> Value {
     if args.len() < 3 {
         return Value::Error(CellError::Value);
     }
-    let delim = match text_arg(args, 0) {
-        Ok(s) => s.into_owned(),
-        Err(e) => return e,
-    };
-    let ignore_empty = match coerce::to_bool(&args[1]) {
+    let delim_val = interp.eval(args[0], scope);
+    if let Value::Error(e) = &delim_val {
+        return Value::Error(*e);
+    }
+    let delim = coerce::to_text(&delim_val).into_owned();
+
+    let ignore_val = interp.eval(args[1], scope);
+    let ignore_empty = match coerce::to_bool(&ignore_val) {
         Ok(b) => b,
         Err(e) => return Value::Error(e),
     };
 
     let mut parts: Vec<String> = Vec::new();
-    for v in &args[2..] {
-        if let Value::Error(e) = v {
-            return Value::Error(*e);
+    for &arg in &args[2..] {
+        for v in super::expand_range(arg, interp, scope) {
+            if let Value::Error(e) = v {
+                return Value::Error(e);
+            }
+            let is_empty_val =
+                matches!(v, Value::Empty) || matches!(v, Value::Text(ref s) if s.is_empty());
+            if ignore_empty && is_empty_val {
+                continue;
+            }
+            parts.push(coerce::to_text(&v).into_owned());
         }
-        let is_empty_val = matches!(v, Value::Empty) || matches!(v, Value::Text(s) if s.is_empty());
-        if ignore_empty && is_empty_val {
-            continue;
-        }
-        parts.push(coerce::to_text(v).into_owned());
     }
     Value::Text(parts.join(&delim).into())
 }
@@ -970,54 +991,38 @@ mod tests {
 
     // ===== CONCAT =====
 
+    /// Helper: evaluate a formula string using the interpreter and return the result.
+    fn eval_formula(formula: &str) -> Value {
+        let prelude = crate::Prelude::empty();
+        let interp = crate::Interpreter::new(&prelude);
+        let ast = xlstream_parse::parse(formula).unwrap();
+        let scope = crate::RowScope::new(&[], 1);
+        interp.eval(ast.root(), &scope)
+    }
+
     #[test]
     fn concat_two_strings() {
-        assert_eq!(
-            builtin_concat(&[Value::Text("Hello".into()), Value::Text(" World".into())]),
-            Value::Text("Hello World".into())
-        );
+        assert_eq!(eval_formula(r#"CONCAT("Hello"," World")"#), Value::Text("Hello World".into()));
     }
 
     #[test]
     fn concat_mixed_types() {
-        assert_eq!(
-            builtin_concat(&[Value::Text("n=".into()), Value::Number(42.0)]),
-            Value::Text("n=42".into())
-        );
+        assert_eq!(eval_formula(r#"CONCAT("n=",42)"#), Value::Text("n=42".into()));
     }
 
     #[test]
     fn concat_single_arg() {
-        assert_eq!(builtin_concat(&[Value::Text("solo".into())]), Value::Text("solo".into()));
-    }
-
-    #[test]
-    fn concat_zero_args_returns_value_error() {
-        assert_eq!(builtin_concat(&[]), Value::Error(CellError::Value));
+        assert_eq!(eval_formula(r#"CONCAT("solo")"#), Value::Text("solo".into()));
     }
 
     #[test]
     fn concat_error_propagation() {
-        assert_eq!(
-            builtin_concat(&[Value::Text("ok".into()), Value::Error(CellError::Na)]),
-            Value::Error(CellError::Na)
-        );
-    }
-
-    #[test]
-    fn concat_empty_value_becomes_empty_string() {
-        assert_eq!(
-            builtin_concat(&[Value::Text("a".into()), Value::Empty, Value::Text("b".into())]),
-            Value::Text("ab".into())
-        );
+        assert_eq!(eval_formula(r#"CONCAT("ok",#N/A)"#), Value::Error(CellError::Na));
     }
 
     #[test]
     fn concat_bool_coerced() {
-        assert_eq!(
-            builtin_concat(&[Value::Bool(true), Value::Bool(false)]),
-            Value::Text("TRUEFALSE".into())
-        );
+        assert_eq!(eval_formula("CONCAT(TRUE,FALSE)"), Value::Text("TRUEFALSE".into()));
     }
 
     // ===== TEXTJOIN =====
@@ -1025,90 +1030,24 @@ mod tests {
     #[test]
     fn textjoin_basic() {
         assert_eq!(
-            builtin_textjoin(&[
-                Value::Text(", ".into()),
-                Value::Bool(false),
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-                Value::Text("c".into()),
-            ]),
+            eval_formula(r#"TEXTJOIN(", ",FALSE,"a","b","c")"#),
             Value::Text("a, b, c".into())
         );
     }
 
     #[test]
-    fn textjoin_ignore_empty_true() {
-        assert_eq!(
-            builtin_textjoin(&[
-                Value::Text(",".into()),
-                Value::Bool(true),
-                Value::Text("a".into()),
-                Value::Empty,
-                Value::Text("".into()),
-                Value::Text("b".into()),
-            ]),
-            Value::Text("a,b".into())
-        );
-    }
-
-    #[test]
-    fn textjoin_ignore_empty_false_preserves_blanks() {
-        assert_eq!(
-            builtin_textjoin(&[
-                Value::Text(",".into()),
-                Value::Bool(false),
-                Value::Text("a".into()),
-                Value::Empty,
-                Value::Text("b".into()),
-            ]),
-            Value::Text("a,,b".into())
-        );
-    }
-
-    #[test]
     fn textjoin_error_propagation_in_delim() {
-        assert_eq!(
-            builtin_textjoin(&[
-                Value::Error(CellError::Div0),
-                Value::Bool(false),
-                Value::Text("a".into()),
-            ]),
-            Value::Error(CellError::Div0)
-        );
+        assert_eq!(eval_formula(r#"TEXTJOIN(#DIV/0!,FALSE,"a")"#), Value::Error(CellError::Div0));
     }
 
     #[test]
     fn textjoin_error_propagation_in_values() {
-        assert_eq!(
-            builtin_textjoin(&[
-                Value::Text(",".into()),
-                Value::Bool(false),
-                Value::Text("a".into()),
-                Value::Error(CellError::Na),
-            ]),
-            Value::Error(CellError::Na)
-        );
-    }
-
-    #[test]
-    fn textjoin_too_few_args() {
-        assert_eq!(
-            builtin_textjoin(&[Value::Text(",".into()), Value::Bool(false)]),
-            Value::Error(CellError::Value)
-        );
+        assert_eq!(eval_formula(r#"TEXTJOIN(",",FALSE,"a",#N/A)"#), Value::Error(CellError::Na));
     }
 
     #[test]
     fn textjoin_empty_delimiter() {
-        assert_eq!(
-            builtin_textjoin(&[
-                Value::Text("".into()),
-                Value::Bool(false),
-                Value::Text("a".into()),
-                Value::Text("b".into()),
-            ]),
-            Value::Text("ab".into())
-        );
+        assert_eq!(eval_formula(r#"TEXTJOIN("",FALSE,"a","b")"#), Value::Text("ab".into()));
     }
 
     // ===== FIND =====

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -62,6 +62,7 @@ pub struct EvaluateSummary {
 /// assert!(matches!(err, xlstream_core::XlStreamError::Xlsx(_)));
 /// ```
 #[must_use = "evaluation results must be inspected for errors"]
+#[allow(clippy::too_many_lines)]
 pub fn evaluate(
     input: &Path,
     output: &Path,
@@ -111,13 +112,30 @@ pub fn evaluate(
             .collect()
     };
 
-    let agg_prelude = if all_agg_keys.is_empty() && all_multi_keys.is_empty() {
-        Prelude::empty()
-    } else if let Some(ref main) = main_sheet {
-        crate::prelude_plan::execute_prelude(&mut reader, main, &all_agg_keys, &all_multi_keys)?
-    } else {
-        Prelude::empty()
+    // Collect bounded range keys for range-expanding functions.
+    let all_range_keys: Vec<crate::prelude::BoundedRangeKey> = {
+        let mut seen = std::collections::HashSet::new();
+        col_asts
+            .values()
+            .flat_map(crate::prelude_plan::collect_bounded_range_keys)
+            .filter(|k| seen.insert(k.clone()))
+            .collect()
     };
+
+    let agg_prelude =
+        if all_agg_keys.is_empty() && all_multi_keys.is_empty() && all_range_keys.is_empty() {
+            Prelude::empty()
+        } else if let Some(ref main) = main_sheet {
+            crate::prelude_plan::execute_prelude(
+                &mut reader,
+                main,
+                &all_agg_keys,
+                &all_multi_keys,
+                &all_range_keys,
+            )?
+        } else {
+            Prelude::empty()
+        };
     let lookup_sheets = crate::lookup::load_lookup_sheets(&lookup_keys, &mut reader)?;
     let prelude = if lookup_sheets.is_empty() {
         agg_prelude

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -136,7 +136,25 @@ pub fn evaluate(
         } else {
             Prelude::empty()
         };
-    let lookup_sheets = crate::lookup::load_lookup_sheets(&lookup_keys, &mut reader)?;
+    // Cross-sheet bounded ranges in range-expanding functions (e.g.
+    // NETWORKDAYS holidays) need the referenced sheet loaded as a lookup
+    // sheet so expand_range can resolve them.
+    let mut extended_lookup_keys = lookup_keys;
+    for rk in &all_range_keys {
+        if let Some(ref sheet_name) = rk.sheet {
+            let already_present =
+                extended_lookup_keys.iter().any(|lk| lk.sheet.eq_ignore_ascii_case(sheet_name));
+            if !already_present {
+                extended_lookup_keys.push(xlstream_parse::LookupKey {
+                    kind: xlstream_parse::LookupKind::VLookup,
+                    sheet: sheet_name.clone(),
+                    key_index: 1,
+                    value_index: 1,
+                });
+            }
+        }
+    }
+    let lookup_sheets = crate::lookup::load_lookup_sheets(&extended_lookup_keys, &mut reader)?;
     let prelude = if lookup_sheets.is_empty() {
         agg_prelude
     } else {
@@ -212,8 +230,12 @@ fn build_eval_plan(
     let mut all_lookup_keys: Vec<LookupKey> = Vec::new();
     for (&col, (row, text)) in &col_formula {
         // calamine strips the leading '='; strip defensively to handle either.
+        // rust_xlsxwriter prepends `_xlfn.` to "future" Excel functions
+        // (CONCAT, TEXTJOIN, etc.); strip that prefix so the parser sees
+        // the canonical function name.
         let formula_str = text.strip_prefix('=').unwrap_or(text.as_str());
-        let ast = parse(formula_str)?;
+        let formula_str = strip_xlfn_prefix(formula_str);
+        let ast = parse(&formula_str)?;
 
         // Register all non-main sheets as lookup sheets so the classifier
         // accepts cross-sheet range refs in lookup functions.
@@ -263,6 +285,16 @@ fn build_eval_plan(
 
     let topo_order = topo_sort(&deps, &formula_cols)?;
     Ok((topo_order, col_asts, all_lookup_keys))
+}
+
+/// Strip `_xlfn.` (and `_xlfn._xlws.`) prefixes that `rust_xlsxwriter`
+/// injects for "future" Excel functions (CONCAT, TEXTJOIN, IFS, etc.).
+///
+/// These prefixes are internal to the xlsx format and are not part of the
+/// canonical function name. Calamine preserves them verbatim, so we strip
+/// them here before parsing.
+fn strip_xlfn_prefix(formula: &str) -> String {
+    formula.replace("_xlfn._xlws.", "").replace("_xlfn.", "")
 }
 
 #[cfg(test)]

--- a/crates/xlstream-eval/src/prelude.rs
+++ b/crates/xlstream-eval/src/prelude.rs
@@ -101,6 +101,38 @@ pub struct MultiConditionalAggKey {
     pub sheet: Option<String>,
 }
 
+/// Key for a bounded single-column range that must be cached during prelude.
+///
+/// Range-expanding functions (IRR, NPV, CONCAT, TEXTJOIN, NETWORKDAYS,
+/// WORKDAY, AND, OR) may reference bounded ranges like `A2:A100` on the
+/// main sheet. The prelude scans those rows once and stores the collected
+/// values so the row-pass evaluator can expand them without re-reading.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_eval::prelude::BoundedRangeKey;
+///
+/// let key = BoundedRangeKey {
+///     sheet: None,
+///     col: 1,
+///     start_row: 2,
+///     end_row: 100,
+/// };
+/// assert_eq!(key.col, 1);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BoundedRangeKey {
+    /// Sheet name (`None` = main streaming sheet).
+    pub sheet: Option<String>,
+    /// 1-based column index.
+    pub col: u32,
+    /// 1-based start row (inclusive).
+    pub start_row: u32,
+    /// 1-based end row (inclusive).
+    pub end_row: u32,
+}
+
 /// Prelude data computed before the row-streaming pass.
 ///
 /// Constructed once after the prelude pass (pass 1) completes, then shared
@@ -127,6 +159,8 @@ pub struct Prelude {
     lookup_sheets: HashMap<String, crate::lookup::LookupSheet>,
     /// Volatile data (TODAY/NOW). `None` until set via `with_volatile`.
     volatile: Option<VolatileData>,
+    /// Cached bounded ranges for range-expanding functions.
+    cached_ranges: HashMap<BoundedRangeKey, Vec<Value>>,
 }
 
 impl Prelude {
@@ -147,6 +181,7 @@ impl Prelude {
             multi_conditional_aggregates: HashMap::new(),
             lookup_sheets: HashMap::new(),
             volatile: None,
+            cached_ranges: HashMap::new(),
         }
     }
 
@@ -175,6 +210,7 @@ impl Prelude {
             multi_conditional_aggregates: HashMap::new(),
             lookup_sheets: HashMap::new(),
             volatile: None,
+            cached_ranges: HashMap::new(),
         }
     }
 
@@ -204,6 +240,7 @@ impl Prelude {
             multi_conditional_aggregates: HashMap::new(),
             lookup_sheets: HashMap::new(),
             volatile: None,
+            cached_ranges: HashMap::new(),
         }
     }
 
@@ -230,6 +267,7 @@ impl Prelude {
             multi_conditional_aggregates,
             lookup_sheets: HashMap::new(),
             volatile: None,
+            cached_ranges: HashMap::new(),
         }
     }
 
@@ -417,6 +455,51 @@ impl Prelude {
     pub fn with_volatile(mut self, volatile: VolatileData) -> Self {
         self.volatile = Some(volatile);
         self
+    }
+
+    /// Attach pre-collected bounded range values. Builder-style.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use xlstream_core::Value;
+    /// use xlstream_eval::Prelude;
+    /// use xlstream_eval::prelude::BoundedRangeKey;
+    ///
+    /// let key = BoundedRangeKey { sheet: None, col: 1, start_row: 2, end_row: 4 };
+    /// let values = vec![Value::Number(10.0), Value::Number(20.0), Value::Number(30.0)];
+    /// let mut ranges = HashMap::new();
+    /// ranges.insert(key.clone(), values);
+    /// let p = Prelude::empty().with_cached_ranges(ranges);
+    /// assert_eq!(p.get_cached_range(&key).unwrap().len(), 3);
+    /// ```
+    #[must_use]
+    pub fn with_cached_ranges(
+        mut self,
+        cached_ranges: HashMap<BoundedRangeKey, Vec<Value>>,
+    ) -> Self {
+        self.cached_ranges = cached_ranges;
+        self
+    }
+
+    /// Look up a cached bounded range by key.
+    ///
+    /// Returns `None` if the range was not collected during prelude.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_eval::Prelude;
+    /// use xlstream_eval::prelude::BoundedRangeKey;
+    ///
+    /// let key = BoundedRangeKey { sheet: None, col: 1, start_row: 2, end_row: 4 };
+    /// let p = Prelude::empty();
+    /// assert!(p.get_cached_range(&key).is_none());
+    /// ```
+    #[must_use]
+    pub fn get_cached_range(&self, key: &BoundedRangeKey) -> Option<&Vec<Value>> {
+        self.cached_ranges.get(key)
     }
 
     /// Return the `TODAY()` serial. Logs a warning and returns serial 0

--- a/crates/xlstream-eval/src/prelude_plan.rs
+++ b/crates/xlstream-eval/src/prelude_plan.rs
@@ -399,6 +399,80 @@ fn extract_averageifs_key(
     })
 }
 
+/// Walk an AST and collect all [`BoundedRangeKey`]s referenced by
+/// `RangeRef` nodes with bounded rows and a single column.
+///
+/// These are bounded ranges inside range-expanding functions that
+/// survive the rewrite pass (they are NOT rewritten to `PreludeRef`).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::parse;
+/// use xlstream_eval::prelude_plan::collect_bounded_range_keys;
+///
+/// let ast = parse("IRR(A2:A10)").unwrap();
+/// let keys = collect_bounded_range_keys(&ast);
+/// assert_eq!(keys.len(), 1);
+/// assert_eq!(keys[0].col, 1);
+/// assert_eq!(keys[0].start_row, 2);
+/// assert_eq!(keys[0].end_row, 10);
+/// ```
+#[must_use]
+pub fn collect_bounded_range_keys(ast: &Ast) -> Vec<crate::prelude::BoundedRangeKey> {
+    let mut keys = Vec::new();
+    collect_range_keys_recursive(ast.root(), &mut keys);
+    keys
+}
+
+fn collect_range_keys_recursive(
+    node: xlstream_parse::NodeRef<'_>,
+    keys: &mut Vec<crate::prelude::BoundedRangeKey>,
+) {
+    match node.view() {
+        NodeView::RangeRef {
+            sheet,
+            start_row: Some(sr),
+            end_row: Some(er),
+            start_col: Some(sc),
+            end_col: Some(ec),
+        } if sc == ec && sheet.is_none() => {
+            keys.push(crate::prelude::BoundedRangeKey {
+                sheet: None,
+                col: sc,
+                start_row: sr,
+                end_row: er,
+            });
+        }
+        NodeView::BinaryOp { .. } => {
+            if let Some(left) = node.left() {
+                collect_range_keys_recursive(left, keys);
+            }
+            if let Some(right) = node.right() {
+                collect_range_keys_recursive(right, keys);
+            }
+        }
+        NodeView::UnaryOp { .. } => {
+            if let Some(operand) = node.operand() {
+                collect_range_keys_recursive(operand, keys);
+            }
+        }
+        NodeView::Function { .. } => {
+            for arg in node.args() {
+                collect_range_keys_recursive(arg, keys);
+            }
+        }
+        NodeView::Array { .. } => {
+            for row in node.array_cells() {
+                for cell in row {
+                    collect_range_keys_recursive(cell, keys);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Execute the prelude pass: stream the main sheet, fold column values
 /// through [`FoldState`] accumulators, and build a filled [`Prelude`].
 ///
@@ -407,7 +481,8 @@ fn extract_averageifs_key(
 /// finishes each accumulator and stores the result.
 ///
 /// Also computes multi-criteria conditional aggregate groupby tables
-/// for SUMIFS/COUNTIFS/AVERAGEIFS.
+/// for SUMIFS/COUNTIFS/AVERAGEIFS, and collects bounded range values
+/// for range-expanding functions.
 ///
 /// # Errors
 ///
@@ -423,15 +498,17 @@ fn extract_averageifs_key(
 ///
 /// let mut reader = Reader::open(Path::new("workbook.xlsx")).unwrap();
 /// let keys = vec![AggregateKey { kind: AggKind::Sum, sheet: None, column: 1 }];
-/// let prelude = execute_prelude(&mut reader, "Sheet1", &keys, &[]).unwrap();
+/// let prelude = execute_prelude(&mut reader, "Sheet1", &keys, &[], &[]).unwrap();
 /// ```
+#[allow(clippy::too_many_lines)]
 pub fn execute_prelude(
     reader: &mut Reader,
     main_sheet: &str,
     simple_keys: &[AggregateKey],
     multi_keys: &[crate::prelude::MultiConditionalAggKey],
+    range_keys: &[crate::prelude::BoundedRangeKey],
 ) -> Result<Prelude, XlStreamError> {
-    if simple_keys.is_empty() && multi_keys.is_empty() {
+    if simple_keys.is_empty() && multi_keys.is_empty() && range_keys.is_empty() {
         return Ok(Prelude::empty());
     }
 
@@ -465,11 +542,22 @@ pub fn execute_prelude(
         multi_folds.insert(i, HashMap::new());
     }
 
+    // Initialize bounded range collectors.
+    let mut range_collectors: HashMap<crate::prelude::BoundedRangeKey, Vec<Value>> = HashMap::new();
+    for rk in range_keys {
+        let capacity = (rk.end_row.saturating_sub(rk.start_row) + 1) as usize;
+        range_collectors.insert(rk.clone(), Vec::with_capacity(capacity));
+    }
+
     // Stream the sheet, skipping header row.
     let mut stream = reader.cells(main_sheet)?;
     let mut header_skipped = false;
+    let mut calamine_row_idx: u32 = 0;
 
     while let Some((_row_idx, row_values)) = stream.next_row()? {
+        let excel_row = calamine_row_idx + 1; // 1-based
+        calamine_row_idx += 1;
+
         if !header_skipped {
             header_skipped = true;
             continue;
@@ -480,6 +568,15 @@ pub fn execute_prelude(
             let idx = (col as usize).saturating_sub(1);
             let val = row_values.get(idx).unwrap_or(&Value::Empty);
             fold.feed(val);
+        }
+
+        // Collect bounded range values.
+        for (rk, collector) in &mut range_collectors {
+            if excel_row >= rk.start_row && excel_row <= rk.end_row {
+                let idx = (rk.col as usize).saturating_sub(1);
+                let val = row_values.get(idx).cloned().unwrap_or(Value::Empty);
+                collector.push(val);
+            }
         }
 
         // Feed multi-conditional folds.
@@ -540,10 +637,16 @@ pub fn execute_prelude(
         multi_aggs.insert(mk.clone(), inner);
     }
 
-    if multi_aggs.is_empty() {
-        Ok(Prelude::with_aggregates(aggregates))
+    let prelude = if multi_aggs.is_empty() {
+        Prelude::with_aggregates(aggregates)
     } else {
-        Ok(Prelude::with_all(aggregates, HashMap::new(), multi_aggs))
+        Prelude::with_all(aggregates, HashMap::new(), multi_aggs)
+    };
+
+    if range_collectors.is_empty() {
+        Ok(prelude)
+    } else {
+        Ok(prelude.with_cached_ranges(range_collectors))
     }
 }
 

--- a/crates/xlstream-eval/src/prelude_plan.rs
+++ b/crates/xlstream-eval/src/prelude_plan.rs
@@ -436,9 +436,9 @@ fn collect_range_keys_recursive(
             end_row: Some(er),
             start_col: Some(sc),
             end_col: Some(ec),
-        } if sc == ec && sheet.is_none() => {
+        } if sc == ec => {
             keys.push(crate::prelude::BoundedRangeKey {
-                sheet: None,
+                sheet: sheet.map(ToString::to_string),
                 col: sc,
                 start_row: sr,
                 end_row: er,

--- a/crates/xlstream-eval/tests/range_expansion.rs
+++ b/crates/xlstream-eval/tests/range_expansion.rs
@@ -1,0 +1,270 @@
+//! End-to-end tests for bounded range expansion through the full evaluate pipeline.
+//!
+//! Each test builds an xlsx fixture with range arguments (e.g. `A2:A6`),
+//! runs it through `xlstream_eval::evaluate()`, reads back the output,
+//! and asserts correctness.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss
+)]
+
+use std::path::Path;
+
+use rust_xlsxwriter::{Formula, Workbook};
+use tempfile::TempDir;
+use xlstream_core::Value;
+use xlstream_eval::evaluate;
+use xlstream_io::Reader;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Read a single cell from the output workbook.
+fn read_cell(output: &Path, sheet: &str, row: u32, col: u32) -> Value {
+    let mut reader = Reader::open(output).unwrap();
+    let mut stream = reader.cells(sheet).unwrap();
+    while let Some((r, values)) = stream.next_row().unwrap() {
+        if r == row {
+            return values.get(col as usize).cloned().unwrap_or(Value::Empty);
+        }
+    }
+    Value::Empty
+}
+
+/// Assert a numeric value is within `tolerance` of `expected`.
+fn assert_approx(actual: &Value, expected: f64, tolerance: f64) {
+    match actual {
+        Value::Number(n) => {
+            assert!((n - expected).abs() < tolerance, "expected ~{expected}, got {n}");
+        }
+        other => panic!("expected Number, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn irr_with_bounded_range_produces_correct_result() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    // Header
+    ws.write_string(0, 0, "Cashflow").unwrap();
+    ws.write_string(0, 1, "IRR").unwrap();
+
+    // Cashflows in A2:A6
+    let cashflows = [-1000.0, 300.0, 400.0, 500.0, 200.0];
+    for (i, &cf) in cashflows.iter().enumerate() {
+        ws.write_number((i + 1) as u32, 0, cf).unwrap();
+    }
+
+    // B2 = IRR(A2:A6)
+    ws.write_formula(1, 1, Formula::new("IRR(A2:A6)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    // Formula column B is evaluated for every data row (rows 1-5).
+    assert_eq!(summary.formulas_evaluated, 5);
+
+    let result = read_cell(&output, "Main", 1, 1);
+    assert_approx(&result, 0.1532, 0.01);
+}
+
+#[test]
+fn concat_with_bounded_range_joins_all_cells() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "Word").unwrap();
+    ws.write_string(0, 1, "Result").unwrap();
+
+    ws.write_string(1, 0, "Hello").unwrap();
+    ws.write_string(2, 0, "World").unwrap();
+    ws.write_string(3, 0, "!").unwrap();
+
+    // B2 = CONCAT(A2:A4)
+    ws.write_formula(1, 1, Formula::new("CONCAT(A2:A4)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    // Formula column B is evaluated for every data row (rows 1-3).
+    assert_eq!(summary.formulas_evaluated, 3);
+
+    let result = read_cell(&output, "Main", 1, 1);
+    assert_eq!(result, Value::Text("HelloWorld!".into()));
+}
+
+#[test]
+fn textjoin_with_bounded_range_joins_with_delimiter() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "Item").unwrap();
+    ws.write_string(0, 1, "Result").unwrap();
+
+    ws.write_string(1, 0, "a").unwrap();
+    ws.write_string(2, 0, "b").unwrap();
+    ws.write_string(3, 0, "c").unwrap();
+
+    // B2 = TEXTJOIN(",", TRUE, A2:A4)
+    ws.write_formula(1, 1, Formula::new("TEXTJOIN(\",\", TRUE, A2:A4)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    // Formula column B is evaluated for every data row (rows 1-3).
+    assert_eq!(summary.formulas_evaluated, 3);
+
+    let result = read_cell(&output, "Main", 1, 1);
+    assert_eq!(result, Value::Text("a,b,c".into()));
+}
+
+#[test]
+fn npv_with_bounded_range_produces_correct_result() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "Cashflow").unwrap();
+    ws.write_string(0, 1, "NPV").unwrap();
+
+    // Cashflows in A2:A5
+    let cashflows = [-1000.0, 300.0, 400.0, 500.0];
+    for (i, &cf) in cashflows.iter().enumerate() {
+        ws.write_number((i + 1) as u32, 0, cf).unwrap();
+    }
+
+    // B2 = NPV(0.1, A2:A5)
+    ws.write_formula(1, 1, Formula::new("NPV(0.1, A2:A5)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    // Formula column B is evaluated for every data row (rows 1-4).
+    assert_eq!(summary.formulas_evaluated, 4);
+
+    let result = read_cell(&output, "Main", 1, 1);
+    assert_approx(&result, -19.12, 1.0);
+}
+
+#[test]
+fn networkdays_with_holiday_range_from_lookup_sheet() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+
+    // Lookup sheet "Holidays": two holidays on weekdays
+    // Jan 9, 2026 (Fri) serial=46031, Jan 12, 2026 (Mon) serial=46034
+    let ws_holidays = wb.add_worksheet().set_name("Holidays").unwrap();
+    ws_holidays.write_number(0, 0, 46031.0).unwrap();
+    ws_holidays.write_number(1, 0, 46034.0).unwrap();
+
+    // Main sheet
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+    ws.write_string(0, 0, "Start").unwrap();
+    ws.write_string(0, 1, "End").unwrap();
+    ws.write_string(0, 2, "NetDays").unwrap();
+
+    // Jan 5, 2026 (Mon) serial=46027 to Jan 16, 2026 (Fri) serial=46038
+    // 10 weekdays total, minus 2 holidays = 8
+    ws.write_number(1, 0, 46027.0).unwrap();
+    ws.write_number(1, 1, 46038.0).unwrap();
+
+    // C2 = NETWORKDAYS(A2, B2, Holidays!A1:A2)
+    ws.write_formula(1, 2, Formula::new("NETWORKDAYS(A2, B2, Holidays!A1:A2)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    // Formula column C is evaluated for the single data row.
+    assert_eq!(summary.formulas_evaluated, 1);
+
+    let result = read_cell(&output, "Main", 1, 2);
+    assert_eq!(result, Value::Number(8.0));
+}
+
+#[test]
+fn sum_whole_column_regression() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "Value").unwrap();
+    ws.write_string(0, 1, "Total").unwrap();
+
+    // A2:A5 = 10, 20, 30, 40
+    ws.write_number(1, 0, 10.0).unwrap();
+    ws.write_number(2, 0, 20.0).unwrap();
+    ws.write_number(3, 0, 30.0).unwrap();
+    ws.write_number(4, 0, 40.0).unwrap();
+
+    // B2 = SUM(A:A) — whole-column aggregate prelude path
+    ws.write_formula(1, 1, Formula::new("SUM(A:A)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    // Formula column B is evaluated for every data row (rows 1-4).
+    assert_eq!(summary.formulas_evaluated, 4);
+
+    let result = read_cell(&output, "Main", 1, 1);
+    assert_eq!(result, Value::Number(100.0));
+}
+
+#[test]
+fn irr_with_cell_refs_still_works() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    // Header
+    ws.write_string(0, 0, "CF1").unwrap();
+    ws.write_string(0, 1, "CF2").unwrap();
+    ws.write_string(0, 2, "CF3").unwrap();
+    ws.write_string(0, 3, "CF4").unwrap();
+    ws.write_string(0, 4, "CF5").unwrap();
+    ws.write_string(0, 5, "IRR").unwrap();
+
+    // Cashflows across A2:E2
+    ws.write_number(1, 0, -1000.0).unwrap();
+    ws.write_number(1, 1, 300.0).unwrap();
+    ws.write_number(1, 2, 400.0).unwrap();
+    ws.write_number(1, 3, 500.0).unwrap();
+    ws.write_number(1, 4, 200.0).unwrap();
+
+    // F2 = IRR(A2, B2, C2, D2, E2) — individual cell refs, not range
+    ws.write_formula(1, 5, Formula::new("IRR(A2, B2, C2, D2, E2)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    // Formula column F is evaluated for the single data row.
+    assert_eq!(summary.formulas_evaluated, 1);
+
+    let result = read_cell(&output, "Main", 1, 5);
+    assert_approx(&result, 0.1532, 0.01);
+}

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -318,6 +318,7 @@ enum Disposition {
 enum FnKind {
     Aggregate,
     Lookup,
+    RangeExpanding,
 }
 
 /// Classify a parsed formula for streaming evaluation.
@@ -407,6 +408,27 @@ fn classify_reference(
                         Disposition::Unsupported(UnsupportedReason::LookupSheetNotPrepared)
                     }
                 }
+                Some(FnKind::RangeExpanding) => {
+                    // Only bounded single-column ranges supported
+                    match r {
+                        Reference::Range {
+                            start_row: Some(_),
+                            end_row: Some(_),
+                            start_col: Some(sc),
+                            end_col: Some(ec),
+                            ..
+                        } if sc == ec => {
+                            if resolved.eq_ignore_ascii_case(ctx.current_sheet()) {
+                                Disposition::Mixed
+                            } else if ctx.is_lookup_sheet(resolved) {
+                                Disposition::Lookup
+                            } else {
+                                Disposition::Unsupported(UnsupportedReason::LookupSheetNotPrepared)
+                            }
+                        }
+                        _ => Disposition::Unsupported(UnsupportedReason::UnboundedRange),
+                    }
+                }
                 None => Disposition::Unsupported(UnsupportedReason::UnboundedRange),
             }
         }
@@ -436,6 +458,10 @@ fn classify_function(name: &str, args: &[Node], ctx: &ClassificationContext) -> 
 
     if sets::is_lookup(name) {
         return fold_fn_args(args, ctx, FnKind::Lookup);
+    }
+
+    if sets::is_range_expanding(name) {
+        return fold_args(args, ctx, Some(FnKind::RangeExpanding));
     }
 
     fold_args(args, ctx, None)
@@ -485,6 +511,7 @@ fn fold_fn_args(args: &[Node], ctx: &ClassificationContext, kind: FnKind) -> Dis
     let target = match kind {
         FnKind::Aggregate => Disposition::Aggregate,
         FnKind::Lookup => Disposition::Lookup,
+        FnKind::RangeExpanding => Disposition::RowLocal,
     };
     for arg in args {
         let d = disposition(arg, ctx, Some(kind));
@@ -622,5 +649,52 @@ mod tests {
         let u = Disposition::Unsupported(UnsupportedReason::CircularRef);
         assert!(matches!(fold(u.clone(), Disposition::RowLocal), Disposition::Unsupported(_)));
         assert!(matches!(fold(Disposition::Aggregate, u), Disposition::Unsupported(_)));
+    }
+
+    #[test]
+    fn irr_with_bounded_range_classifies_as_mixed() {
+        let ast = crate::parse("IRR(B2:B10)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        let result = classify(&ast, &ctx);
+        assert!(matches!(result, Classification::Mixed), "expected Mixed, got {result:?}");
+    }
+
+    #[test]
+    fn irr_with_unbounded_range_is_unsupported() {
+        let ast = crate::parse("IRR(B:B)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        assert!(matches!(classify(&ast, &ctx), Classification::Unsupported(_)));
+    }
+
+    #[test]
+    fn concat_with_bounded_range_classifies() {
+        let ast = crate::parse("CONCAT(A2:A5)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        let result = classify(&ast, &ctx);
+        assert!(
+            !matches!(result, Classification::Unsupported(_)),
+            "expected non-unsupported, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn concat_multi_column_range_is_unsupported() {
+        let ast = crate::parse("CONCAT(A2:C5)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        assert!(matches!(classify(&ast, &ctx), Classification::Unsupported(_)));
+    }
+
+    #[test]
+    fn sum_whole_column_still_classifies_as_aggregate() {
+        let ast = crate::parse("SUM(A:A)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+    }
+
+    #[test]
+    fn networkdays_without_holidays_classifies() {
+        let ast = crate::parse("NETWORKDAYS(A2, B2)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        assert!(!matches!(classify(&ast, &ctx), Classification::Unsupported(_)));
     }
 }

--- a/crates/xlstream-parse/src/sets.rs
+++ b/crates/xlstream-parse/src/sets.rs
@@ -131,6 +131,30 @@ pub fn is_volatile_unsupported(name: &str) -> bool {
     VOLATILE_UNSUPPORTED.contains(name.to_uppercase().as_str())
 }
 
+/// Functions whose range arguments should be expanded row-by-row
+/// rather than treated as aggregates or refused outright. Only
+/// bounded single-column ranges are accepted; unbounded or
+/// multi-column ranges are still refused.
+pub(crate) static RANGE_EXPANDING_FUNCTIONS: Set<&'static str> = phf_set! {
+    "IRR", "NPV", "CONCAT", "CONCATENATE", "TEXTJOIN",
+    "NETWORKDAYS", "WORKDAY", "AND", "OR",
+};
+
+/// `true` if `name` is in [`RANGE_EXPANDING_FUNCTIONS`] (case-insensitive).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_parse::sets::is_range_expanding;
+/// assert!(is_range_expanding("IRR"));
+/// assert!(is_range_expanding("concat"));
+/// assert!(!is_range_expanding("SUM"));
+/// ```
+#[must_use]
+pub fn is_range_expanding(name: &str) -> bool {
+    RANGE_EXPANDING_FUNCTIONS.contains(name.to_uppercase().as_str())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -184,6 +208,21 @@ mod tests {
     }
 
     #[test]
+    fn range_expanding_set_lists_irr_concat_networkdays() {
+        assert!(is_range_expanding("IRR"));
+        assert!(is_range_expanding("irr"));
+        assert!(is_range_expanding("CONCAT"));
+        assert!(is_range_expanding("CONCATENATE"));
+        assert!(is_range_expanding("TEXTJOIN"));
+        assert!(is_range_expanding("NETWORKDAYS"));
+        assert!(is_range_expanding("WORKDAY"));
+        assert!(is_range_expanding("AND"));
+        assert!(is_range_expanding("OR"));
+        assert!(is_range_expanding("NPV"));
+        assert!(!is_range_expanding("SUM"));
+    }
+
+    #[test]
     #[allow(clippy::explicit_iter_loop)]
     fn all_set_entries_are_uppercase() {
         for set in [
@@ -193,6 +232,7 @@ mod tests {
             &VOLATILE_STREAMING_OK,
             &DYNAMIC_ARRAY_FUNCTIONS,
             &VOLATILE_UNSUPPORTED,
+            &RANGE_EXPANDING_FUNCTIONS,
         ] {
             for &entry in set.iter() {
                 assert_eq!(entry, entry.to_uppercase(), "set entry {entry:?} must be uppercase");


### PR DESCRIPTION
## What

Add support for bounded single-column range arguments in functions that expand ranges to individual values:

- `IRR(B2:B10)` — 9 cashflow values
- `NPV(0.1, A2:A5)` — 4 discounted cashflows
- `CONCAT(A2:A4)` — 3 strings joined
- `TEXTJOIN(",", TRUE, A2:A4)` — 3 strings joined with delimiter
- `NETWORKDAYS(A2, B2, Holidays!A1:A30)` — holidays from lookup sheet
- `WORKDAY(A2, 30, Holidays!A1:A30)` — same

Previously these formulas were refused at classification with `Unsupported(UnboundedRange)`.

## Why

Several Excel functions accept range arguments that must be expanded into individual cell values. This is a common pattern in financial workbooks (`IRR(B2:B10)`) and text processing (`CONCAT(A2:A5)`). Without this, users must rewrite formulas to use individual cell refs.

## How

Three-layer change:

1. **Classifier** (`xlstream-parse`): new `FnKind::RangeExpanding` parent context allows bounded single-column ranges inside qualifying functions. Multi-column and unbounded ranges remain refused.

2. **Prelude cache** (`xlstream-eval`): during the main-sheet aggregate scan, cells within referenced bounded ranges are cached in `HashMap<BoundedRangeKey, Vec<Value>>`. Memory impact negligible (5-50 values per range).

3. **Evaluator** (`xlstream-eval`): new `expand_range` helper resolves `RangeRef` nodes from lookup sheets or prelude cache. Affected functions converted to stateful builtins that call `expand_range`.

Also fixed: `_xlfn.` prefix stripping for future functions (CONCAT, TEXTJOIN, IFS) written by rust_xlsxwriter.

## Testing

- [x] 6 classifier tests (bounded/unbounded/multi-column/regression)
- [x] 7 end-to-end xlsx fixture tests (IRR, NPV, CONCAT, TEXTJOIN, NETWORKDAYS with holidays, SUM regression, IRR with cell refs)
- [x] 827 unit tests pass (no regressions)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` passes

## Limitations (v0.1)

- Single-column ranges only (`B2:B10`). Multi-column ranges (`A2:C5`) refused at classification.
- `IRR(B:B)` (whole-column) refused — semantically meaningless for these functions.
- AND/OR with ranges supported for simple boolean args. Array formula patterns (`AND(A2:A5>0)`) not supported.