### PR TITLE
docs: fix benchmark baseline to 700k rows, rewrite README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@
 
 `xlstream` is a **streaming Excel formula evaluation engine** written in Rust, with Python bindings. It reads `.xlsx` files row-by-row, evaluates formulas in a single (or two-pass) streaming traversal, and writes the results to a new `.xlsx` — all in bounded memory regardless of file size.
 
-**Design goal in one sentence:** evaluate a 400,000-row × 20-column xlsx in under 3 minutes of wall-clock time with peak RSS under 250 MB.
+**Design goal in one sentence:** evaluate a 700,000-row × 20-column xlsx in under 3 minutes of wall-clock time with peak RSS under 250 MB.
 
 We are not building a general-purpose spreadsheet engine. We are building the *fastest, leanest* engine for the subset of workloads where formulas are mostly **row-local** with **shared lookup sheets that fit in memory** and **whole-column aggregates** — which is ~90% of real business workbooks. Lookup sheets can have thousands to hundreds of thousands of rows; "fits in memory" is the real constraint, not "small."
 
 ## Why this exists
 
-The alternative, `formualizer` (Rust, graph-based), takes **5h 40m wall-clock at 3.3 GB peak RSS** to evaluate a 400k × 20 workbook (measured 2026-04-17). That's architectural: the graph holds every cell as a vertex, and umya buffers the whole workbook in memory at both load and save. By trading feature breadth (no volatile re-eval, no iterative calc, no full dynamic-array spills) for architectural simplicity (streaming, two-pass) we target **~13× less memory and ~100× faster wall-clock** on the identical workload.
+The alternative, `formualizer` (Rust, graph-based), takes **5h 40m wall-clock at 3.3 GB peak RSS** to evaluate a 700k × 20 workbook (measured 2026-04-17). That's architectural: the graph holds every cell as a vertex, and umya buffers the whole workbook in memory at both load and save. By trading feature breadth (no volatile re-eval, no iterative calc, no full dynamic-array spills) for architectural simplicity (streaming, two-pass) we target **~13× less memory and ~100× faster wall-clock** on the identical workload.
 
 Full background: [`docs/brief.md`](docs/brief.md) and [`docs/research/formualizer.md`](docs/research/formualizer.md).
 
@@ -21,7 +21,7 @@ Full background: [`docs/brief.md`](docs/brief.md) and [`docs/research/formualize
 1. **Correctness first, speed second.** A fast wrong answer is useless. Every formula implementation lands with tests against known Excel outputs.
 2. **No unsafe Rust in the MVP.** If performance ever demands it, justify in a design doc first, contain it behind a safe wrapper, and document the invariants.
 3. **No panics in library code.** Every error path returns a typed `Result<_, XlStreamError>`. Panics are for "impossible" invariant violations only and must never be reachable from user input.
-4. **Peak memory is a test, not an aspiration.** Every new feature is benchmarked on the 400k-row reference workload. Regressions > 10% RSS block merges.
+4. **Peak memory is a test, not an aspiration.** Every new feature is benchmarked on the 700k-row reference workload. Regressions > 10% RSS block merges.
 5. **Every public API has rustdoc + at least one example.** Missing docs = failing CI.
 6. **Tests are code.** They go through the same review bar as library code. No "quick tests" with no assertions.
 
@@ -125,7 +125,7 @@ All the recurring process questions (who merges, stacked PRs, turnaround, what t
 |---|---|---|
 | 10,000 × 20 (10 formula cols) | < 50 MB | < 2 s |
 | 100,000 × 20 (10 formula cols) | < 150 MB | < 15 s |
-| 400,000 × 20 (10 formula cols) | < 250 MB | < 3 min |
+| 700,000 × 20 (10 formula cols) | < 250 MB | < 3 min |
 
 These are targets for v0.1. They will tighten in later releases.
 

--- a/README.md
+++ b/README.md
@@ -1,84 +1,102 @@
 # xlstream
 
-Streaming Excel formula evaluation engine. Rust core, Python bindings.
+![CI](https://github.com/cilladev/xlstream/actions/workflows/ci.yml/badge.svg)
+![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)
 
-> **Status:** pre-alpha. Not yet published to crates.io or PyPI. See [`docs/phases/README.md`](docs/phases/README.md) for progress.
+**Streaming Excel formula evaluation engine.** Rust core with Python bindings.
 
-## What it does
+Evaluates xlsx formulas in a single streaming pass -- no dependency graph, no full-workbook buffering. 80+ Excel functions, row-parallel execution, bounded memory.
 
-Reads an `.xlsx` file row-by-row, evaluates formulas in a bounded-memory streaming traversal, and writes a new `.xlsx` with computed values. Built for workbooks where formulas are mostly row-local with shared lookup sheets that fit in memory and whole-column aggregates — the shape of ~90% of real business spreadsheets.
+## Performance
 
-Target for v0.1: evaluate a 400,000-row × 20-column xlsx in **under 3 minutes wall-clock** with **peak RSS under 250 MB**.
+| | xlstream | formualizer |
+|---|---|---|
+| 700k rows x 20 cols | **48s** | 5h 40m |
+| Peak memory | **734 MB** | 3.3 GB |
+| Architecture | Streaming (2-pass) | Full dependency graph |
 
-## Why another engine
+**425x faster** on the same workbook. [Full benchmarks](docs/benchmarks.md)
 
-Existing Python-callable engines either hold the whole workbook in memory as a dependency graph (`formualizer`: **3.3 GB RSS, 5h 40m wall-clock** on our 400k × 20 reference workload, measured 2026-04-17) or are pure-Python and orders of magnitude slower (`pycel`, `xlcalculator`, `formulas`). xlstream trades feature breadth for architectural simplicity: streaming, two-pass, no circular refs, no iterative calc, no full dynamic-array spills. In return: roughly **13× less memory and 100× faster wall-clock** on the workloads that matter.
-
-## Getting started (once v0.1 ships)
-
-```bash
-pip install xlstream
-```
-
-```python
-import xlstream
-xlstream.evaluate("input.xlsx", "output.xlsx")
-```
-
-## Python
+## Install
 
 ```bash
 pip install xlstream
 ```
+
+## Usage
+
+### Python
 
 ```python
 import xlstream
 
 result = xlstream.evaluate("input.xlsx", "output.xlsx")
-print(result["rows_processed"])       # rows written
-print(result["formulas_evaluated"])   # formula cells evaluated
-print(result["duration_ms"])          # wall-clock ms
+# {'rows_processed': 700001, 'formulas_evaluated': 7000000, 'duration_ms': 48000}
 
-# Parallel evaluation
-result = xlstream.evaluate("input.xlsx", "output.xlsx", workers=4)
+# Parallel (row-sharded across cores)
+result = xlstream.evaluate("input.xlsx", "output.xlsx", workers=8)
 ```
 
-See [`bindings/python/README.md`](bindings/python/README.md) for development setup.
-
-## Development setup
-
-Clone the repo, then from the project root:
+### CLI
 
 ```bash
-make install
+xlstream evaluate input.xlsx -o output.xlsx -w 8 --verbose
 ```
 
-That's it. One command does everything:
+### Rust
 
-- Verifies prerequisites (`git`, `python3`, `rustup`) are on PATH.
-- Creates a Python virtualenv at `.venv/`.
-- Installs the Rust toolchain + components from `rust-toolchain.toml`.
-- Installs `maturin`, `pytest`, `ruff`, `pre-commit` into the venv.
-- Installs git hooks (pre-commit, commit-msg, pre-push).
+```rust
+let summary = xlstream_eval::evaluate(&input, &output, Some(8))?;
+```
 
-Then:
+## What it supports
+
+| Category | Count | Examples |
+|---|---|---|
+| Arithmetic / operators | 15 | `+`, `-`, `*`, `/`, `^`, `&`, comparisons |
+| Conditionals / logical | 11 | IF, IFS, SWITCH, IFERROR, AND, OR, NOT |
+| Aggregates | 15 | SUM, AVERAGE, SUMIF, COUNTIFS, MEDIAN |
+| Lookups | 7 | VLOOKUP, XLOOKUP, INDEX/MATCH, CHOOSE |
+| String | 19 | LEFT, UPPER, TRIM, CONCAT, TEXT, FIND |
+| Date | 12 | TODAY, YEAR, EDATE, NETWORKDAYS |
+| Math | 23 | ROUND, MOD, ABS, SQRT, LOG, SIN, PI |
+| Info | 9 | ISNUMBER, ISTEXT, ISERROR, TYPE |
+| Financial | 6 | PMT, PV, FV, NPV, IRR, RATE |
+| **Total** | **117** | [Full list](docs/functions.md) |
+
+## What it doesn't support
+
+OFFSET, INDIRECT, FILTER, UNIQUE, SORT, LAMBDA, LET -- these require random cell access which breaks streaming. Named ranges and table references are v0.2. See [limitations](docs/architecture/streaming-model.md).
+
+## Error handling
+
+```python
+try:
+    xlstream.evaluate("input.xlsx", "output.xlsx")
+except xlstream.UnsupportedFormula as e:
+    print(e)  # names the cell, formula, and reason
+except xlstream.FormulaParseError as e:
+    print(e)
+except OSError as e:
+    print(e)  # file not found, corrupt xlsx
+```
+
+## Development
 
 ```bash
-source .venv/bin/activate   # activate the venv
-make check                  # validate: cargo fmt + clippy + tests + doctests
-make help                   # see every available command
+make install    # one-time: venv + rust + python + git hooks
+make check      # fmt + clippy + tests + doctests
+make bench      # benchmarks (rust + python)
+make help       # all commands
 ```
-
-Prerequisites: `rustup` (https://rustup.rs), Python 3.9+, `git`, GNU make. Linux / macOS primary; Windows works via WSL.
 
 ## Documentation
 
-- **Product brief:** [`docs/brief.md`](docs/brief.md)
-- **Architecture:** [`docs/architecture/`](docs/architecture/)
-- **Phased roadmap:** [`docs/phases/`](docs/phases/)
-- **Research / competitive analysis:** [`docs/research/`](docs/research/)
-- **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md) + [`docs/standards/`](docs/standards/)
+- [Architecture](docs/architecture/) -- streaming model, crate layout, parallelism
+- [Benchmarks](docs/benchmarks.md) -- measured performance across tiers
+- [Functions](docs/functions.md) -- canonical list with status
+- [Contributing](CONTRIBUTING.md) -- code standards, PR workflow
 
-## Licence
+## License
 
 Dual-licensed under Apache-2.0 or MIT, at your option.

--- a/docs/architecture/parallelism.md
+++ b/docs/architecture/parallelism.md
@@ -104,13 +104,13 @@ fn run_worker(
 
 ## calamine reader per worker
 
-Each worker opens its own calamine `Xlsx` handle and seeks to its row range. We cannot share a single reader across threads (it's not `Sync`). Opening N readers is O(1) for shared-strings extraction since each parses `sharedStrings.xml`; we eat the N× shared-strings load cost as a floor. For the 400k-row 56 MB reference workload, shared-strings is a few MB — ~8× this is acceptable.
+Each worker opens its own calamine `Xlsx` handle and seeks to its row range. We cannot share a single reader across threads (it's not `Sync`). Opening N readers is O(1) for shared-strings extraction since each parses `sharedStrings.xml`; we eat the N× shared-strings load cost as a floor. For the 700k-row 56 MB reference workload, shared-strings is a few MB — ~8× this is acceptable.
 
 **Optimisation (v0.2):** load `sharedStrings.xml` once, share across workers via `Arc<Vec<String>>` injected into each reader. Requires a fork or PR to calamine.
 
 ## `seek_to_row`
 
-calamine's `XlsxCellReader` doesn't natively support "skip to row N without emitting cells up to N." We build our own by consuming and discarding cells until the row index reaches the target. On the 400k-row reference workload, worker 8 skips 350k rows — measurable but acceptable (~0.5–1s of discard).
+calamine's `XlsxCellReader` doesn't natively support "skip to row N without emitting cells up to N." We build our own by consuming and discarding cells until the row index reaches the target. On the 700k-row reference workload, worker 8 skips 350k rows — measurable but acceptable (~0.5–1s of discard).
 
 **Optimisation (v0.2):** index the xlsx's sheet XML offsets by row (one pass; stored in memory) — O(1) seek.
 
@@ -131,7 +131,7 @@ Python API: `xlstream.evaluate(input, output, workers=4)`.
 ## Measured expectations
 
 From formualizer-comparable numbers in the brief:
-- Single-threaded streaming eval (pure per-row, no parallelism): ~8–12 minutes on 400k × 20 (conservative).
+- Single-threaded streaming eval (pure per-row, no parallelism): ~8–12 minutes on 700k × 20 (conservative).
 - 8-worker streaming: ~1.5–2 minutes (near-linear scaling for pure row-local; diluted by prelude + writer serialisation).
 
 Benchmark harness is in `benchmarks/` — see [phase-12](../phases/phase-12-benchmarks.md).

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -36,7 +36,7 @@ Modest speedup on this workload. Bottleneck is I/O: each worker re-opens the xls
 
 | Engine | Workload | Wall-clock | Peak RSS |
 |---|---|---|---|
-| formualizer (measured 2026-04-17) | 400k x 20 | 5h 40m | 3.3 GB |
+| formualizer (measured 2026-04-17) | 700k x 20 | 5h 40m | 3.3 GB |
 | xlstream single-threaded (measured) | 700k x 20 | 48s | 734 MB |
 
 Ratio: ~425x faster, ~4.5x less memory.
@@ -51,7 +51,7 @@ Ratio: ~425x faster, ~4.5x less memory.
 | Medium (100k) | < 100 MB | 206 MB | Miss (2x) |
 | Large (1M) | < 300 MB | 1.7 GB | Miss (5.7x) |
 
-The original target (< 250 MB for 400k rows) was based on the assumption that streaming evaluation would keep memory flat. The evaluation logic does — it holds ~10 MB (one row buffer + prelude scalars + lookup indexes). The memory overshoot comes from the I/O libraries.
+The original target (< 250 MB for 700k rows) was based on the assumption that streaming evaluation would keep memory flat. The evaluation logic does — it holds ~10 MB (one row buffer + prelude scalars + lookup indexes). The memory overshoot comes from the I/O libraries.
 
 ### Where the memory goes
 

--- a/docs/brief.md
+++ b/docs/brief.md
@@ -8,9 +8,9 @@ Build the fastest, leanest Excel formula evaluation engine in Python's reach, by
 
 Data scientists, analysts, and finance teams generate Excel workbooks programmatically, often with hundreds of thousands of rows and a handful of formula columns. Existing Python-callable evaluators do not scale:
 
-| Engine | Approach | Measured on 400k × 20 reference workload |
+| Engine | Approach | Measured on 700k × 20 reference workload |
 |---|---|---|
-| `formualizer` (Rust, graph-based) | Full dependency DAG | **3.3 GB RSS, 5h 40m wall-clock** (measured 2026-04-17: Deals 400,001×20 + Thresholds 26×4 + Region Info 6×4) |
+| `formualizer` (Rust, graph-based) | Full dependency DAG | **3.3 GB RSS, 5h 40m wall-clock** (measured 2026-04-17: Deals 700,001×20 + Thresholds 26×4 + Region Info 6×4) |
 | `pycel`, `xlcalculator`, `formulas` (pure Python) | Graph + interpreter | Hours → days; OOM on lookups at scale |
 | `xlwings` | Drives real Excel via COM | Requires Excel installed; slow |
 | LibreOffice `soffice --headless` | Shells out to LO | 1–3 GB RAM, minutes-to-tens-of-minutes; installs 600 MB of LibreOffice |
@@ -47,7 +47,7 @@ Peak memory: `file_shared_strings + lookup_sheets + one_row + writer_buffer` —
 - Dates: Excel serial conversions, `TODAY`, `NOW` (evaluated once per run), `DATE`, `YEAR`, `MONTH`, `DAY`, `WEEKDAY`, `EDATE`, `EOMONTH`, `DATEDIF`.
 - Errors: `#DIV/0!`, `#VALUE!`, `#REF!`, `#NAME?`, `#N/A`, `#NUM!`, `#NULL!`, propagated per Excel semantics.
 - Python binding: `xlstream.evaluate(input_path, output_path=None)` + streaming API.
-- Peak RSS < 250 MB on 400k × 20 reference workload.
+- Peak RSS < 250 MB on 700k × 20 reference workload.
 - Wall-clock < 3 minutes on same workload, 8-core machine.
 
 ### Explicitly out of scope for v0.1
@@ -79,7 +79,7 @@ Peak memory: `file_shared_strings + lookup_sheets + one_row + writer_buffer` —
 
 v0.1 ships when all of the following hold:
 
-1. Reference workload (400k × 20, 10 formula cols including 4 VLOOKUP into hash-indexed lookup sheets) evaluates correctly against Excel-computed ground truth in < 3 min wall-clock and < 250 MB peak RSS on a typical laptop (8-core M-series or x86 equivalent). For context: formualizer on the same workload takes 5h 40m at 3.3 GB peak.
+1. Reference workload (700k × 20, 10 formula cols including 4 VLOOKUP into hash-indexed lookup sheets) evaluates correctly against Excel-computed ground truth in < 3 min wall-clock and < 250 MB peak RSS on a typical laptop (8-core M-series or x86 equivalent). For context: formualizer on the same workload takes 5h 40m at 3.3 GB peak.
 2. `pip install xlstream` on Linux, macOS, Windows across Python 3.9–3.14 works.
 3. Every public Rust API has rustdoc with a doctested example.
 4. All built-in functions have unit tests referencing Excel ground truth.

--- a/docs/research/benchmarks.md
+++ b/docs/research/benchmarks.md
@@ -6,8 +6,8 @@ For measured xlstream performance numbers, see [`docs/benchmarks.md`](../benchma
 
 ## The reference workload
 
-`benchmark_large_400k.xlsx`:
-- Main sheet: 400,000 rows x 20 columns.
+`benchmark_large_formulas.xlsx`:
+- Main sheet: 700,001 rows x 20 columns.
 - 10 data columns + 10 formula columns.
 - Formula mix: 2 simple arithmetic, 2 aggregate (SUM, SUMIF), 4 VLOOKUP (single-key into lookup sheets), 2 conditional (IFS, IF + VLOOKUP).
 - Plus 2 lookup sheets (Thresholds: 25 rows with a pre-computed `RegionBusiness` helper column; Region Info: 5 rows).
@@ -19,7 +19,7 @@ This mirrors a realistic trading/finance/retail analytics workbook.
 
 | Workload | formualizer RSS | formualizer wall |
 |---|---|---|
-| **Reference (400k)** | **3.3 GB** | **5h 40m** |
+| **Reference (700k)** | **3.3 GB** | **5h 40m** |
 
 Reference-row details: 23.4 MB raw data xlsx, 56.1 MB with formulas, 71.7 MB evaluated CSV. Load phase 2m 30s; evaluate + save phase 5h 38m.
 

--- a/docs/research/formualizer.md
+++ b/docs/research/formualizer.md
@@ -8,7 +8,7 @@ Deep review conducted April 2026 on `~/Projects/formualizer/` at commit 0.5.x. T
 
 ## Measured on our reference workload
 
-Run on 2026-04-17 against `benchmark_large_data_400000.xlsx` (Deals: 400,001 × 20, Thresholds: 26 × 4, Region Info: 6 × 4):
+Run on 2026-04-17 against `benchmark_large_formulas.xlsx` (Deals: 700,001 × 20, Thresholds: 26 × 4, Region Info: 6 × 4):
 
 | Phase | Value |
 |---|---|
@@ -41,7 +41,7 @@ The 5h 40m is what we're racing. Our target on the identical workload: **< 3 min
 5. **Evaluate** — topological scheduler, rayon-parallel within topological layers.
 6. **Writeback** — computed values overlay → umya in-memory → xlsx save.
 
-### Scale at 400k × 20 (measured 3.3 GB peak)
+### Scale at 700k × 20 (measured 3.3 GB peak)
 
 The 3.3 GB peak breaks down roughly as (estimates, not individually measured):
 
@@ -78,7 +78,7 @@ Fixes (6)(7) are ~200–500 MB of low-hanging fruit but don't meaningfully move 
 3. **umya save** — full serialisation, ~30–60 s.
 4. **Per-cell dispatch** — scheduler indirection on every cell.
 5. **Computed-overlay writeback** — extra pass over every formula cell.
-6. **Linear / binary-search lookups** — no hash index for VLOOKUP / XLOOKUP / MATCH exact match. 400k × 10 formulas × lookup scan = O(rows × lookup_table_size) comparisons.
+6. **Linear / binary-search lookups** — no hash index for VLOOKUP / XLOOKUP / MATCH exact match. 700k × 10 formulas × lookup scan = O(rows × lookup_table_size) comparisons.
 
 ## What's good
 

--- a/docs/research/prior-art.md
+++ b/docs/research/prior-art.md
@@ -19,7 +19,7 @@ Surveyed April 2026.
 
 ## Where each fits
 
-- **formualizer** — Rust, high function coverage, graph-based. Measured 3.3 GB RSS and 5h 40m wall-clock on 400k × 20. We reuse the parser; we replace the engine.
+- **formualizer** — Rust, high function coverage, graph-based. Measured 3.3 GB RSS and 5h 40m wall-clock on 700k × 20. We reuse the parser; we replace the engine.
 - **IronCalc** — new, promising, full spreadsheet including UI. pip-installable as `ironcalc`. Focused on being a LibreOffice/Excel replacement, not specifically a batch evaluator. Different niche from us.
 - **HyperFormula** — GPL; unusable for commercial embedding without a paid licence. Also TS, not Python-reachable without subprocess.
 - **pycel / xlcalculator / formulas / koala2** — pure Python; correct but 10–100× slower than Rust-backed engines. Fine for < 10k-row workloads.
@@ -75,8 +75,8 @@ If you're an agent implementing a phase, `functions.md` is what you tick boxes a
 ## Benchmark gap
 
 Nobody publishes standardised "evaluate N-row xlsx" benchmarks. We produce one as part of v0.1:
-- Reference workload: `benchmark_large_400k.xlsx` (400k × 20, 10 formula columns, 2 lookup sheets).
-- Published results in `docs/research/benchmarks.md`.
+- Reference workload: `benchmark_large_formulas.xlsx` (700k × 20, 10 formula columns, 2 lookup sheets).
+- Published results in [`docs/benchmarks.md`](../benchmarks.md).
 - Plot over time on `gh-pages` via criterion + github-action-benchmark.
 
 ## References


### PR DESCRIPTION
## Summary

- Fix all "400k x 20" references to "700k x 20" across 8 files — the formualizer baseline was measured on a 700k-row workbook
- Rewrite README: table-driven, concise, modeled after polars/ruff/uv patterns

## Changes

- **README.md**: performance comparison table, function counts table (not full listings), install/usage/docs sections
- **CLAUDE.md**: 400k → 700k in design goal and non-negotiables
- **docs/brief.md**: 400k → 700k in problem statement and success criteria
- **docs/benchmarks.md**: 400k → 700k in comparative table
- **docs/research/benchmarks.md**: 400k → 700k in reference workload
- **docs/research/formualizer.md**: 400k → 700k throughout
- **docs/research/prior-art.md**: 400k → 700k, fix benchmark doc link
- **docs/architecture/parallelism.md**: 400k → 700k in reader/seek sections