### PR TITLE
fix: cross-sheet conditional aggregates return #VALUE!

### DIFF
--- a/crates/xlstream-eval/src/builtins/multi_conditional.rs
+++ b/crates/xlstream-eval/src/builtins/multi_conditional.rs
@@ -29,12 +29,12 @@ fn extract_static_criteria(
     coerce::to_text(&val).to_ascii_lowercase()
 }
 
-/// Extract column index from a range reference argument. Returns the
-/// 1-based column index if the argument is a whole-column range
-/// (e.g., `A:A`).
-fn extract_criteria_col(node: NodeRef<'_>) -> Option<u32> {
+/// Extract column index and optional sheet from a range reference argument.
+fn extract_criteria_col_and_sheet(node: NodeRef<'_>) -> Option<(u32, Option<String>)> {
     match node.view() {
-        NodeView::RangeRef { start_col: Some(sc), end_col: Some(ec), .. } if sc == ec => Some(sc),
+        NodeView::RangeRef { sheet, start_col: Some(sc), end_col: Some(ec), .. } if sc == ec => {
+            Some((sc, sheet.map(ToString::to_string)))
+        }
         _ => None,
     }
 }
@@ -54,7 +54,7 @@ pub(crate) fn builtin_sumifs(
         return Value::Error(CellError::Value);
     }
 
-    let Some(sum_col) = extract_criteria_col(args[0]) else {
+    let Some((sum_col, sheet)) = extract_criteria_col_and_sheet(args[0]) else {
         return Value::Error(CellError::Value);
     };
 
@@ -66,7 +66,7 @@ pub(crate) fn builtin_sumifs(
         let range_idx = 1 + i * 2;
         let crit_idx = 2 + i * 2;
 
-        let Some(col) = extract_criteria_col(args[range_idx]) else {
+        let Some((col, _)) = extract_criteria_col_and_sheet(args[range_idx]) else {
             return Value::Error(CellError::Value);
         };
         criteria_cols.push(col);
@@ -75,7 +75,7 @@ pub(crate) fn builtin_sumifs(
         criteria_values.push(val);
     }
 
-    let key = MultiConditionalAggKey { kind: AggKind::Sum, sum_col, criteria_cols, sheet: None };
+    let key = MultiConditionalAggKey { kind: AggKind::Sum, sum_col, criteria_cols, sheet };
 
     let composite = build_composite_key(&criteria_values);
     interp.prelude().get_multi_conditional(&key, &composite)
@@ -98,23 +98,25 @@ pub(crate) fn builtin_countifs(
     let num_pairs = args.len() / 2;
     let mut criteria_cols = Vec::with_capacity(num_pairs);
     let mut criteria_values = Vec::with_capacity(num_pairs);
+    let mut sheet: Option<String> = None;
 
     for i in 0..num_pairs {
         let range_idx = i * 2;
         let crit_idx = i * 2 + 1;
 
-        let Some(col) = extract_criteria_col(args[range_idx]) else {
+        let Some((col, s)) = extract_criteria_col_and_sheet(args[range_idx]) else {
             return Value::Error(CellError::Value);
         };
         criteria_cols.push(col);
+        if i == 0 {
+            sheet = s;
+        }
 
         let val = extract_static_criteria(args[crit_idx], interp, scope);
         criteria_values.push(val);
     }
 
-    // COUNTIFS uses sum_col = 0 as a sentinel (no sum column needed).
-    let key =
-        MultiConditionalAggKey { kind: AggKind::Count, sum_col: 0, criteria_cols, sheet: None };
+    let key = MultiConditionalAggKey { kind: AggKind::Count, sum_col: 0, criteria_cols, sheet };
 
     let composite = build_composite_key(&criteria_values);
     interp.prelude().get_multi_conditional(&key, &composite)
@@ -134,7 +136,7 @@ pub(crate) fn builtin_averageifs(
         return Value::Error(CellError::Value);
     }
 
-    let Some(sum_col) = extract_criteria_col(args[0]) else {
+    let Some((sum_col, sheet)) = extract_criteria_col_and_sheet(args[0]) else {
         return Value::Error(CellError::Value);
     };
 
@@ -146,7 +148,7 @@ pub(crate) fn builtin_averageifs(
         let range_idx = 1 + i * 2;
         let crit_idx = 2 + i * 2;
 
-        let Some(col) = extract_criteria_col(args[range_idx]) else {
+        let Some((col, _)) = extract_criteria_col_and_sheet(args[range_idx]) else {
             return Value::Error(CellError::Value);
         };
         criteria_cols.push(col);
@@ -155,8 +157,7 @@ pub(crate) fn builtin_averageifs(
         criteria_values.push(val);
     }
 
-    let key =
-        MultiConditionalAggKey { kind: AggKind::Average, sum_col, criteria_cols, sheet: None };
+    let key = MultiConditionalAggKey { kind: AggKind::Average, sum_col, criteria_cols, sheet };
 
     let composite = build_composite_key(&criteria_values);
     interp.prelude().get_multi_conditional(&key, &composite)
@@ -171,11 +172,11 @@ pub(crate) fn builtin_sumif(
     if args.len() < 2 || args.len() > 3 {
         return Value::Error(CellError::Value);
     }
-    let Some(criteria_col) = extract_criteria_col(args[0]) else {
+    let Some((criteria_col, sheet)) = extract_criteria_col_and_sheet(args[0]) else {
         return Value::Error(CellError::Value);
     };
     let sum_col = if args.len() >= 3 {
-        let Some(sc) = extract_criteria_col(args[2]) else {
+        let Some((sc, _)) = extract_criteria_col_and_sheet(args[2]) else {
             return Value::Error(CellError::Value);
         };
         sc
@@ -187,7 +188,7 @@ pub(crate) fn builtin_sumif(
         kind: AggKind::Sum,
         sum_col,
         criteria_cols: vec![criteria_col],
-        sheet: None,
+        sheet,
     };
     let composite = build_composite_key(&[criteria_val]);
     interp.prelude().get_multi_conditional(&key, &composite)
@@ -202,7 +203,7 @@ pub(crate) fn builtin_countif(
     if args.len() != 2 {
         return Value::Error(CellError::Value);
     }
-    let Some(criteria_col) = extract_criteria_col(args[0]) else {
+    let Some((criteria_col, sheet)) = extract_criteria_col_and_sheet(args[0]) else {
         return Value::Error(CellError::Value);
     };
     let criteria_val = extract_static_criteria(args[1], interp, scope);
@@ -210,7 +211,7 @@ pub(crate) fn builtin_countif(
         kind: AggKind::Count,
         sum_col: 0,
         criteria_cols: vec![criteria_col],
-        sheet: None,
+        sheet,
     };
     let composite = build_composite_key(&[criteria_val]);
     interp.prelude().get_multi_conditional(&key, &composite)
@@ -225,11 +226,11 @@ pub(crate) fn builtin_averageif(
     if args.len() < 2 || args.len() > 3 {
         return Value::Error(CellError::Value);
     }
-    let Some(criteria_col) = extract_criteria_col(args[0]) else {
+    let Some((criteria_col, sheet)) = extract_criteria_col_and_sheet(args[0]) else {
         return Value::Error(CellError::Value);
     };
     let sum_col = if args.len() >= 3 {
-        let Some(sc) = extract_criteria_col(args[2]) else {
+        let Some((sc, _)) = extract_criteria_col_and_sheet(args[2]) else {
             return Value::Error(CellError::Value);
         };
         sc
@@ -241,7 +242,7 @@ pub(crate) fn builtin_averageif(
         kind: AggKind::Average,
         sum_col,
         criteria_cols: vec![criteria_col],
-        sheet: None,
+        sheet,
     };
     let composite = build_composite_key(&[criteria_val]);
     interp.prelude().get_multi_conditional(&key, &composite)

--- a/crates/xlstream-eval/src/prelude_plan.rs
+++ b/crates/xlstream-eval/src/prelude_plan.rs
@@ -672,8 +672,11 @@ pub fn execute_prelude(
             }
         }
 
-        // Feed multi-conditional folds.
+        // Feed multi-conditional folds (main-sheet keys only).
         for (i, mk) in multi_keys.iter().enumerate() {
+            if mk.sheet.is_some() {
+                continue;
+            }
             // Build composite key from criteria columns.
             let mut composite_parts: Vec<String> = Vec::with_capacity(mk.criteria_cols.len());
             for &cc in &mk.criteria_cols {
@@ -698,6 +701,47 @@ pub fn execute_prelude(
                 continue;
             };
             folds_map.entry(composite).or_insert_with(FoldState::new).feed(feed_val);
+        }
+    }
+
+    // Release mutable borrow on reader before cross-sheet scanning.
+    drop(stream);
+
+    // Cross-sheet multi-conditional pass: scan non-main sheets.
+    let mut cross_sheet_keys: HashMap<
+        String,
+        Vec<(usize, &crate::prelude::MultiConditionalAggKey)>,
+    > = HashMap::new();
+    for (i, mk) in multi_keys.iter().enumerate() {
+        if let Some(ref sheet_name) = mk.sheet {
+            cross_sheet_keys.entry(sheet_name.clone()).or_default().push((i, mk));
+        }
+    }
+
+    for (sheet_name, sheet_keys) in &cross_sheet_keys {
+        let mut cs_stream = reader.cells(sheet_name)?;
+        while let Some((_row_idx, row_values)) = cs_stream.next_row()? {
+            for &(i, mk) in sheet_keys {
+                let mut composite_parts: Vec<String> = Vec::with_capacity(mk.criteria_cols.len());
+                for &cc in &mk.criteria_cols {
+                    let idx = (cc as usize).saturating_sub(1);
+                    let val = row_values.get(idx).unwrap_or(&Value::Empty);
+                    composite_parts.push(xlstream_core::coerce::to_text(val).to_ascii_lowercase());
+                }
+                let composite = composite_parts.join("\0");
+
+                let feed_val = if mk.sum_col > 0 {
+                    let idx = (mk.sum_col as usize).saturating_sub(1);
+                    row_values.get(idx).unwrap_or(&Value::Empty)
+                } else {
+                    &Value::Number(1.0)
+                };
+
+                let Some(folds_map) = multi_folds.get_mut(&i) else {
+                    continue;
+                };
+                folds_map.entry(composite).or_insert_with(FoldState::new).feed(feed_val);
+            }
         }
     }
 

--- a/crates/xlstream-eval/src/prelude_plan.rs
+++ b/crates/xlstream-eval/src/prelude_plan.rs
@@ -335,10 +335,12 @@ fn collect_multi_keys_recursive(
     }
 }
 
-/// Extract column from a range-ref node (whole-column like `A:A`).
-fn extract_range_col(node: xlstream_parse::NodeRef<'_>) -> Option<u32> {
+/// Extract column and optional sheet from a range-ref node (whole-column like `A:A` or `Sheet!A:A`).
+fn extract_range_col_and_sheet(node: xlstream_parse::NodeRef<'_>) -> Option<(u32, Option<String>)> {
     match node.view() {
-        NodeView::RangeRef { start_col: Some(sc), end_col: Some(ec), .. } if sc == ec => Some(sc),
+        NodeView::RangeRef { sheet, start_col: Some(sc), end_col: Some(ec), .. } if sc == ec => {
+            Some((sc, sheet.map(ToString::to_string)))
+        }
         _ => None,
     }
 }
@@ -352,18 +354,18 @@ fn extract_sumifs_key(
     if args.len() < 3 || (args.len() - 1) % 2 != 0 {
         return None;
     }
-    let sum_col = extract_range_col(args[0])?;
+    let (sum_col, sheet) = extract_range_col_and_sheet(args[0])?;
     let num_pairs = (args.len() - 1) / 2;
     let mut criteria_cols = Vec::with_capacity(num_pairs);
     for i in 0..num_pairs {
-        let col = extract_range_col(args[1 + i * 2])?;
+        let (col, _) = extract_range_col_and_sheet(args[1 + i * 2])?;
         criteria_cols.push(col);
     }
     Some(crate::prelude::MultiConditionalAggKey {
         kind: AggKind::Sum,
         sum_col,
         criteria_cols,
-        sheet: None,
+        sheet,
     })
 }
 
@@ -378,15 +380,19 @@ fn extract_countifs_key(
     }
     let num_pairs = args.len() / 2;
     let mut criteria_cols = Vec::with_capacity(num_pairs);
+    let mut sheet: Option<String> = None;
     for i in 0..num_pairs {
-        let col = extract_range_col(args[i * 2])?;
+        let (col, s) = extract_range_col_and_sheet(args[i * 2])?;
         criteria_cols.push(col);
+        if i == 0 {
+            sheet = s;
+        }
     }
     Some(crate::prelude::MultiConditionalAggKey {
         kind: AggKind::Count,
         sum_col: 0,
         criteria_cols,
-        sheet: None,
+        sheet,
     })
 }
 
@@ -399,18 +405,18 @@ fn extract_averageifs_key(
     if args.len() < 3 || (args.len() - 1) % 2 != 0 {
         return None;
     }
-    let sum_col = extract_range_col(args[0])?;
+    let (sum_col, sheet) = extract_range_col_and_sheet(args[0])?;
     let num_pairs = (args.len() - 1) / 2;
     let mut criteria_cols = Vec::with_capacity(num_pairs);
     for i in 0..num_pairs {
-        let col = extract_range_col(args[1 + i * 2])?;
+        let (col, _) = extract_range_col_and_sheet(args[1 + i * 2])?;
         criteria_cols.push(col);
     }
     Some(crate::prelude::MultiConditionalAggKey {
         kind: AggKind::Average,
         sum_col,
         criteria_cols,
-        sheet: None,
+        sheet,
     })
 }
 
@@ -423,13 +429,18 @@ fn extract_sumif_key(
     if args.len() < 2 || args.len() > 3 {
         return None;
     }
-    let criteria_col = extract_range_col(args[0])?;
-    let sum_col = if args.len() >= 3 { extract_range_col(args[2])? } else { criteria_col };
+    let (criteria_col, sheet) = extract_range_col_and_sheet(args[0])?;
+    let sum_col = if args.len() >= 3 {
+        let (sc, _) = extract_range_col_and_sheet(args[2])?;
+        sc
+    } else {
+        criteria_col
+    };
     Some(crate::prelude::MultiConditionalAggKey {
         kind: AggKind::Sum,
         sum_col,
         criteria_cols: vec![criteria_col],
-        sheet: None,
+        sheet,
     })
 }
 
@@ -442,12 +453,12 @@ fn extract_countif_key(
     if args.len() != 2 {
         return None;
     }
-    let criteria_col = extract_range_col(args[0])?;
+    let (criteria_col, sheet) = extract_range_col_and_sheet(args[0])?;
     Some(crate::prelude::MultiConditionalAggKey {
         kind: AggKind::Count,
         sum_col: 0,
         criteria_cols: vec![criteria_col],
-        sheet: None,
+        sheet,
     })
 }
 
@@ -460,13 +471,18 @@ fn extract_averageif_key(
     if args.len() < 2 || args.len() > 3 {
         return None;
     }
-    let criteria_col = extract_range_col(args[0])?;
-    let sum_col = if args.len() >= 3 { extract_range_col(args[2])? } else { criteria_col };
+    let (criteria_col, sheet) = extract_range_col_and_sheet(args[0])?;
+    let sum_col = if args.len() >= 3 {
+        let (sc, _) = extract_range_col_and_sheet(args[2])?;
+        sc
+    } else {
+        criteria_col
+    };
     Some(crate::prelude::MultiConditionalAggKey {
         kind: AggKind::Average,
         sum_col,
         criteria_cols: vec![criteria_col],
-        sheet: None,
+        sheet,
     })
 }
 
@@ -1016,6 +1032,61 @@ mod tests {
         let keys = collect_multi_conditional_keys(&rewritten);
         assert_eq!(keys.len(), 1);
         assert_eq!(keys[0].sum_col, 1);
+        assert_eq!(keys[0].criteria_cols, vec![1]);
+    }
+
+    #[test]
+    fn collect_multi_keys_extracts_cross_sheet_sumif() {
+        let ast = xlstream_parse::parse("SUMIF(RefData!A:A,A2,RefData!B:B)").unwrap();
+        let ctx = xlstream_parse::ClassificationContext::for_cell("Main", 2, 5)
+            .with_lookup_sheet("RefData");
+        let verdict = xlstream_parse::classify(&ast, &ctx);
+        let rewritten = xlstream_parse::rewrite(ast, &ctx, &verdict);
+        let keys = collect_multi_conditional_keys(&rewritten);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].sheet.as_deref(), Some("RefData"));
+        assert_eq!(keys[0].sum_col, 2);
+        assert_eq!(keys[0].criteria_cols, vec![1]);
+    }
+
+    #[test]
+    fn collect_multi_keys_extracts_cross_sheet_countif() {
+        let ast = xlstream_parse::parse("COUNTIF(RefData!A:A,A2)").unwrap();
+        let ctx = xlstream_parse::ClassificationContext::for_cell("Main", 2, 5)
+            .with_lookup_sheet("RefData");
+        let verdict = xlstream_parse::classify(&ast, &ctx);
+        let rewritten = xlstream_parse::rewrite(ast, &ctx, &verdict);
+        let keys = collect_multi_conditional_keys(&rewritten);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].sheet.as_deref(), Some("RefData"));
+        assert_eq!(keys[0].criteria_cols, vec![1]);
+    }
+
+    #[test]
+    fn collect_multi_keys_extracts_cross_sheet_averageif() {
+        let ast = xlstream_parse::parse("AVERAGEIF(RefData!A:A,A2,RefData!B:B)").unwrap();
+        let ctx = xlstream_parse::ClassificationContext::for_cell("Main", 2, 5)
+            .with_lookup_sheet("RefData");
+        let verdict = xlstream_parse::classify(&ast, &ctx);
+        let rewritten = xlstream_parse::rewrite(ast, &ctx, &verdict);
+        let keys = collect_multi_conditional_keys(&rewritten);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].sheet.as_deref(), Some("RefData"));
+        assert_eq!(keys[0].sum_col, 2);
+        assert_eq!(keys[0].criteria_cols, vec![1]);
+    }
+
+    #[test]
+    fn collect_multi_keys_extracts_cross_sheet_sumifs() {
+        let ast = xlstream_parse::parse("SUMIFS(RefData!B:B,RefData!A:A,A2)").unwrap();
+        let ctx = xlstream_parse::ClassificationContext::for_cell("Main", 2, 5)
+            .with_lookup_sheet("RefData");
+        let verdict = xlstream_parse::classify(&ast, &ctx);
+        let rewritten = xlstream_parse::rewrite(ast, &ctx, &verdict);
+        let keys = collect_multi_conditional_keys(&rewritten);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].sheet.as_deref(), Some("RefData"));
+        assert_eq!(keys[0].sum_col, 2);
         assert_eq!(keys[0].criteria_cols, vec![1]);
     }
 }

--- a/crates/xlstream-eval/tests/regressions/issue_cross_sheet_aggregates.rs
+++ b/crates/xlstream-eval/tests/regressions/issue_cross_sheet_aggregates.rs
@@ -55,6 +55,46 @@ fn build_cross_sheet_fixture(input: &std::path::Path) {
     wb.save(input).unwrap();
 }
 
+fn build_cross_sheet_fixture_with_sumifs(input: &std::path::Path) {
+    let mut wb = Workbook::new();
+
+    let ws_ref = wb.add_worksheet();
+    ws_ref.set_name("RefData").unwrap();
+    let data: &[(&str, f64)] =
+        &[("EMEA", 500.0), ("APAC", 300.0), ("AMER", 700.0), ("EMEA", 200.0), ("APAC", 400.0)];
+    for (i, &(region, amount)) in data.iter().enumerate() {
+        let r = i as u32;
+        ws_ref.write_string(r, 0, region).unwrap();
+        ws_ref.write_number(r, 1, amount).unwrap();
+    }
+
+    let ws_main = wb.add_worksheet();
+    ws_main.set_name("Main").unwrap();
+    ws_main.write_string(0, 0, "Label").unwrap();
+    ws_main.write_string(0, 1, "SumifsResult").unwrap();
+
+    ws_main.write_string(1, 0, "test").unwrap();
+    ws_main.write_formula(1, 1, Formula::new("=SUMIFS(RefData!B:B,RefData!A:A,\"EMEA\")")).unwrap();
+
+    wb.save(input).unwrap();
+}
+
+#[test]
+fn sumifs_on_non_streaming_sheet() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    build_cross_sheet_fixture_with_sumifs(&input);
+    evaluate(&input, &output, None).unwrap();
+
+    let mut reader = Reader::open(&output).unwrap();
+    let rows = read_all_rows(&mut reader, "Main");
+
+    // SUMIFS(RefData!B:B, RefData!A:A, "EMEA") = 500 + 200 = 700
+    assert_eq!(rows[1].1[1], Value::Number(700.0), "cross-sheet SUMIFS");
+}
+
 #[test]
 #[ignore = "bug: cross-sheet conditional aggregates return #VALUE! (see issue.md section 2)"]
 fn sumif_on_non_streaming_sheet() {

--- a/crates/xlstream-eval/tests/regressions/issue_cross_sheet_aggregates.rs
+++ b/crates/xlstream-eval/tests/regressions/issue_cross_sheet_aggregates.rs
@@ -96,7 +96,6 @@ fn sumifs_on_non_streaming_sheet() {
 }
 
 #[test]
-#[ignore = "bug: cross-sheet conditional aggregates return #VALUE! (see issue.md section 2)"]
 fn sumif_on_non_streaming_sheet() {
     let dir = TempDir::new().unwrap();
     let input = dir.path().join("input.xlsx");
@@ -113,7 +112,6 @@ fn sumif_on_non_streaming_sheet() {
 }
 
 #[test]
-#[ignore = "bug: cross-sheet conditional aggregates return #VALUE! (see issue.md section 2)"]
 fn countif_on_non_streaming_sheet() {
     let dir = TempDir::new().unwrap();
     let input = dir.path().join("input.xlsx");
@@ -130,7 +128,6 @@ fn countif_on_non_streaming_sheet() {
 }
 
 #[test]
-#[ignore = "bug: cross-sheet conditional aggregates return #VALUE! (see issue.md section 2)"]
 fn averageif_on_non_streaming_sheet() {
     let dir = TempDir::new().unwrap();
     let input = dir.path().join("input.xlsx");


### PR DESCRIPTION
## Summary

- Propagate `sheet` field from parsed `RangeRef` nodes through conditional aggregate key extraction (`prelude_plan.rs`) and runtime builtin lookup (`multi_conditional.rs`)
- Add cross-sheet scanning pass in `execute_prelude` — after the main-sheet stream completes, scan each non-main sheet referenced by multi-conditional keys
- Un-ignore 3 regression tests, add 1 new SUMIFS cross-sheet test

Fixes #2 (cross-sheet SUMIF/COUNTIF/AVERAGEIF return #VALUE!).
Also fixes #3 (cross-sheet SUMIFS/COUNTIFS return 0).

## Test plan

- [x] 4 new unit tests for cross-sheet key extraction (`collect_multi_keys_extracts_cross_sheet_*`)
- [x] 4 integration tests pass end-to-end (`sumif_on_non_streaming_sheet`, `countif_on_non_streaming_sheet`, `averageif_on_non_streaming_sheet`, `sumifs_on_non_streaming_sheet`)
- [x] 838 unit tests pass, 0 regressions
- [x] Golden-file: all `agg_sumif/countif/avgif/sumifs/cntifs` columns removed from mismatch list
- [x] Benchmark: within noise threshold (+1.1%)