### PR TITLE
fix: PRODUCT with literal args returns #VALUE!

### DIFF
--- a/crates/xlstream-eval/src/builtins/mod.rs
+++ b/crates/xlstream-eval/src/builtins/mod.rs
@@ -79,6 +79,7 @@ pub(crate) fn expand_range(
 /// Look up `name` (case-insensitive) and call the matching builtin.
 ///
 /// Returns `None` for unknown functions — the caller decides the fallback.
+#[allow(clippy::too_many_lines)]
 pub(crate) fn dispatch(
     name: &str,
     args: &[NodeRef<'_>],
@@ -105,6 +106,9 @@ pub(crate) fn dispatch(
         "SUMIF" => Some(multi_conditional::builtin_sumif(args, interp, scope)),
         "COUNTIF" => Some(multi_conditional::builtin_countif(args, interp, scope)),
         "AVERAGEIF" => Some(multi_conditional::builtin_averageif(args, interp, scope)),
+        "PRODUCT" => {
+            Some(aggregate::product(&eval_args(args, interp, scope)).unwrap_or_else(Value::Error))
+        }
         "VLOOKUP" => Some(lookup::builtin_vlookup(args, interp, scope)),
         "XLOOKUP" | "_XLFN.XLOOKUP" => Some(lookup::builtin_xlookup(args, interp, scope)),
         "HLOOKUP" => Some(lookup::builtin_hlookup(args, interp, scope)),

--- a/crates/xlstream-eval/tests/regressions/issue_product_literals.rs
+++ b/crates/xlstream-eval/tests/regressions/issue_product_literals.rs
@@ -13,7 +13,6 @@ use xlstream_core::Value;
 use xlstream_eval::evaluate;
 
 #[test]
-#[ignore = "bug: PRODUCT with literal args returns #VALUE! (see issue.md section 3)"]
 fn product_literal_args() {
     let dir = TempDir::new().unwrap();
     let input = dir.path().join("input.xlsx");
@@ -39,7 +38,6 @@ fn product_literal_args() {
 }
 
 #[test]
-#[ignore = "bug: PRODUCT with literal args returns #VALUE! (see issue.md section 3)"]
 fn product_cell_ref_args() {
     let dir = TempDir::new().unwrap();
     let input = dir.path().join("input.xlsx");

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -470,6 +470,7 @@ fn classify_function(name: &str, args: &[Node], ctx: &ClassificationContext) -> 
 fn classify_aggregate(name: &str, args: &[Node], ctx: &ClassificationContext) -> Disposition {
     let upper = name.to_uppercase();
     let mut has_row_local_criteria = false;
+    let mut has_aggregate_arg = false;
     for (i, arg) in args.iter().enumerate() {
         if is_criteria_arg(&upper, i) && contains_row_local_ref(arg, ctx) {
             has_row_local_criteria = true;
@@ -483,11 +484,16 @@ fn classify_aggregate(name: &str, args: &[Node], ctx: &ClassificationContext) ->
         if matches!(d, Disposition::Unsupported(_)) {
             return d;
         }
+        if matches!(d, Disposition::Aggregate) {
+            has_aggregate_arg = true;
+        }
     }
     if has_row_local_criteria {
         Disposition::Mixed
-    } else {
+    } else if has_aggregate_arg {
         Disposition::Aggregate
+    } else {
+        Disposition::RowLocal
     }
 }
 
@@ -727,5 +733,33 @@ mod tests {
         let ast = crate::parse("SUMIF(A:A,\"EMEA\",B:B)").unwrap();
         let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
         assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+    }
+
+    #[test]
+    fn aggregate_with_literal_args_is_row_local() {
+        let ast = crate::parse("PRODUCT(2,3,4)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 3);
+        assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+    }
+
+    #[test]
+    fn aggregate_with_cell_ref_args_is_row_local() {
+        let ast = crate::parse("PRODUCT(A2,B2)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 3);
+        assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
+    }
+
+    #[test]
+    fn aggregate_with_range_arg_stays_aggregate() {
+        let ast = crate::parse("PRODUCT(A:A)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 3);
+        assert_eq!(classify(&ast, &ctx), Classification::AggregateOnly);
+    }
+
+    #[test]
+    fn sum_with_literal_args_is_row_local() {
+        let ast = crate::parse("SUM(1,2,3)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 3);
+        assert_eq!(classify(&ast, &ctx), Classification::RowLocal);
     }
 }


### PR DESCRIPTION
## Summary

- Add PRODUCT to builtin dispatch table with eager arg evaluation via existing `aggregate::product()`
- Fix `classify_aggregate()` to return `RowLocal` when all args are non-range (literals, current-row cell refs) — prevents unnecessary rewrite pass
- Un-ignore 2 regression tests

Fixes #4 (PRODUCT(2,3,4) returns #VALUE!).

Generalizes: after the classification fix, `SUM(1,2,3)`, `COUNT(A2,B2)`, `MIN(5,10)` etc. also classify as RowLocal. They'd need dispatch entries to work inline — deferred to follow-up PRs.

## Test plan

- [x] 2 regression tests pass (`product_literal_args`=24.0, `product_cell_ref_args`=30.0)
- [x] 4 new classification tests (`aggregate_with_literal_args_is_row_local`, `aggregate_with_cell_ref_args_is_row_local`, `aggregate_with_range_arg_stays_aggregate`, `sum_with_literal_args_is_row_local`)
- [x] Existing `product_whole_column_returns_precomputed_scalar` still passes (PreludeRef path unchanged)
- [x] Golden-file: all `agg_product` mismatches eliminated (10 cells)
- [x] 838+ unit tests pass, 0 regressions