### PR TITLE
fix: COUNTA skips header row — off by one

### DIFF
--- a/crates/xlstream-eval/src/prelude_plan.rs
+++ b/crates/xlstream-eval/src/prelude_plan.rs
@@ -649,12 +649,11 @@ pub fn execute_prelude(
         let excel_row = calamine_row_idx + 1; // 1-based
         calamine_row_idx += 1;
 
-        if !header_skipped {
+        if header_skipped {
+            data_row_count = data_row_count.saturating_add(1);
+        } else {
             header_skipped = true;
-            continue;
         }
-
-        data_row_count = data_row_count.saturating_add(1);
 
         // Feed simple aggregate folds.
         for (&col, fold) in &mut col_folds {


### PR DESCRIPTION
## Summary

- Remove `continue` from the header-skip guard in `execute_prelude` so aggregate folds see all rows including the header
- `data_row_count` (used for parallelism) still excludes the header

Safe for numeric aggregates: `FoldState::feed` already ignores text values for SUM/AVERAGE/MIN/MAX. Only COUNTA/COUNTBLANK are affected.

Fixes #5.

## Test plan

- [x] Golden-file: all 10 `agg_counta` mismatches eliminated (expected 7.0, was 6.0)
- [x] Full test suite passes, 0 regressions
- [x] fmt + clippy clean