### PR TITLE
fix: FLOOR(-2.3, 1) returns #NUM! instead of -3

### DIFF
--- a/crates/xlstream-eval/src/builtins/math.rs
+++ b/crates/xlstream-eval/src/builtins/math.rs
@@ -274,9 +274,6 @@ pub(crate) fn builtin_floor(args: &[Value]) -> Value {
     if sig == 0.0 {
         return Value::Number(0.0);
     }
-    if x < 0.0 && sig > 0.0 {
-        return Value::Error(CellError::Num);
-    }
     Value::Number((x / sig).floor() * sig)
 }
 
@@ -944,11 +941,9 @@ mod tests {
     }
 
     #[test]
-    fn floor_negative_x_positive_sig_returns_num() {
-        assert_eq!(
-            builtin_floor(&[Value::Number(-5.0), Value::Number(1.0)]),
-            Value::Error(CellError::Num)
-        );
+    fn floor_negative_x_positive_sig_rounds_toward_neg_infinity() {
+        assert_eq!(builtin_floor(&[Value::Number(-5.0), Value::Number(1.0)]), Value::Number(-5.0));
+        assert_eq!(builtin_floor(&[Value::Number(-2.3), Value::Number(1.0)]), Value::Number(-3.0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove legacy sign-mismatch guard in `builtin_floor` that returned `#NUM!` when number is negative and significance is positive
- The existing formula `(x / sig).floor() * sig` already produces correct results for all sign combinations in modern Excel (2010+)

Fixes #7.

## Test plan

- [x] Golden-file: `m_floor` mismatch eliminated (row 6)
- [x] Updated unit test verifies `FLOOR(-5, 1) = -5` and `FLOOR(-2.3, 1) = -3`
- [x] All existing FLOOR tests pass
- [x] Full test suite passes, 0 regressions