### PR TITLE
fix: treat empty string as equivalent to empty in golden-file comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,22 @@ Semver.
 ### Added
 - Golden-file regression test suite comparing xlstream output against Excel-cached values (117 formula surfaces)
 - Per-issue regression test framework (`regression_per_issue.rs`) with ignored-until-fixed workflow
+- `EXCEL_MAX_ROWS` (1,048,576) and `EXCEL_MAX_COLS` (16,384) constants in xlstream-core
 
 ### Fixed
 - SUMIF/COUNTIF/AVERAGEIF with row-local criteria (e.g., `SUMIF(A:A,A2,B:B)`) no longer rejected at classification with `NonStaticCriteria`; pre-computes grouped aggregate maps in prelude, O(1) lookup per row
+- Cross-sheet conditional aggregates (e.g., `SUMIF(RefData!A:A,"EMEA",RefData!B:B)`) now correctly scan non-main sheets during prelude; previously returned `#VALUE!` or 0
+- `PRODUCT(2,3,4)` with literal/cell-ref args no longer returns `#VALUE!`; aggregate functions with all-scalar args now classify as RowLocal and evaluate inline
+- `COUNTA(H:H)` includes header row in prelude scan; previously undercounted by 1
+- `COUNTBLANK(H:H)` uses `EXCEL_MAX_ROWS - COUNTA` for whole-column ranges to match Excel's 1M+ row grid semantics
+- `FLOOR(-2.3, 1)` returns -3 instead of `#NUM!`; removed legacy sign-mismatch check to match modern Excel (2010+)
+
+### Known Limitations
+- Empty string cells (e.g., `MID("x",2,3)` → `""`) are written as blank by `rust_xlsxwriter` (library discards empty strings); downstream readers see `Empty` instead of `""`. Golden-file comparison treats these as equivalent.
 
 ### Changed
 - Renamed test files: `regression.rs` → `regression_base.rs` (golden-file), `regression_base.rs` → `regression_per_issue.rs` (per-issue)
+- `classify_aggregate` returns `RowLocal` when all args are scalar (no column ranges); generalizes to SUM/COUNT/MIN/MAX with literal args
 
 ## [0.1.0] - 2026-04-20
 

--- a/crates/xlstream-eval/tests/regression_base.rs
+++ b/crates/xlstream-eval/tests/regression_base.rs
@@ -452,6 +452,8 @@ fn values_match(expected: &Data, actual: &Data) -> bool {
         | (Data::Bool(false), Data::Int(0))
         | (Data::Int(0), Data::Bool(false))
         | (Data::Empty, Data::Empty) => true,
+        // Empty string ≈ Empty (rust_xlsxwriter discards empty strings)
+        (Data::String(s), Data::Empty) | (Data::Empty, Data::String(s)) if s.is_empty() => true,
         // Error (Excel) vs String (xlstream writes errors as text)
         (Data::Error(e), Data::String(s)) | (Data::String(s), Data::Error(e)) => {
             s == error_to_string(e)


### PR DESCRIPTION
## Summary

- Add `String("") ≈ Empty` equivalence in golden-file `values_match()`
- Root cause: `rust_xlsxwriter` silently discards empty strings (`store_string` returns early when `string.is_empty()` without format) — this is a library limitation, not a logic bug
- MID correctly returns `Value::Text("")`; the xlsx serialization loses the distinction

Fixes #8.

## Test plan

- [x] Golden-file: `tx_mid` row 11 mismatch eliminated
- [x] Full test suite passes, 0 regressions