### PR TITLE
fix: ISREF always returns FALSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Semver.
 - `COUNTA(H:H)` includes header row in prelude scan; previously undercounted by 1
 - `COUNTBLANK(H:H)` uses `EXCEL_MAX_ROWS - COUNTA` for whole-column ranges to match Excel's 1M+ row grid semantics
 - `FLOOR(-2.3, 1)` returns -3 instead of `#NUM!`; removed legacy sign-mismatch check to match modern Excel (2010+)
+- `ISREF(A2)` returns TRUE; moved to lazy dispatch to inspect raw AST node before evaluation
 
 ### Known Limitations
 - Empty string cells (e.g., `MID("x",2,3)` → `""`) are written as blank by `rust_xlsxwriter` (library discards empty strings); downstream readers see `Empty` instead of `""`. Golden-file comparison treats these as equivalent.

--- a/crates/xlstream-eval/src/builtins/info.rs
+++ b/crates/xlstream-eval/src/builtins/info.rs
@@ -166,11 +166,10 @@ pub fn builtin_isnontext(args: &[Value]) -> Value {
 // ISREF
 // ---------------------------------------------------------------------------
 
-/// `ISREF(x)` — always `false`.
+/// `ISREF(x)` — legacy eager-eval stub (always returns `false`).
 ///
-/// By the time builtins run, all references have already been resolved
-/// to concrete values. A proper implementation would require the parser
-/// to preserve ref-vs-value distinction, which is out of scope for v0.1.
+/// Superseded by the lazy dispatch in `builtins/mod.rs` which inspects
+/// the raw AST node. Kept for doc-test backward compat.
 ///
 /// # Examples
 ///

--- a/crates/xlstream-eval/src/builtins/mod.rs
+++ b/crates/xlstream-eval/src/builtins/mod.rs
@@ -14,8 +14,8 @@ pub(crate) mod math;
 mod multi_conditional;
 pub(crate) mod string;
 
-use xlstream_core::Value;
-use xlstream_parse::NodeRef;
+use xlstream_core::{CellError, Value};
+use xlstream_parse::{NodeRef, NodeView};
 
 use crate::interp::Interpreter;
 use crate::scope::RowScope;
@@ -181,7 +181,14 @@ pub(crate) fn dispatch(
         "ISNA" => Some(info::builtin_isna(&eval_args(args, interp, scope))),
         "ISLOGICAL" => Some(info::builtin_islogical(&eval_args(args, interp, scope))),
         "ISNONTEXT" => Some(info::builtin_isnontext(&eval_args(args, interp, scope))),
-        "ISREF" => Some(info::builtin_isref(&eval_args(args, interp, scope))),
+        "ISREF" => {
+            if args.is_empty() {
+                return Some(Value::Error(CellError::Value));
+            }
+            let is_ref =
+                matches!(args[0].view(), NodeView::CellRef { .. } | NodeView::RangeRef { .. });
+            Some(Value::Bool(is_ref))
+        }
         "NA" => Some(info::builtin_na(&eval_args(args, interp, scope))),
         "TYPE" => Some(info::builtin_type(&eval_args(args, interp, scope))),
         // -- financial builtins (pure, eager eval) --


### PR DESCRIPTION
## Summary

- Move ISREF from eager dispatch (args pre-evaluated) to lazy dispatch (inspects raw AST nodes)
- `ISREF(A2)` now returns TRUE by checking for `NodeView::CellRef` or `NodeView::RangeRef`
- Keep legacy `builtin_isref` stub for doc-test compat

Fixes #9.

## Test plan

- [x] Golden-file: all 10 `inf_isref` mismatches eliminated
- [x] Existing ISREF unit tests still pass (non-ref args return FALSE)
- [x] Full test suite passes, 0 regressions