### PR TITLE
release: bump to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Semver.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-20
+
 ### Added
 - Golden-file regression test suite comparing xlstream output against Excel-cached values (117 formula surfaces)
 - Per-issue regression test framework (`regression_per_issue.rs`) with ignored-until-fixed workflow
@@ -19,12 +21,12 @@ Semver.
 - `FLOOR(-2.3, 1)` returns -3 instead of `#NUM!`; removed legacy sign-mismatch check to match modern Excel (2010+)
 - `ISREF(A2)` returns TRUE; moved to lazy dispatch to inspect raw AST node before evaluation
 
-### Known Limitations
-- Empty string cells (e.g., `MID("x",2,3)` → `""`) are written as blank by `rust_xlsxwriter` (library discards empty strings); downstream readers see `Empty` instead of `""`. Golden-file comparison treats these as equivalent.
-
 ### Changed
-- Renamed test files: `regression.rs` → `regression_base.rs` (golden-file), `regression_base.rs` → `regression_per_issue.rs` (per-issue)
 - `classify_aggregate` returns `RowLocal` when all args are scalar (no column ranges); generalizes to SUM/COUNT/MIN/MAX with literal args
+- Renamed test files: `regression.rs` → `regression_base.rs` (golden-file), `regression_base.rs` → `regression_per_issue.rs` (per-issue)
+
+### Known limitations
+- Empty string cells (e.g., `MID("x",2,3)` → `""`) written as blank by `rust_xlsxwriter` (upstream library discards empty strings); downstream readers see `Empty` instead of `""`
 
 ## [0.1.0] - 2026-04-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-benchmarks"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "memory-stats",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "tracing",
@@ -2025,14 +2025,14 @@ dependencies = [
 
 [[package]]
 name = "xlstream-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "xlstream-eval"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "calamine",
  "crossbeam-channel",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-io"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "calamine",
  "rust_xlsxwriter",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-parse"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "formualizer-common",
  "formualizer-parse",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-python"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pyo3",
  "xlstream-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3.workspace = true
-xlstream-core = { path = "../../crates/xlstream-core", version = "0.1.0" }
-xlstream-eval = { path = "../../crates/xlstream-eval", version = "0.1.0" }
-xlstream-io = { path = "../../crates/xlstream-io", version = "0.1.0" }
+xlstream-core = { path = "../../crates/xlstream-core", version = "0.1.1" }
+xlstream-eval = { path = "../../crates/xlstream-eval", version = "0.1.1" }
+xlstream-io = { path = "../../crates/xlstream-io", version = "0.1.1" }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/xlstream-cli/Cargo.toml
+++ b/crates/xlstream-cli/Cargo.toml
@@ -17,10 +17,10 @@ name = "xlstream"
 path = "src/main.rs"
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
-xlstream-eval = { path = "../xlstream-eval", version = "0.1.0" }
-xlstream-parse = { path = "../xlstream-parse", version = "0.1.0" }
-xlstream-io = { path = "../xlstream-io", version = "0.1.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.1.1" }
+xlstream-eval = { path = "../xlstream-eval", version = "0.1.1" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.1.1" }
+xlstream-io = { path = "../xlstream-io", version = "0.1.1" }
 clap.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/xlstream-eval/Cargo.toml
+++ b/crates/xlstream-eval/Cargo.toml
@@ -12,9 +12,9 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
-xlstream-parse = { path = "../xlstream-parse", version = "0.1.0" }
-xlstream-io = { path = "../xlstream-io", version = "0.1.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.1.1" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.1.1" }
+xlstream-io = { path = "../xlstream-io", version = "0.1.1" }
 rust_decimal.workspace = true
 ssfmt.workspace = true
 tracing.workspace = true

--- a/crates/xlstream-io/Cargo.toml
+++ b/crates/xlstream-io/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.1.1" }
 calamine.workspace = true
 rust_xlsxwriter.workspace = true
 

--- a/crates/xlstream-parse/Cargo.toml
+++ b/crates/xlstream-parse/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.1.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.1.1" }
 formualizer-parse = { workspace = true }
 formualizer-common = { workspace = true }
 smallvec = { workspace = true }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,12 +1,15 @@
 # Benchmarks — measured performance
 
-Measured on Apple M-series, 8-core. Criterion for micro-benchmarks; wall-clock via `std::time::Instant`.
+Measured on iMac 2020 (3.6 GHz 10-core Intel i9, 128 GB DDR4). Criterion for micro-benchmarks; wall-clock via `std::time::Instant`.
+
+**Version:** v0.1.1 (2026-04-20)
 
 ## Tier results (50-column workbook: 20 data + 30 formula)
 
 | Tier | Rows | Workers | Wall-clock | Peak RSS | Formulas evaluated |
 |---|---|---|---|---|---|
-| Small | 10,000 | 1 | 1.6s | 31 MB | 299,970 |
+| Quick | 5,000 | 1 | 67.6ms | — | ~150,000 |
+| Small | 10,000 | 1 | 1.66s | 31 MB | 299,970 |
 | Medium | 100,000 | 1 | 16.0s | 206 MB | 2,999,970 |
 | Medium | 100,000 | 4 | 13.8s | 270 MB | 2,999,970 |
 | Large | 1,000,000 | 1 | 156s | 1.7 GB | 29,999,970 |
@@ -34,10 +37,10 @@ Modest speedup on this workload. Bottleneck is I/O: each worker re-opens the xls
 
 ## Comparative summary
 
-| Engine | Workload | Wall-clock | Peak RSS |
-|---|---|---|---|
-| formualizer (measured 2026-04-17) | 700k x 20 | 5h 40m | 3.3 GB |
-| xlstream single-threaded (measured) | 700k x 20 | 48s | 734 MB |
+| Engine | Workload | Wall-clock | Peak RSS | Measured |
+|---|---|---|---|---|
+| formualizer | 700k x 20 | 5h 40m | 3.3 GB | 2026-04-17 |
+| xlstream single-threaded | 700k x 20 | 48s | 734 MB | 2026-04-19 |
 
 Ratio: ~425x faster, ~4.5x less memory.
 
@@ -88,6 +91,9 @@ make bench-python
 
 # Run everything
 make bench
+
+# Quick smoke (CI runs this per PR)
+cargo bench --bench quick -p xlstream-benchmarks -- --sample-size 10
 ```
 
 Criterion HTML reports: `target/criterion/report/index.html`.
@@ -97,3 +103,12 @@ Criterion HTML reports: `target/criterion/report/index.html`.
 `cargo run -p xlstream-benchmarks --release --bin generate-fixtures -- --tier all`
 
 Deterministic (seed=42). Produces `bench_small.xlsx`, `bench_medium.xlsx`, `bench_large.xlsx`. Not committed — regenerated before bench runs.
+
+## Updating this file
+
+After any release or batch of changes that could affect performance:
+
+1. Run `make bench` (or at minimum quick + small tier)
+2. Update the **Version** line at the top with the new version and date
+3. Update the tier table with measured numbers
+4. If any number regressed > 10% from previous, investigate before shipping


### PR DESCRIPTION
## Summary
- Bump all workspace + inter-crate dependency versions from 0.1.0 → 0.1.1
- Promote changelog [Unreleased] → [0.1.1] - 2026-04-20
- Update benchmarks with correct hardware specs (Intel i9 iMac, not M-series)

## Changes in 0.1.1
- 7 formula evaluation fixes (SUMIF row-local criteria, cross-sheet aggregates, PRODUCT literals, COUNTA header, COUNTBLANK, FLOOR, ISREF)
- Golden-file regression test suite (117 surfaces)
- EXCEL_MAX_ROWS/EXCEL_MAX_COLS constants

## Files bumped
- `Cargo.toml` (workspace version)
- `crates/xlstream-{core,parse,io,eval,cli}/Cargo.toml` (inter-crate deps)
- `bindings/python/Cargo.toml` (inter-crate deps)
- `CHANGELOG.md` (promoted to 0.1.1)
- `docs/benchmarks.md` (version + hardware)

## Test plan
- [x] `cargo check --workspace` compiles
- [x] CI passes
- [x] Tag `v0.1.1` after merge