### PR TITLE
fix: PyPI project description is empty

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,6 +7,7 @@ name = "xlstream"
 requires-python = ">=3.9"
 dynamic = ["version"]
 description = "Streaming Excel formula evaluation engine"
+readme = {file = "README.md", content-type = "text/markdown"}
 license = { text = "MIT OR Apache-2.0" }
 authors = [{ name = "Priscilla Emasoga" }]
 classifiers = [


### PR DESCRIPTION
## Summary

- Add `readme = {file = "README.md", content-type = "text/markdown"}` to `bindings/python/pyproject.toml`
- The file existed but wasn't referenced, so maturin never included it in wheel metadata

Fixes #10.

## Test plan

- [x] `maturin build --release` then inspect wheel METADATA for README content