### PR TITLE
ci: add auto-tagging and github release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,49 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags: ["v*"]
 
 jobs:
+  # On push to main, read version from Cargo.toml and create a tag if missing.
+  # The new tag triggers this same workflow again via the tags: ["v*"] trigger,
+  # which runs the build + publish jobs below.
+  tag-release:
+    name: Create Release Tag
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version from Cargo.toml
+        id: meta
+        run: |
+          version="$(awk -F'"' '/^version = / {print $2; exit}' Cargo.toml)"
+          tag="v${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag if missing
+        run: |
+          tag="${{ steps.meta.outputs.tag }}"
+          git fetch --tags --force
+          if git rev-parse "${tag}" >/dev/null 2>&1; then
+            echo "Tag ${tag} already exists — skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "Release ${tag}"
+          git push origin "${tag}"
+
   # Build one wheel per (os, arch). abi3-py39 = Python 3.9-3.14+ covered.
   build-wheels:
     name: wheels (${{ matrix.os }}-${{ matrix.target }})
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -40,7 +77,10 @@ jobs:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: bindings/python/dist/*.whl
 
+  # Source distribution (.tar.gz of Python source). Fallback for platforms
+  # without a prebuilt wheel — pip downloads and compiles locally.
   sdist:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -83,6 +123,74 @@ jobs:
       - uses: actions/download-artifact@v8
         with: { name: sdist, path: dist }
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Creates a GitHub Release with changelog-extracted notes and wheel artifacts.
+  publish-github:
+    name: Publish GitHub Release
+    needs: [build-wheels, sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version from tag
+        id: meta
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="${tag#v}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog section
+        run: |
+          version="${{ steps.meta.outputs.version }}"
+          python3 - "$version" <<'PY'
+          import sys
+          from pathlib import Path
+
+          version = sys.argv[1]
+          changelog = Path("CHANGELOG.md")
+          if not changelog.exists():
+              Path("release-notes.md").write_text("No changelog entry found.\n")
+              sys.exit(0)
+
+          in_section = False
+          lines = []
+          for line in changelog.read_text().splitlines():
+              if line.startswith("## "):
+                  if in_section:
+                      break
+                  if version in line:
+                      in_section = True
+                      continue
+              elif in_section:
+                  lines.append(line)
+
+          body = "\n".join(lines).strip() or "No changelog entry found."
+          Path("release-notes.md").write_text(body + "\n")
+          PY
+
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Download sdist
+        uses: actions/download-artifact@v8
+        with: { name: sdist, path: dist }
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          body_path: release-notes.md
+          files: dist/*
 
   # crates.io publish, in dependency order. Gated on manual approval via
   # the `crates-io` environment. crates.io does NOT support OIDC trusted


### PR DESCRIPTION
## Summary

- Adds `tag-release` job: on push to main, reads version from `Cargo.toml`, creates a git tag if it doesn't exist. No-op when tag already present.
- Adds `publish-github` job: extracts the matching version section from `CHANGELOG.md`, attaches wheel + sdist artifacts, creates a GitHub Release.
- Adds `if` guards on `build-wheels` and `sdist` so they only run on tag pushes, not on the main-branch push that triggers auto-tagging.
- Adds comment on `sdist` job explaining what source distributions are for.

No new dependencies. No secrets required beyond what's already configured.

## Test plan

- [x] Merge to main with current `Cargo.toml` version (0.2.0) — `tag-release` should skip since `v0.2.0` tag exists
- [x] Bump version in `Cargo.toml`, merge to main — `tag-release` creates tag, release workflow fires, GitHub Release appears with changelog notes