### PR TITLE
docs: fix stale refs, update crate readmes, clean testing standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ xlstream/
 | How do errors flow through the system? | [`docs/architecture/errors.md`](docs/architecture/errors.md) |
 | What are the code-style rules? | [`docs/standards/code-style.md`](docs/standards/code-style.md) |
 | What kinds of tests do we write? | [`docs/standards/testing.md`](docs/standards/testing.md) |
-| What's the current phase? | [`docs/phases/README.md`](docs/phases/README.md) |
+| What's the current version roadmap? | [`docs/roadmap/README.md`](docs/roadmap/README.md) |
 | Why one repo, not three? | [`docs/operations/repo-structure.md`](docs/operations/repo-structure.md) |
 | How is CI wired? | [`docs/operations/ci.md`](docs/operations/ci.md) |
 | Why did we pick calamine / rust_xlsxwriter? | [`docs/research/`](docs/research/) |
@@ -75,7 +75,7 @@ xlstream/
 ### Before you touch code
 
 0. **Use `/rust-skills` before writing any Rust code.** Covers idiomatic patterns, error handling, type design, and common pitfalls. Use it alongside (not instead of) any other applicable skills.
-1. **Read the current phase doc.** Find it via [`docs/phases/README.md`](docs/phases/README.md). You are implementing a specific checkbox in a specific phase. Don't free-lance.
+1. **Read the current version roadmap.** Find it via [`docs/roadmap/README.md`](docs/roadmap/README.md). You are implementing a specific checkbox in the current version. Don't free-lance.
 2. **Read the architecture doc that covers your area.** Unclear architecture → stop and ask. Do not invent.
 3. **Search for existing patterns.** If three other builtins handle errors a given way, yours does too. Consistency outranks cleverness.
 4. **Always use Context7 MCP for up-to-date docs before writing code.** This is non-negotiable. Any time you're about to use a library, framework, SDK, or crate — calamine, rust_xlsxwriter, pyo3, maturin, rayon, formualizer-parse, phf, thiserror, tokio, anything — call Context7 first to verify the API shape against the **current** documentation. Your training-data knowledge may be stale; library APIs drift between versions. Context7 costs nothing; a silently-wrong import costs hours. Prefer it over general web search for library docs.
@@ -98,7 +98,8 @@ xlstream/
 3. **Update the phase checklist.** Tick the box you completed. Do not tick boxes you didn't actually finish.
 4. **Update any doc that's now stale.** If you changed a public API, the rustdoc and any mention in `docs/` must be updated in the same PR.
 5. **If you landed a builtin function, tick it in [`docs/functions.md`](docs/functions.md) too.** Same PR.
-6. **One PR per checkbox** unless the doc says otherwise.
+6. **If you added a formula with a novel code path** (not just dispatch to existing machinery), add a criterion bench in the matching `benchmarks/benches/<category>.rs` file. See `docs/standards/testing.md` for the code path → benchmark mapping.
+7. **One PR per checkbox** unless the doc says otherwise.
 
 ### Do NOT
 
@@ -130,7 +131,7 @@ All the recurring process questions (who merges, stacked PRs, turnaround, what t
 
 ## Current state
 
-Phases 0-12 complete. Phase 13 (docs polish) in progress. See [`docs/phases/README.md`](docs/phases/README.md).
+v0.1 shipped 2026-04-20. v0.2 in progress. See [`docs/roadmap/README.md`](docs/roadmap/README.md).
 
 ## Tone
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,8 @@ At minimum:
 6. If the function needs prelude data (aggregates, lookups), use the lazy dispatch path instead.
 7. Add rustdoc with `# Examples` block.
 8. Tick the box in `docs/functions.md` in the same PR.
-9. Run `make check`.
+9. If the function introduces a novel code path (not just dispatch to existing machinery), add a criterion bench in `benchmarks/benches/<category>.rs`. See [`docs/standards/testing.md`](docs/standards/testing.md) for the code path → benchmark mapping.
+10. Run `make check`.
 
 ## Code style
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 # xlstream workspace root.
-# Crates are added in Phase 1 — see docs/phases/phase-01-scaffolding.md.
+# xlstream workspace root.
 
 [workspace]
 resolver = "2"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install: check-prereqs $(VENV)/.stamp install-rust install-python install-precom
 	@echo "Next steps:"
 	@echo "  source $(VENV)/bin/activate    # activate the Python venv"
 	@echo "  make check                     # validate your setup (fmt + clippy + tests)"
-	@echo "  cat docs/phases/README.md      # find the current phase"
+	@echo "  cat docs/roadmap/README.md      # see the current version roadmap"
 	@echo ""
 
 .PHONY: check-prereqs

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We are not building a general-purpose spreadsheet engine. We are building the *f
 
 ## Supported functions
 
-113 functions + 13 operators across 9 categories. [Full list with cross-reference](docs/functions.md).
+103 functions + 13 operators across 9 categories. [Full list with cross-reference](docs/functions.md).
 
 | Category   | Count | Examples                                          |
 | ---------- | ----- | ------------------------------------------------- |
@@ -55,12 +55,6 @@ result = xlstream.evaluate("input.xlsx", "output.xlsx")
 
 # Parallel (row-sharded across cores)
 result = xlstream.evaluate("input.xlsx", "output.xlsx", workers=8)
-```
-
-### CLI
-
-```bash
-xlstream evaluate input.xlsx -o output.xlsx -w 8 --verbose
 ```
 
 ### Rust

--- a/crates/xlstream-cli/README.md
+++ b/crates/xlstream-cli/README.md
@@ -1,6 +1,6 @@
 # xlstream-cli
 
-Development CLI for the xlstream streaming Excel evaluator. Not published -- internal tool for smoke tests and ad-hoc evaluation.
+Development CLI for the [xlstream](https://github.com/cilladev/xlstream) streaming Excel evaluator. Not published to crates.io — internal tool for debugging and ad-hoc evaluation.
 
 ## Commands
 
@@ -9,10 +9,14 @@ xlstream evaluate <INPUT> --output <OUTPUT> [--workers N] [--verbose]
 xlstream classify <FORMULA> [--sheet SHEET] [--row ROW] [--col COL] [--lookup-sheet SHEET]...
 ```
 
-**evaluate** -- run the full pipeline (read, parse, classify, prelude, evaluate, write).
+**evaluate** -- run the full pipeline (read, parse, classify, prelude, evaluate, write). `--verbose` prints per-sheet stats and peak RSS.
 
-**classify** -- parse and classify a single formula. Shows streaming verdict and any rejection reasons.
+**classify** -- parse and classify a single formula. Shows streaming verdict, classification, and any rejection reasons.
 
 ## Dependencies
 
 `xlstream-core`, `xlstream-parse`, `xlstream-eval`, `xlstream-io`, `clap`, `tracing`, `tracing-subscriber`, `memory-stats`.
+
+## License
+
+Dual-licensed under Apache-2.0 or MIT, at your option.

--- a/crates/xlstream-cli/README.md
+++ b/crates/xlstream-cli/README.md
@@ -1,0 +1,18 @@
+# xlstream-cli
+
+Development CLI for the xlstream streaming Excel evaluator. Not published -- internal tool for smoke tests and ad-hoc evaluation.
+
+## Commands
+
+```
+xlstream evaluate <INPUT> --output <OUTPUT> [--workers N] [--verbose]
+xlstream classify <FORMULA> [--sheet SHEET] [--row ROW] [--col COL] [--lookup-sheet SHEET]...
+```
+
+**evaluate** -- run the full pipeline (read, parse, classify, prelude, evaluate, write).
+
+**classify** -- parse and classify a single formula. Shows streaming verdict and any rejection reasons.
+
+## Dependencies
+
+`xlstream-core`, `xlstream-parse`, `xlstream-eval`, `xlstream-io`, `clap`, `tracing`, `tracing-subscriber`, `memory-stats`.

--- a/crates/xlstream-core/README.md
+++ b/crates/xlstream-core/README.md
@@ -1,0 +1,24 @@
+# xlstream-core
+
+Foundation types for the xlstream streaming Excel evaluator. Every other crate in the workspace depends on this one.
+
+## What it owns
+
+- **`Value`** -- cell-value enum: `Number(f64)`, `Integer(i64)`, `Text(Box<str>)`, `Bool(bool)`, `Date(ExcelDate)`, `Error(CellError)`, `Empty`
+- **`CellError`** -- Excel in-cell errors: `Div0`, `Value`, `Ref`, `Name`, `Na`, `Num`, `Null`
+- **`ExcelDate`** -- wraps Excel serial date (days since 1900 epoch, leap-year bug preserved)
+- **`XlStreamError`** -- library-level errors that stop evaluation: `Io`, `Xlsx`, `XlsxWrite`, `Unsupported`, `FormulaParse`, `Classification`, `CircularReference`, `Internal`
+- **`col_row_to_a1`** -- convert 1-based (col, row) to A1 notation
+- **Constants** -- `EXCEL_MAX_ROWS` (1,048,576), `EXCEL_MAX_COLS` (16,384)
+
+## What it does NOT own
+
+- Parsing, I/O, evaluation, or builtin functions. Those live in sibling crates.
+
+## Dependencies
+
+`thiserror`. Nothing else.
+
+## Why separate
+
+Breaking core types into their own crate avoids circular-dep pain, reduces recompile scope, and gives a small stable ABI surface for the public Rust API.

--- a/crates/xlstream-core/README.md
+++ b/crates/xlstream-core/README.md
@@ -1,24 +1,29 @@
 # xlstream-core
 
-Foundation types for the xlstream streaming Excel evaluator. Every other crate in the workspace depends on this one.
+[![Crates.io](https://img.shields.io/crates/v/xlstream-core.svg)](https://crates.io/crates/xlstream-core)
+[![docs.rs](https://docs.rs/xlstream-core/badge.svg)](https://docs.rs/xlstream-core)
 
-## What it owns
+Core value and error types shared across the [xlstream](https://github.com/cilladev/xlstream) streaming Excel evaluator.
+
+This is an internal crate. Depend on [`xlstream-eval`](https://crates.io/crates/xlstream-eval) for the evaluation API, or `pip install xlstream` for Python.
+
+## What it provides
 
 - **`Value`** -- cell-value enum: `Number(f64)`, `Integer(i64)`, `Text(Box<str>)`, `Bool(bool)`, `Date(ExcelDate)`, `Error(CellError)`, `Empty`
 - **`CellError`** -- Excel in-cell errors: `Div0`, `Value`, `Ref`, `Name`, `Na`, `Num`, `Null`
 - **`ExcelDate`** -- wraps Excel serial date (days since 1900 epoch, leap-year bug preserved)
-- **`XlStreamError`** -- library-level errors that stop evaluation: `Io`, `Xlsx`, `XlsxWrite`, `Unsupported`, `FormulaParse`, `Classification`, `CircularReference`, `Internal`
+- **`XlStreamError`** -- typed error enum for the full pipeline: `Io`, `Xlsx`, `XlsxWrite`, `Unsupported`, `FormulaParse`, `Classification`, `CircularReference`, `Internal`
 - **`col_row_to_a1`** -- convert 1-based (col, row) to A1 notation
 - **Constants** -- `EXCEL_MAX_ROWS` (1,048,576), `EXCEL_MAX_COLS` (16,384)
 
-## What it does NOT own
+## When to use directly
 
-- Parsing, I/O, evaluation, or builtin functions. Those live in sibling crates.
+Only if you're building a custom component that handles xlstream value types without pulling in the full evaluator. Most users should depend on `xlstream-eval` instead.
 
 ## Dependencies
 
 `thiserror`. Nothing else.
 
-## Why separate
+## License
 
-Breaking core types into their own crate avoids circular-dep pain, reduces recompile scope, and gives a small stable ABI surface for the public Rust API.
+Dual-licensed under Apache-2.0 or MIT, at your option.

--- a/crates/xlstream-eval/README.md
+++ b/crates/xlstream-eval/README.md
@@ -1,35 +1,51 @@
 # xlstream-eval
 
-Streaming Excel formula evaluator. Two-pass architecture: prelude (aggregates + lookups), then row-by-row streaming with optional parallelism.
+[![Crates.io](https://img.shields.io/crates/v/xlstream-eval.svg)](https://crates.io/crates/xlstream-eval)
+[![docs.rs](https://docs.rs/xlstream-eval/badge.svg)](https://docs.rs/xlstream-eval)
 
-## Public API
+Streaming Excel formula evaluator for the [xlstream](https://github.com/cilladev/xlstream) engine. Two-pass architecture: prelude (aggregates + lookups), then row-by-row streaming with automatic parallelism.
 
-- **`evaluate(input, output, workers) -> Result<EvaluateSummary>`** -- main entry point. Reads xlsx, evaluates all formulas, writes results. `workers=None` auto-detects cores; `Some(n)` uses n threads if >= 10k rows.
+This is the main Rust entry point. For Python, use `pip install xlstream`.
+
+## Usage
+
+```rust
+use std::path::Path;
+use xlstream_eval::evaluate;
+
+let summary = evaluate(
+    Path::new("input.xlsx"),
+    Path::new("output.xlsx"),
+    None, // auto-detect worker count
+)?;
+println!("Evaluated {} formulas in {:?}", summary.formulas_evaluated, summary.duration);
+```
+
+## What it provides
+
+- **`evaluate(input, output, workers) -> Result<EvaluateSummary>`** -- reads xlsx, evaluates all formulas on all sheets, writes results
 - **`EvaluateSummary`** -- `rows_processed`, `formulas_evaluated`, `duration`
-- **`Interpreter`** -- AST walker. `eval(node, scope) -> Value`
-- **`Prelude`** -- pre-computed aggregates, lookup indexes, cached ranges, volatile data
-- **`RowScope`** -- current row's cell values for evaluation context
+- **`Interpreter`** -- AST walker for custom evaluation pipelines
+- **`Prelude`** -- pre-computed aggregates, lookup indexes, cached ranges
 
-## Builtins (70+)
+## 103 Excel-compatible functions
 
-Conditional (IF, IFS, SWITCH, IFERROR), aggregate (SUM, COUNT, AVERAGE, MIN, MAX), conditional aggregate (SUMIF, SUMIFS, COUNTIF, COUNTIFS, AVERAGEIF, AVERAGEIFS), lookup (VLOOKUP, XLOOKUP, HLOOKUP, INDEX, MATCH), string (LEFT, RIGHT, MID, CONCAT, TEXTJOIN, SUBSTITUTE, TEXT), date (DATE, YEAR, MONTH, NETWORKDAYS, WORKDAY, EDATE), math (ROUND, ABS, SQRT, MOD, POWER), financial (PMT, FV, PV, RATE), info (ISBLANK, ISNUMBER, ISTEXT, TYPE).
+Logical (IF, IFS, SWITCH, IFERROR), aggregate (SUM, COUNT, AVERAGE, MIN, MAX, MEDIAN), conditional aggregate (SUMIF, SUMIFS, COUNTIF, COUNTIFS, AVERAGEIF, AVERAGEIFS), lookup (VLOOKUP, XLOOKUP, HLOOKUP, INDEX, MATCH), string (LEFT, RIGHT, MID, CONCAT, TEXTJOIN, SUBSTITUTE, TEXT), date (DATE, YEAR, MONTH, NETWORKDAYS, EDATE), math (ROUND, ABS, SQRT, MOD, POWER), financial (PMT, FV, PV, IRR, RATE), info (ISBLANK, ISNUMBER, ISTEXT, TYPE).
 
-Full list: [`docs/functions.md`](../../docs/functions.md)
+Full list: [functions.md](https://github.com/cilladev/xlstream/blob/main/docs/functions.md)
 
-## What it does NOT own
+## Architecture
 
-- xlsx I/O (that's `xlstream-io`).
-- Value types (that's `xlstream-core`).
-- Formula parsing (that's `xlstream-parse`).
+**Pass 1 (prelude):** single-threaded scan. Parse formulas, classify, compute whole-column aggregates, load lookup sheets, build hash indexes. Runs once per formula-bearing sheet.
+
+**Pass 2 (row stream):** multi-threaded if >= 10k rows. Each worker reads its row range, evaluates formulas in topological order, sends results through a bounded channel. Main thread drains in row order to the writer.
+
+See [streaming-model.md](https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md).
 
 ## Dependencies
 
 `xlstream-core`, `xlstream-parse`, `xlstream-io`, `rayon`, `crossbeam-channel`, `num_cpus`, `phf`, `tracing`.
 
-## Architecture
+## License
 
-Pass 1 (prelude): single-threaded scan. Parse formulas, classify, compute whole-column aggregates, load lookup sheets, build hash indexes.
-
-Pass 2 (row stream): multi-threaded if >= 10k rows. Each worker reads its row range, evaluates formulas in topological order, sends results through a bounded channel. Main thread drains in row order to the writer.
-
-See [`docs/architecture/streaming-model.md`](../../docs/architecture/streaming-model.md).
+Dual-licensed under Apache-2.0 or MIT, at your option.

--- a/crates/xlstream-eval/README.md
+++ b/crates/xlstream-eval/README.md
@@ -1,0 +1,35 @@
+# xlstream-eval
+
+Streaming Excel formula evaluator. Two-pass architecture: prelude (aggregates + lookups), then row-by-row streaming with optional parallelism.
+
+## Public API
+
+- **`evaluate(input, output, workers) -> Result<EvaluateSummary>`** -- main entry point. Reads xlsx, evaluates all formulas, writes results. `workers=None` auto-detects cores; `Some(n)` uses n threads if >= 10k rows.
+- **`EvaluateSummary`** -- `rows_processed`, `formulas_evaluated`, `duration`
+- **`Interpreter`** -- AST walker. `eval(node, scope) -> Value`
+- **`Prelude`** -- pre-computed aggregates, lookup indexes, cached ranges, volatile data
+- **`RowScope`** -- current row's cell values for evaluation context
+
+## Builtins (70+)
+
+Conditional (IF, IFS, SWITCH, IFERROR), aggregate (SUM, COUNT, AVERAGE, MIN, MAX), conditional aggregate (SUMIF, SUMIFS, COUNTIF, COUNTIFS, AVERAGEIF, AVERAGEIFS), lookup (VLOOKUP, XLOOKUP, HLOOKUP, INDEX, MATCH), string (LEFT, RIGHT, MID, CONCAT, TEXTJOIN, SUBSTITUTE, TEXT), date (DATE, YEAR, MONTH, NETWORKDAYS, WORKDAY, EDATE), math (ROUND, ABS, SQRT, MOD, POWER), financial (PMT, FV, PV, RATE), info (ISBLANK, ISNUMBER, ISTEXT, TYPE).
+
+Full list: [`docs/functions.md`](../../docs/functions.md)
+
+## What it does NOT own
+
+- xlsx I/O (that's `xlstream-io`).
+- Value types (that's `xlstream-core`).
+- Formula parsing (that's `xlstream-parse`).
+
+## Dependencies
+
+`xlstream-core`, `xlstream-parse`, `xlstream-io`, `rayon`, `crossbeam-channel`, `num_cpus`, `phf`, `tracing`.
+
+## Architecture
+
+Pass 1 (prelude): single-threaded scan. Parse formulas, classify, compute whole-column aggregates, load lookup sheets, build hash indexes.
+
+Pass 2 (row stream): multi-threaded if >= 10k rows. Each worker reads its row range, evaluates formulas in topological order, sends results through a bounded channel. Main thread drains in row order to the writer.
+
+See [`docs/architecture/streaming-model.md`](../../docs/architecture/streaming-model.md).

--- a/crates/xlstream-io/README.md
+++ b/crates/xlstream-io/README.md
@@ -1,29 +1,27 @@
 # xlstream-io
 
-xlsx I/O. Calamine-backed reader, rust_xlsxwriter-backed writer (constant-memory mode), and a row-oriented cell stream abstraction.
+[![Crates.io](https://img.shields.io/crates/v/xlstream-io.svg)](https://crates.io/crates/xlstream-io)
+[![docs.rs](https://docs.rs/xlstream-io/badge.svg)](https://docs.rs/xlstream-io)
 
-## Public API
+xlsx read/write layer for the [xlstream](https://github.com/cilladev/xlstream) streaming Excel evaluator. Calamine-backed reader, rust_xlsxwriter-backed writer (constant-memory mode), and a row-oriented cell stream abstraction.
 
-- **`Reader`** -- open xlsx for streaming. Methods: `open(path)`, `sheet_names()`, `defined_names()`, `cells(sheet) -> CellStream`, `formulas(sheet)`, `sheet_dimensions(sheet)`
-- **`Writer`** -- create xlsx in constant-memory mode. Methods: `create(path)`, `add_sheet(name) -> SheetHandle`, `finish()`
-- **`SheetHandle`** -- write rows to a single sheet. Enforces strictly-increasing row order. Methods: `write_row(row_idx, values)`, `write_formula(row, col, formula, cached)`
-- **`CellStream`** -- row-oriented iterator. `next_row() -> Option<(row_idx, Vec<Value>)>`, `seek_to_row(row)`
+This is an internal crate. Most users should depend on [`xlstream-eval`](https://crates.io/crates/xlstream-eval), which calls xlstream-io internally.
 
-## Type conversions
+## What it provides
 
-- `calamine::DataRef` -> `Value` (read path)
-- `Value` -> `rust_xlsxwriter` write calls (write path)
+- **`Reader`** -- open xlsx for streaming. `open(path)`, `sheet_names()`, `defined_names()`, `cells(sheet) -> CellStream`, `formulas(sheet)`
+- **`Writer`** -- create xlsx in constant-memory mode. `create(path)`, `add_sheet(name) -> SheetHandle`, `finish()`
+- **`SheetHandle`** -- write rows to a single sheet. Enforces strictly-increasing row order.
+- **`CellStream`** -- row-oriented iterator. `next_row() -> Option<(row_idx, Vec<Value>)>`
 
-## What it does NOT own
+## When to use directly
 
-- Formula parsing or evaluation. Those live in `xlstream-parse` and `xlstream-eval`.
+Only if you need raw xlsx streaming I/O without formula evaluation — e.g., building a custom pipeline that reads cell values and writes transformed output. For formula evaluation, use `xlstream-eval`.
 
 ## Dependencies
 
 `calamine`, `rust_xlsxwriter` (features: `constant_memory`, `zlib`, `ryu`), `xlstream-core`.
 
-## Why separate
+## License
 
-The evaluator works against `Reader` and `Writer` -- tests can construct fake row iterators and assert evaluated values without hitting disk.
-
-See [`docs/architecture/io.md`](../../docs/architecture/io.md).
+Dual-licensed under Apache-2.0 or MIT, at your option.

--- a/crates/xlstream-io/README.md
+++ b/crates/xlstream-io/README.md
@@ -1,0 +1,29 @@
+# xlstream-io
+
+xlsx I/O. Calamine-backed reader, rust_xlsxwriter-backed writer (constant-memory mode), and a row-oriented cell stream abstraction.
+
+## Public API
+
+- **`Reader`** -- open xlsx for streaming. Methods: `open(path)`, `sheet_names()`, `defined_names()`, `cells(sheet) -> CellStream`, `formulas(sheet)`, `sheet_dimensions(sheet)`
+- **`Writer`** -- create xlsx in constant-memory mode. Methods: `create(path)`, `add_sheet(name) -> SheetHandle`, `finish()`
+- **`SheetHandle`** -- write rows to a single sheet. Enforces strictly-increasing row order. Methods: `write_row(row_idx, values)`, `write_formula(row, col, formula, cached)`
+- **`CellStream`** -- row-oriented iterator. `next_row() -> Option<(row_idx, Vec<Value>)>`, `seek_to_row(row)`
+
+## Type conversions
+
+- `calamine::DataRef` -> `Value` (read path)
+- `Value` -> `rust_xlsxwriter` write calls (write path)
+
+## What it does NOT own
+
+- Formula parsing or evaluation. Those live in `xlstream-parse` and `xlstream-eval`.
+
+## Dependencies
+
+`calamine`, `rust_xlsxwriter` (features: `constant_memory`, `zlib`, `ryu`), `xlstream-core`.
+
+## Why separate
+
+The evaluator works against `Reader` and `Writer` -- tests can construct fake row iterators and assert evaluated values without hitting disk.
+
+See [`docs/architecture/io.md`](../../docs/architecture/io.md).

--- a/crates/xlstream-io/src/lib.rs
+++ b/crates/xlstream-io/src/lib.rs
@@ -1,9 +1,7 @@
 //! # xlstream-io
 //!
 //! xlsx I/O. Calamine-backed [`Reader`], `rust_xlsxwriter`-backed [`Writer`],
-//! and a row-oriented [`CellStream`] abstraction. All three are stubs in
-//! Phase 1; real implementations land in Phase 3. See
-//! `docs/phases/phase-03-io.md`.
+//! and a row-oriented [`CellStream`] abstraction.
 
 #![warn(missing_docs, rust_2018_idioms, clippy::pedantic, clippy::cargo)]
 #![deny(

--- a/crates/xlstream-parse/README.md
+++ b/crates/xlstream-parse/README.md
@@ -1,0 +1,27 @@
+# xlstream-parse
+
+Formula parser adapter. Wraps `formualizer-parse` and adds a classification layer that labels each AST with a streaming verdict.
+
+## What it owns
+
+- **`parse(text) -> Result<Ast>`** -- parse formula text into an AST
+- **`classify(ast, context) -> Classification`** -- assign streaming verdict
+- **`Classification`** -- `RowLocal`, `AggregateOnly`, `LookupOnly`, `Mixed`, `Unsupported(reason)`
+- **`UnsupportedReason`** -- specific rejection reasons with `doc_link()` for user-facing errors
+- **`ClassificationContext`** -- inputs for classification (main sheet, lookup sheets, etc.)
+- **`extract_references(ast) -> References`** -- find all cell/range/sheet references in a formula
+- **`rewrite`** -- AST transformations: aggregate-to-prelude-ref, lookup key extraction, named range resolution
+- **`AggregateKey`**, **`LookupKey`**, **`BoundedRangeKey`** -- prelude planning keys
+
+## What it does NOT own
+
+- Evaluation of formulas (that's `xlstream-eval`).
+- I/O (that's `xlstream-io`).
+
+## Dependencies
+
+`formualizer-parse`, `formualizer-common`, `xlstream-core`, `smallvec`, `phf`.
+
+## Why this layer exists
+
+Decouples the rest of the codebase from the upstream parser. If we ever fork or swap the parser, this is the only crate that changes.

--- a/crates/xlstream-parse/README.md
+++ b/crates/xlstream-parse/README.md
@@ -1,27 +1,36 @@
 # xlstream-parse
 
-Formula parser adapter. Wraps `formualizer-parse` and adds a classification layer that labels each AST with a streaming verdict.
+[![Crates.io](https://img.shields.io/crates/v/xlstream-parse.svg)](https://crates.io/crates/xlstream-parse)
+[![docs.rs](https://docs.rs/xlstream-parse/badge.svg)](https://docs.rs/xlstream-parse)
 
-## What it owns
+Formula parser and streaming classifier for the [xlstream](https://github.com/cilladev/xlstream) evaluator. Wraps [`formualizer-parse`](https://crates.io/crates/formualizer-parse) and adds a classification layer that labels each AST with a streaming verdict.
+
+Use this crate directly if you need to analyze formula structure without evaluating. For evaluation, depend on [`xlstream-eval`](https://crates.io/crates/xlstream-eval).
+
+## What it provides
 
 - **`parse(text) -> Result<Ast>`** -- parse formula text into an AST
-- **`classify(ast, context) -> Classification`** -- assign streaming verdict
-- **`Classification`** -- `RowLocal`, `AggregateOnly`, `LookupOnly`, `Mixed`, `Unsupported(reason)`
-- **`UnsupportedReason`** -- specific rejection reasons with `doc_link()` for user-facing errors
-- **`ClassificationContext`** -- inputs for classification (main sheet, lookup sheets, etc.)
-- **`extract_references(ast) -> References`** -- find all cell/range/sheet references in a formula
-- **`rewrite`** -- AST transformations: aggregate-to-prelude-ref, lookup key extraction, named range resolution
+- **`classify(ast, context) -> Classification`** -- assign streaming verdict: `RowLocal`, `AggregateOnly`, `LookupOnly`, `Mixed`, `Unsupported(reason)`
+- **`extract_references(ast) -> References`** -- find all cell/range/sheet/table references
+- **`resolve_named_ranges(ast, names) -> Ast`** -- rewrite named range refs to resolved cell/range refs
+- **`rewrite(ast, ctx, verdict) -> Ast`** -- aggregate-to-prelude-ref, lookup key extraction
 - **`AggregateKey`**, **`LookupKey`**, **`BoundedRangeKey`** -- prelude planning keys
 
-## What it does NOT own
+## Example
 
-- Evaluation of formulas (that's `xlstream-eval`).
-- I/O (that's `xlstream-io`).
+```rust
+use xlstream_parse::{parse, classify, ClassificationContext};
+
+let ast = parse("SUM(A:A)").unwrap();
+let ctx = ClassificationContext::for_cell("Sheet1", 2, 1);
+let verdict = classify(&ast, &ctx);
+// verdict == Classification::AggregateOnly
+```
 
 ## Dependencies
 
 `formualizer-parse`, `formualizer-common`, `xlstream-core`, `smallvec`, `phf`.
 
-## Why this layer exists
+## License
 
-Decouples the rest of the codebase from the upstream parser. If we ever fork or swap the parser, this is the only crate that changes.
+Dual-licensed under Apache-2.0 or MIT, at your option.

--- a/crates/xlstream-parse/src/lib.rs
+++ b/crates/xlstream-parse/src/lib.rs
@@ -3,8 +3,8 @@
 //! Formula parser adapter. Wraps [`formualizer-parse`] and adds a
 //! classification layer that labels each AST with a streaming verdict.
 //!
-//! This crate exposes stub types in Phase 1; real parse + classify logic
-//! lands in Phase 2. See `docs/phases/phase-02-parser.md`.
+//! Wraps the upstream parser, adds reference extraction, named range
+//! resolution, classification, and AST rewriting for prelude refs.
 //!
 //! [`formualizer-parse`]: https://docs.rs/formualizer-parse
 

--- a/docs/architecture/parallelism.md
+++ b/docs/architecture/parallelism.md
@@ -134,7 +134,7 @@ From formualizer-comparable numbers in the brief:
 - Single-threaded streaming eval (pure per-row, no parallelism): ~8–12 minutes on 700k × 20 (conservative).
 - 8-worker streaming: ~1.5–2 minutes (near-linear scaling for pure row-local; diluted by prelude + writer serialisation).
 
-Benchmark harness is in `benchmarks/` — see [phase-12](../phases/phase-12-benchmarks.md).
+Benchmark harness is in `benchmarks/` — see [benchmarks reports](../../benchmarks/reports/).
 
 ## Thread pool ownership
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -23,7 +23,7 @@ Each version gets its own folder with a checklist. When a version ships, its fol
 
 ### Where we are
 
-Excel has ~516 functions. xlstream implements 113 — but covers all 15 functions that appear in 76% of real business spreadsheets (Enron Corpus, Hermans et al., IEEE ICSE 2015). See [FUNCTIONS.md](../../FUNCTIONS.md) for the full cross-reference.
+Excel has ~516 functions. xlstream implements 103 functions — covering all 15 functions that appear in 76% of real business spreadsheets (Enron Corpus, Hermans et al., IEEE ICSE 2015). See [functions.md](../functions.md) for the full cross-reference.
 
 ### Where we're going
 
@@ -90,7 +90,7 @@ These are architecturally incompatible with streaming. Users get a clear `Classi
 | **OLAP** | CUBE* family (7 functions) | Requires external OLAP connection |
 | **External refs** | `[Book.xlsx]Sheet1!A1` | Violates single-file model |
 
-**~51 functions permanently excluded.** ~465 are streaming-compatible. See [FUNCTIONS.md](../../FUNCTIONS.md) for the complete breakdown.
+**~51 functions permanently excluded.** ~465 are streaming-compatible. See [functions.md](../functions.md) for the complete breakdown.
 
 ### Function count trajectory
 

--- a/docs/roadmap/v0.2/02-table-references.md
+++ b/docs/roadmap/v0.2/02-table-references.md
@@ -1,0 +1,118 @@
+# Feature: Table References
+
+**Branch:** `feat/table-references`
+**Effort:** ~2 days
+**Crates:** xlstream-io, xlstream-parse, xlstream-eval
+
+## What
+
+Excel structured references let formulas address table columns by name instead of cell coordinates. A formula on a row inside `Table1` can say `=[@Price]*[@Quantity]` (current row's Price and Quantity columns) or `=SUM(Table1[Amount])` (entire Amount column). The syntax is parsed by `formualizer-parse` already; xlstream currently refuses all table references at classification with `UnsupportedReason::TableReference`.
+
+```
+=[@Price]*1.1          → current row's Price cell times 1.1
+=SUM(Table1[Amount])   → sum of entire Amount column
+=Table1[@Region]       → current row's Region cell
+```
+
+Current behavior: any formula containing a table reference returns `UnsupportedFormula` error.
+
+## What already exists
+
+- `formualizer-parse` parses table references and emits `RefView::Table { name, specifier }` with a rich `TableSpecifier` enum (Column, ColumnRange, All, Data, Headers, Totals, ThisRow, Combination). See `refs/formualizer/crates/formualizer-parse/src/parser.rs:65`.
+- `xlstream-parse` extracts `Reference::Table { name, specifier }` in `collect_view()` at `crates/xlstream-parse/src/references.rs:143-148`. The specifier is stored as `Option<String>` via `Display`.
+- Classification refuses `Reference::Table` at `crates/xlstream-parse/src/classify.rs:440`.
+- `UnsupportedReason::TableReference` variant exists with doc link at `crates/xlstream-parse/src/classify.rs:42-43`.
+- Calamine has full table metadata support: `load_tables()`, `table_names()`, `table_by_name()`, `table_names_in_sheet()`. Metadata includes table name, sheet name, column names, and data dimensions. See `refs/calamine/src/xlsx/mod.rs:1086-1204` and `TableMetadata` struct at line 1541.
+- Named range resolution (`crates/xlstream-parse/src/resolve.rs`) provides the pattern: AST rewriting that replaces symbolic references with resolved cell/range references before classification.
+- `Reader` wraps `calamine::Xlsx<BufReader<File>>` at `crates/xlstream-io/src/reader.rs:26-28`.
+
+## Where to look
+
+- `crates/xlstream-parse/src/references.rs` — `Reference::Table` variant (line 62), `collect_view` (line 143)
+- `crates/xlstream-parse/src/classify.rs` — refusal at line 440, `UnsupportedReason::TableReference` at line 42
+- `crates/xlstream-parse/src/resolve.rs` — named range resolution pattern to follow
+- `crates/xlstream-io/src/reader.rs` — `Reader` struct, `defined_names()` at line 107
+- `crates/xlstream-eval/src/evaluate.rs` — `build_plan()` at line 151, named range loading at line 154, `build_eval_plan()` call at line 171
+- `refs/calamine/src/xlsx/mod.rs` — `load_tables()` at line 1086, `table_names()` at line 1133, `get_table_meta()` at line 862, `TableMetadata` at line 1541
+- `refs/formualizer/crates/formualizer-parse/src/parser.rs` — `TableSpecifier` enum at line 65, `SpecialItem` at line 107, `RefView::Table` at line 1801
+
+## Resolution / Evaluation behavior
+
+Table references resolve at **classification time** (before prelude), following the same pattern as named ranges:
+
+1. **IO layer** (`xlstream-io`): `Reader` exposes table metadata — a map from table name to `{ sheet_name, columns: Vec<String>, data_dimensions }`. Calls calamine's `load_tables()` + `get_table_meta()` / `table_names()` internally.
+
+2. **Parse layer** (`xlstream-parse`): A new `resolve_table_references()` function rewrites the AST. For each `Reference::Table { name, specifier }`:
+   - Look up the table metadata by name (case-insensitive).
+   - `Table[Column]` (whole column) → `Reference::Range` over the column's data rows on the table's sheet.
+   - `Table[@Column]` or `[@Column]` (current row) → `Reference::Cell` pointing to the column index on the current sheet. Row is unresolved at classification time — the evaluator fills it per-row.
+   - `Table` (whole table, no specifier) → `Reference::Range` over all data columns/rows.
+   - Unknown table name → leave as `Reference::Table`, classifier rejects with a new `UnsupportedReason::UnknownTable` or similar.
+
+3. **Eval layer** (`xlstream-eval`): `build_plan()` loads table metadata from the reader (same location as named ranges loading), passes it to the parse layer for resolution before classification.
+
+**Streaming invariant compliance:** `Table[Column]` resolves to a whole-column range — handled by prelude aggregates, same as `A:A`. `[@Column]` resolves to a same-row cell reference — row-local by definition. No new data access patterns are introduced.
+
+### The `@` (ThisRow) specifier
+
+This is the nuanced case. `[@Column]` means "the value in this column on the current row." At classification time the row number is unknown. Two approaches:
+
+**Option A:** Resolve `[@Column]` to a cell reference with a sentinel row (e.g., row 0) and have the evaluator substitute the actual row at eval time. Requires the evaluator to recognize and rewrite sentinels.
+
+**Option B:** Introduce a new AST node or Reference variant (e.g., `Reference::CurrentRowCell { sheet, col }`) that the evaluator resolves per-row. Cleaner but wider surface area.
+
+The agent should evaluate both against the existing evaluator's row-dispatch code (`crates/xlstream-eval/src/evaluate.rs` row loop and `crates/xlstream-eval/src/interpreter.rs`) and pick the one that requires fewer changes.
+
+## Tests
+
+### Classification (unit tests)
+
+**Happy path:**
+- `Table1[Amount]` with table metadata resolves and classifies as Aggregate (whole-column range)
+- `[@Price]*1.1` with table metadata resolves and classifies as RowLocal
+- `SUM(Table1[Amount])` classifies as Aggregate
+- `VLOOKUP([@Key], Table2[Data], 2, FALSE)` classifies as Lookup
+- `IF([@Status]="Active", [@Amount], 0)` classifies as RowLocal
+
+**Edge cases:**
+- Case insensitivity: `table1[amount]` resolves same as `Table1[Amount]`
+- Unknown table name: `UnknownTable[Col]` produces a clear classification error (not a panic)
+- Unknown column name: `Table1[NonexistentCol]` produces a classification error
+- Empty specifier: `Table1` (whole table reference) resolves to full data range
+- Column range: `Table1[[Col1]:[Col3]]` resolves to bounded range
+- Nested in SUMIF: `SUMIF(Table1[Region], "EMEA", Table1[Amount])` classifies as Aggregate
+- Nested in IF: `IF([@A]>0, [@B], [@C])` classifies as RowLocal
+- Mixed with named ranges: `SUM(MyRange) + [@Price]` — both resolve
+- Mixed with regular cell refs: `[@Price] + B2` classifies as RowLocal
+- Error propagation: table reference inside a formula that also has an unsupported function — unsupported function error takes precedence
+- `[@Column]` outside any table context — should produce a classification error
+
+**Regression guards:**
+- All existing classification tests pass unchanged
+- Named range resolution still works
+- Formulas without table references are unaffected
+
+### Evaluation (integration tests)
+
+- Programmatic xlsx with a table (created via openpyxl with `ws.add_table()`), formula `=[@Price]*[@Qty]` on each row — verify correct per-row multiplication
+- `=SUM(Table1[Amount])` on a non-table sheet referencing a table column — verify correct aggregate
+- `=VLOOKUP([@Key], Table2[[Key]:[Value]], 2, FALSE)` — table reference as lookup table array
+- Table on a non-main sheet with `[@Column]` formulas — verify evaluation (related to issue #42 if resolved)
+- Unknown table name in formula — verify `UnsupportedFormula` error with actionable message
+
+### Golden-file regression
+
+The golden regression fixture will need new formula columns exercising table references. The fixture must be created in Excel (not openpyxl) to have correct cached values. Alternatively, add a separate table-reference regression fixture.
+
+## Docs to update (same PR)
+
+| File | Change |
+|---|---|
+| `CHANGELOG.md` | Add table reference entry under `[Unreleased]` |
+| `docs/functions.md` | Tick the table reference checkbox (line 607) |
+| `docs/roadmap/v0.2/README.md` | Tick the table references checkbox |
+| `docs/architecture/streaming-model.md` | Update table reference row from "Unsupported" to supported with resolution description (line 75) |
+
+## Streaming invariant
+
+Does not violate the invariant. `Table[Column]` resolves to a whole-column range (prelude-computed). `[@Column]` resolves to a same-row cell (row-local). All resolution happens before or during the existing two-pass model.

--- a/docs/standards/code-style.md
+++ b/docs/standards/code-style.md
@@ -218,6 +218,15 @@ We are pre-1.0. Breaking changes are allowed between minor versions (0.1 → 0.2
 - Give deprecation warnings where possible.
 - Make the change worth it.
 
+## Magic numbers
+
+No numeric literals with non-obvious meaning in library code. Extract to a named `const`.
+
+- Engine-wide thresholds (row limits, parallel cutoffs) go in `xlstream-core` next to `EXCEL_MAX_ROWS`.
+- Domain-specific constants (iteration limits, convergence tolerances) stay local to the module that uses them.
+- Standard mathematical constants (`PI`, `E`) use `std::f64::consts`.
+- Literal `0`, `1`, `-1` in arithmetic are fine. So are array/vec indices and lengths.
+
 ## Forbidden in library code
 
 - `println!`, `eprintln!`, `dbg!` — use `tracing`.

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -1,13 +1,11 @@
 # Testing
 
-Five tiers. Every feature lands with the right ones.
+Four tiers. Every feature lands with the right ones.
 
 1. **Unit tests** — in-module, `#[cfg(test)] mod tests`. Test one function, one behaviour.
 2. **Integration tests** — in `tests/` of each crate. Test cross-module behaviour within a crate.
-3. **Workspace integration tests** — in `tests/` at repo root. Test cross-crate end-to-end.
-4. **Property tests** — `proptest` for functions with algebraic properties.
-5. **Fuzz tests** — `cargo-fuzz` for the parser and I/O layer.
-6. **Benchmarks** — `criterion` for perf-sensitive code.
+3. **End-to-end tests** — full pipeline through `evaluate()`: read xlsx, parse, classify, prelude, stream, write, verify output.
+4. **Benchmarks** — `criterion` for perf-sensitive code.
 
 Separately: **Python tests** in `bindings/python/tests/` via `pytest`.
 
@@ -52,23 +50,30 @@ Each crate's `tests/` directory holds integration tests. One file per feature ar
 
 ```
 crates/xlstream-eval/tests/
-├── arithmetic.rs
-├── conditional.rs
-├── lookups.rs
-├── aggregates.rs
-└── end_to_end.rs
+├── end_to_end.rs                        ← test binary root (imports submodules)
+├── end_to_end/
+│   ├── helpers/mod.rs                   ← shared fixture generators
+│   ├── pipeline.rs                      ← core pipeline (cell refs, chained formulas, errors)
+│   ├── lookups.rs                       ← VLOOKUP, XLOOKUP, INDEX/MATCH
+│   ├── cross_sheet_aggregates.rs        ← cross-sheet SUMIF/COUNTIF/AVERAGEIF
+│   ├── grouped_sumif.rs                 ← SUMIF with row-local criteria
+│   ├── product_literals.rs              ← PRODUCT(2,3,4) inline eval
+│   ├── named_ranges.rs                  ← named range resolution
+│   └── secondary_sheet_formulas.rs      ← multi-sheet formula evaluation
+├── fixtures/
+│   └── regression.xlsx                  ← Excel-verified golden file
+├── regression_base.rs                   ← golden-file comparison (all surfaces)
+└── *.rs                                 ← per-category unit-level tests
 ```
-
-Fixtures (small .xlsx files) live in `fixtures/canonical/`. Committed to the repo, each < 50 KB. Large fixtures go in `fixtures/generated/` and are reproduced by a build script.
 
 ### The two layers of integration testing
 
 Every builtin lands with both:
 
 1. **Evaluator-level integration** — drive the builtin via `xlstream_eval::Interpreter::eval` with a real AST node. Proves the builtin is reachable through dispatch, argument coercion, and error propagation. Lives in `crates/xlstream-eval/tests/<family>.rs`.
-2. **End-to-end integration** (at least once per feature area) — drive the builtin via `xlstream_eval::evaluate(input, output, None)` on a tiny committed xlsx fixture. Proves the builtin works through the full pipeline: read → classify → prelude → stream → write. Lives in `tests/end_to_end.rs` at the repo root.
+2. **End-to-end integration** (at least once per feature area) — drive the builtin via `xlstream_eval::evaluate(input, output, None)` on a programmatic fixture. Proves the builtin works through the full pipeline: read, classify, prelude, stream, write. Lives in `crates/xlstream-eval/tests/end_to_end/<feature>.rs`.
 
-Evaluator-level integration is per-builtin. End-to-end is per-feature-area (one `IF` fixture covers all logical builtins conceptually; one `VLOOKUP` fixture covers the lookup family).
+Evaluator-level integration is per-builtin. End-to-end is per-feature-area.
 
 ### Minimum bar per builtin PR
 
@@ -83,24 +88,6 @@ A PR that lands a new **feature area** (arithmetic, aggregates, lookups, etc.) a
 - **≥ 1 end-to-end test** that evaluates a fixture xlsx containing formulas from that area and asserts the output matches an Excel-computed golden.
 
 No exceptions without a design note in the PR explaining why.
-
-## Workspace integration tests
-
-`tests/` at the repo root. Test the whole pipeline: input xlsx → evaluate → output xlsx → read → compare.
-
-```rust
-#[test]
-fn reference_workload_small() {
-    let input = fixtures::dir().join("canonical/benchmark_small.xlsx");
-    let output = tempfile::NamedTempFile::new().unwrap();
-    xlstream_eval::evaluate(&input, output.path(), None).unwrap();
-
-    let df_actual = read_output(output.path());
-    let df_expected = read_golden(fixtures::dir().join("canonical/benchmark_small_golden.xlsx"));
-
-    assert_frames_equal(&df_actual, &df_expected);
-}
-```
 
 ## Regression testing
 
@@ -118,89 +105,17 @@ The test evaluates the fixture through xlstream and compares every formula cell 
 
 **When to regenerate:** after adding new formula columns to the `FORMULAS` spec in `regression_base.rs`.
 
-### Base regression tests (`regression_base.rs`)
+### Per-bug regression tests
 
-Per-bug regression tests. Each test builds a minimal fixture programmatically and asserts exact output. No Excel needed.
+Added as end-to-end tests in `crates/xlstream-eval/tests/end_to_end/`. Each test builds a minimal fixture programmatically and asserts exact output. No Excel needed.
 
 - Tests land BEFORE the fix (`#[ignore = "blocked: ..."]`).
 - Fix un-ignores the test.
 - Test + fix commit together.
 
-Naming: `test_<short_description>`.
-
 ## Excel parity
 
-Every builtin function has at least one test asserting its output against values produced by real Excel. The golden-file regression suite (`regression_base.rs`) is the primary mechanism — it covers all 117 surfaces in a single workbook verified by Excel.
-
-## The 1900 leap year test
-
-Write it early. It's the most commonly-missed Excel compatibility trap.
-
-```rust
-#[test]
-fn excel_treats_1900_02_29_as_valid() {
-    // Excel serial 60 = Feb 29 1900 (not a real date; legacy Lotus bug).
-    let v = ExcelDate::from_serial(60.0);
-    assert_eq!(v.year_month_day(), (1900, 2, 29));
-}
-
-#[test]
-fn dates_after_march_1900_match_excel() {
-    let v = ExcelDate::from_serial(61.0);
-    assert_eq!(v.year_month_day(), (1900, 3, 1));
-}
-```
-
-## Accuracy test list (do early)
-
-From the research:
-- Text comparison case-insensitivity: `"a"="A"` → TRUE (except `EXACT`).
-- Boolean coercion in arithmetic: `TRUE + 1` → 2.
-- Empty cell vs 0 vs "": `ISBLANK(empty)` → TRUE, `ISBLANK(0)` → FALSE.
-- Error propagation through arithmetic.
-- Error interception by `IFERROR` / `IFNA`.
-- Whole-column ranges don't allocate 1M cells.
-- `VLOOKUP` approximate match on unsorted data returns Excel-compatible garbage (not our place to fix).
-- Operator precedence: unary minus before `^` (Excel: `-2^2 = 4`, not `-4`).
-- 1900 leap year (above).
-- 1904 date system — workbook flag respected.
-
-Each becomes a named test in `tests/accuracy_parity.rs`.
-
-## Property tests
-
-`proptest` for functions with algebraic properties.
-
-```rust
-proptest! {
-    #[test]
-    fn sum_is_commutative(a: f64, b: f64) {
-        prop_assert_eq!(
-            sum(&[Value::Number(a), Value::Number(b)]),
-            sum(&[Value::Number(b), Value::Number(a)]),
-        );
-    }
-
-    #[test]
-    fn parsed_formula_round_trips(ast in ast_strategy()) {
-        let s = ast.to_string();
-        let parsed = parse(&s).unwrap();
-        prop_assert_eq!(parsed, ast);
-    }
-}
-```
-
-Especially useful for: parser round-trip, arithmetic associativity, coercion idempotence.
-
-## Fuzz tests
-
-`cargo-fuzz` targets live in `fuzz/` at the workspace root.
-
-- `fuzz_parser` — feeds arbitrary bytes to the parser. Must not panic.
-- `fuzz_xlsx_reader` — feeds malformed xlsx files to the reader. Must return `Err`, not crash.
-- `fuzz_classifier` — random ASTs into classification. Must return a valid `Classification` or `Unsupported`.
-
-Run in CI weekly (scheduled workflow). Shorter run in per-PR CI (1 minute each target) to catch obvious regressions.
+Every builtin function has at least one test asserting its output against values produced by real Excel. The golden-file regression suite (`regression_base.rs`) is the primary mechanism — it covers all 117 surfaces in a single workbook verified by Excel. Edge cases (1900 leap year, boolean coercion, case-insensitive comparison, error propagation, operator precedence) are covered by the golden file and per-category integration tests.
 
 ## Benchmarks
 
@@ -215,11 +130,29 @@ fn bench_vlookup_10k(c: &mut Criterion) {
 }
 ```
 
+### Benchmark coverage by code path
+
+Every formula maps to one of these code paths. Each path has a criterion benchmark.
+
+| Code path | Benchmark file | Formulas using it |
+|---|---|---|
+| Parser | `parse.rs` | all formulas |
+| Binary/unary ops | `arithmetic.rs` | +, -, *, /, ^, %, &, comparisons |
+| String ops | `string.rs` | LEFT, RIGHT, MID, UPPER, CONCAT, TEXT, etc. |
+| Date serial conversion | `date.rs` | YEAR, MONTH, EDATE, NETWORKDAYS, etc. |
+| Pure math | `math.rs` | ROUND, MOD, SQRT, ABS, INT, POWER, etc. |
+| Iterative solvers | `financial.rs` | IRR, RATE, PMT, NPV, FV |
+| Short-circuit eval | `conditional.rs` | IF, IFS, SWITCH, IFERROR, AND, OR |
+| Type checking | `info.rs` | ISBLANK, ISNUMBER, TYPE, ISERROR |
+| Hash index probe | `lookup.rs` | VLOOKUP, XLOOKUP, INDEX/MATCH |
+| Streaming fold | `aggregate.rs` | SUM, COUNT, AVERAGE, SUMIF, COUNTIF |
+| Full pipeline | `end_to_end.rs` | read+parse+classify+prelude+eval+write at 10k rows |
+
+**Rule: when you add a formula with a novel code path** (not just dispatch to existing machinery), add a criterion bench for it in the matching `benches/<category>.rs` file. If no category fits, create a new file and add a `[[bench]]` entry to `benchmarks/Cargo.toml`.
+
 ### Reference workload
 
-`benchmarks/fixtures/reference_400k.xlsx` is the ground truth. Every perf claim in the docs comes from this workload.
-
-CI runs the `quick` bench (5k rows) on every PR. Full tier benchmarks run locally via `make bench`.
+CI runs criterion micro-benchmarks on every PR via `bench-gate` (fails on >15% regression). Full tier benchmarks (100k+) run locally via `scripts/bench-report.sh`. Reports are stored in `benchmarks/reports/`.
 
 ## Memory profiling
 
@@ -267,17 +200,14 @@ cargo bench
 ## CI gates
 
 A PR merges only when:
-- `cargo test --all-features` passes.
-- `cargo test --doc` passes.
+- `cargo test --all-features` passes (unit + integration + doctests).
 - `cargo clippy --all-targets --all-features -- -D warnings` is clean.
 - `cargo fmt --check` is clean.
 - `pytest` passes (for PRs touching the Python binding).
-- Code coverage didn't drop (target: 85%+ line coverage on library crates).
+- Criterion bench-gate passes (no >15% regression on micro-benchmarks).
 
 ## Test data
 
-- Small (< 50 KB) xlsx fixtures → committed in `fixtures/canonical/`.
-- Large xlsx fixtures → generated by a script, gitignored, reproduced on CI.
-- Expected outputs → committed as JSON next to the input, one fixture per test.
-
-Scripts to (re)generate fixtures live in `fixtures/scripts/`. Each is a small Rust binary or a Python openpyxl script, invoked by `cargo xtask regenerate-fixtures` (or a `Makefile` target).
+- Golden-file fixture (`tests/fixtures/regression.xlsx`) — committed, Excel-verified.
+- Programmatic fixtures — generated in test code via `rust_xlsxwriter`, no committed xlsx needed.
+- Large fixtures for benchmarks — generated by `benchmarks/src/bin/generate_fixtures.rs`, gitignored.


### PR DESCRIPTION
## Summary

- Fix all `docs/phases/` references to `docs/roadmap/` (CLAUDE.md, Makefile, Cargo.toml, parallelism.md)
- Fix `FUNCTIONS.md` (uppercase, wrong path) to `docs/functions.md` in roadmap
- Fix function count 113 -> 103 in README and roadmap (verified against codebase dispatch)
- Remove stale phase references from xlstream-parse and xlstream-io rustdoc
- Update all 5 per-crate READMEs: add crates.io + docs.rs badges, "when to use" guidance, absolute GitHub links for crates.io compatibility
- Remove CLI section from root README (not published)
- Add magic numbers rule to code-style.md
- Add benchmark coverage rule to CLAUDE.md, CONTRIBUTING.md, testing.md (novel code path -> criterion bench)
- Clean testing.md: remove stale sections (proptest, fuzz, workspace integration tests, accuracy test list, wrong fixture paths), update to match actual test structure
- Update CLAUDE.md current state from "Phase 13 in progress" to "v0.2 in progress"
- Add table references feature spec (docs/roadmap/v0.2/02-table-references.md)

## Test plan

- [x] All links in updated docs resolve correctly on GitHub
- [x] `make check` passes
- [x] No code changes — docs only