### PR TITLE
xlstream-core: extract magic numbers to named constants

### DIFF
--- a/crates/xlstream-core/src/lib.rs
+++ b/crates/xlstream-core/src/lib.rs
@@ -38,3 +38,7 @@ pub use value::Value;
 pub const EXCEL_MAX_ROWS: u64 = 1_048_576;
 /// Maximum column count in an Excel xlsx worksheet (2^14).
 pub const EXCEL_MAX_COLS: u16 = 16_384;
+
+/// Minimum data rows on the main sheet before the evaluator spawns parallel
+/// workers. Below this threshold single-threaded evaluation is faster.
+pub const PARALLEL_ROW_THRESHOLD: u32 = 10_000;

--- a/crates/xlstream-eval/src/builtins/financial.rs
+++ b/crates/xlstream-eval/src/builtins/financial.rs
@@ -10,6 +10,10 @@ use xlstream_parse::NodeRef;
 use crate::interp::Interpreter;
 use crate::scope::RowScope;
 
+/// Maximum Newton-Raphson iterations for IRR and RATE. Matches Excel's
+/// documented 100-iteration limit.
+const MAX_NEWTON_ITERATIONS: usize = 100;
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -307,7 +311,7 @@ pub fn irr_from_cashflows(cashflows: &[f64]) -> Value {
 
     let mut rate: f64 = 0.1; // default guess
 
-    for _ in 0..100 {
+    for _ in 0..MAX_NEWTON_ITERATIONS {
         let mut npv: f64 = 0.0;
         let mut d_npv: f64 = 0.0;
         for (t, &cf) in cashflows.iter().enumerate() {
@@ -425,7 +429,7 @@ pub fn builtin_rate(args: &[Value]) -> Value {
 
     let mut rate = guess;
 
-    for _ in 0..100 {
+    for _ in 0..MAX_NEWTON_ITERATIONS {
         if rate == 0.0 {
             // Special case: avoid division by zero in derivative
             // f(0) = pmt * nper + pv + fv

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
-use xlstream_core::{col_row_to_a1, Value, XlStreamError};
+use xlstream_core::{col_row_to_a1, Value, XlStreamError, PARALLEL_ROW_THRESHOLD};
 use xlstream_io::{Reader, Writer};
 use xlstream_parse::{
     classify, collect_lookup_keys, extract_references, parse, resolve_named_ranges, rewrite,
@@ -103,7 +103,7 @@ pub fn evaluate(
     let use_parallel = num_workers > 1
         && plan.main_sheet.is_some()
         && !plan.col_asts.is_empty()
-        && plan.total_data_rows >= 10_000;
+        && plan.total_data_rows >= PARALLEL_ROW_THRESHOLD;
 
     let (rows_processed, formulas_evaluated) = if use_parallel {
         let main_sheet_name = plan


### PR DESCRIPTION
## Summary
- `PARALLEL_ROW_THRESHOLD` (10,000) added to xlstream-core, next to `EXCEL_MAX_ROWS`/`EXCEL_MAX_COLS`
- `MAX_NEWTON_ITERATIONS` (100) added to `financial.rs`, shared by IRR and RATE
- No behavior change — same values, just named

## Test plan
- [ ] `make check` passes
- [ ] No behavior change (identical values)