### PR TITLE
docs: update pr template, remove stale regression pattern, add contributing prereq

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,19 @@
 - [ ] New tests added for changed behavior
 - [ ] Existing tests still pass
 
+<!-- Test location guide:
+  - Unit tests: in-module `#[cfg(test)] mod tests`
+  - Per-category integration: `crates/xlstream-eval/tests/<category>.rs`
+  - End-to-end pipeline: `crates/xlstream-eval/tests/end_to_end/<feature>.rs`
+  - See docs/standards/testing.md for the full test structure.
+-->
+
 ## Checklist
 
+- [ ] Read `CONTRIBUTING.md` and `docs/standards/` before starting
 - [ ] No `unwrap`/`expect`/`panic` in library code
 - [ ] Public items have rustdoc + doctest
 - [ ] Commit messages follow `<prefix>: <imperative, lowercase>` format
-- [ ] Phase doc checkboxes updated (if applicable)
+- [ ] Roadmap checkboxes updated (if applicable)
 - [ ] `docs/functions.md` updated (if new function added)
+- [ ] Criterion benchmark added (if novel code path introduced)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,12 @@ xlstream/
 ### Before you touch code
 
 0. **Use `/rust-skills` before writing any Rust code.** Covers idiomatic patterns, error handling, type design, and common pitfalls. Use it alongside (not instead of) any other applicable skills.
-1. **Read the current version roadmap.** Find it via [`docs/roadmap/README.md`](docs/roadmap/README.md). You are implementing a specific checkbox in the current version. Don't free-lance.
-2. **Read the architecture doc that covers your area.** Unclear architecture → stop and ask. Do not invent.
-3. **Search for existing patterns.** If three other builtins handle errors a given way, yours does too. Consistency outranks cleverness.
-4. **Always use Context7 MCP for up-to-date docs before writing code.** This is non-negotiable. Any time you're about to use a library, framework, SDK, or crate — calamine, rust_xlsxwriter, pyo3, maturin, rayon, formualizer-parse, phf, thiserror, tokio, anything — call Context7 first to verify the API shape against the **current** documentation. Your training-data knowledge may be stale; library APIs drift between versions. Context7 costs nothing; a silently-wrong import costs hours. Prefer it over general web search for library docs.
-5. **When Context7 has gaps, read the upstream source at `refs/<library>/`.** Present on every dev machine (gitignored, cloned from upstream). Covers `formualizer`, `calamine`, `rust_xlsxwriter`, `pyo3`, `maturin`. Grep-able. Authoritative. Never fabricate an API shape you can't verify — either Context7 confirms or `refs/` confirms, otherwise stop and ask. If a library isn't in `refs/` yet, clone it there: `git clone --depth 1 <upstream-url> refs/<libname>`.
+1. **Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/standards/`](docs/standards/).** These are mandatory, not optional. `CONTRIBUTING.md` covers setup, workflow, and the minimum bar for PRs. The standards docs cover code style, testing, commits, and documentation requirements.
+2. **Read the current version roadmap.** Find it via [`docs/roadmap/README.md`](docs/roadmap/README.md). You are implementing a specific checkbox in the current version. Don't free-lance.
+3. **Read the architecture doc that covers your area.** Unclear architecture → stop and ask. Do not invent.
+4. **Search for existing patterns.** If three other builtins handle errors a given way, yours does too. Consistency outranks cleverness.
+5. **Always use Context7 MCP for up-to-date docs before writing code.** This is non-negotiable. Any time you're about to use a library, framework, SDK, or crate — calamine, rust_xlsxwriter, pyo3, maturin, rayon, formualizer-parse, phf, thiserror, tokio, anything — call Context7 first to verify the API shape against the **current** documentation. Your training-data knowledge may be stale; library APIs drift between versions. Context7 costs nothing; a silently-wrong import costs hours. Prefer it over general web search for library docs.
+6. **When Context7 has gaps, read the upstream source at `refs/<library>/`.** Present on every dev machine (gitignored, cloned from upstream). Covers `formualizer`, `calamine`, `rust_xlsxwriter`, `pyo3`, `maturin`. Grep-able. Authoritative. Never fabricate an API shape you can't verify — either Context7 confirms or `refs/` confirms, otherwise stop and ask. If a library isn't in `refs/` yet, clone it there: `git clone --depth 1 <upstream-url> refs/<libname>`.
 
 ### When you write code
 

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -105,14 +105,6 @@ The test evaluates the fixture through xlstream and compares every formula cell 
 
 **When to regenerate:** after adding new formula columns to the `FORMULAS` spec in `regression_base.rs`.
 
-### Per-bug regression tests
-
-Added as end-to-end tests in `crates/xlstream-eval/tests/end_to_end/`. Each test builds a minimal fixture programmatically and asserts exact output. No Excel needed.
-
-- Tests land BEFORE the fix (`#[ignore = "blocked: ..."]`).
-- Fix un-ignores the test.
-- Test + fix commit together.
-
 ## Excel parity
 
 Every builtin function has at least one test asserting its output against values produced by real Excel. The golden-file regression suite (`regression_base.rs`) is the primary mechanism — it covers all 117 surfaces in a single workbook verified by Excel. Edge cases (1900 leap year, boolean coercion, case-insensitive comparison, error propagation, operator precedence) are covered by the golden file and per-category integration tests.


### PR DESCRIPTION
## Summary

- PR template: add test location guide comment, add `Read CONTRIBUTING.md` and `Criterion benchmark` checklist items, replace stale "Phase doc" with "Roadmap"
- testing.md: remove per-bug regression test section (stale `#[ignore]` pattern)
- CLAUDE.md: add mandatory `CONTRIBUTING.md` and `docs/standards/` prereq before touching code

## Test plan

- [x] No code changes — docs and templates only