### PR TITLE
xlstream-eval: add SUMPRODUCT builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Semver.
 
 ### Added
 - MINIFS and MAXIFS conditional aggregate functions
+- SUMPRODUCT: sum of element-wise products of bounded ranges; single-array degenerate case sums the array; booleans coerce to 1/0
 
 ### Fixed
 - Formulas on sheets not referenced by the main sheet are now evaluated instead of producing None (#42)

--- a/crates/xlstream-eval/src/builtins/aggregate.rs
+++ b/crates/xlstream-eval/src/builtins/aggregate.rs
@@ -331,6 +331,52 @@ pub fn median(values: &[Value]) -> Result<Value, CellError> {
     }
 }
 
+/// `SUMPRODUCT` — sum of element-wise products of arrays.
+///
+/// With a single array, sums the array. All arrays must have the same
+/// length. Values are coerced via [`xlstream_core::coerce::to_number`]:
+/// booleans become 1/0, empty becomes 0, errors propagate, text that
+/// cannot parse as a number returns `#VALUE!`.
+///
+/// # Errors
+///
+/// Returns `Err(CellError::Value)` if no arrays are provided or if
+/// arrays have different lengths. Returns `Err(CellError)` if any
+/// value is an error or non-numeric text.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::Value;
+/// use xlstream_eval::builtins::aggregate::sumproduct;
+/// let a = [Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)];
+/// let b = [Value::Number(4.0), Value::Number(5.0), Value::Number(6.0)];
+/// assert_eq!(sumproduct(&[&a[..], &b[..]]), Ok(Value::Number(32.0)));
+/// ```
+pub fn sumproduct(arrays: &[&[Value]]) -> Result<Value, CellError> {
+    if arrays.is_empty() {
+        return Err(CellError::Value);
+    }
+
+    let len = arrays[0].len();
+    for arr in &arrays[1..] {
+        if arr.len() != len {
+            return Err(CellError::Value);
+        }
+    }
+
+    let mut total = 0.0_f64;
+    for i in 0..len {
+        let mut product = 1.0_f64;
+        for arr in arrays {
+            product *= xlstream_core::coerce::to_number(&arr[i])?;
+        }
+        total += product;
+    }
+
+    Ok(Value::Number(total))
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::float_cmp)]
@@ -654,5 +700,68 @@ mod tests {
     fn max_with_integer() {
         let vals = [Value::Number(5.0), Value::Integer(10)];
         assert_eq!(max(&vals).unwrap(), Value::Number(10.0));
+    }
+
+    // ===== SUMPRODUCT =====
+
+    #[test]
+    fn sumproduct_two_equal_ranges() {
+        let a = [Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)];
+        let b = [Value::Number(4.0), Value::Number(5.0), Value::Number(6.0)];
+        assert_eq!(sumproduct(&[&a[..], &b[..]]).unwrap(), Value::Number(32.0));
+    }
+
+    #[test]
+    fn sumproduct_single_range_sums() {
+        let a = [Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)];
+        assert_eq!(sumproduct(&[&a[..]]).unwrap(), Value::Number(6.0));
+    }
+
+    #[test]
+    fn sumproduct_three_ranges() {
+        let a = [Value::Number(1.0), Value::Number(2.0)];
+        let b = [Value::Number(3.0), Value::Number(4.0)];
+        let c = [Value::Number(5.0), Value::Number(6.0)];
+        assert_eq!(sumproduct(&[&a[..], &b[..], &c[..]]).unwrap(), Value::Number(63.0));
+    }
+
+    #[test]
+    fn sumproduct_mismatched_lengths_returns_value_error() {
+        let a = [Value::Number(1.0), Value::Number(2.0)];
+        let b = [Value::Number(3.0)];
+        assert_eq!(sumproduct(&[&a[..], &b[..]]).unwrap_err(), CellError::Value);
+    }
+
+    #[test]
+    fn sumproduct_empty_args_returns_value_error() {
+        assert_eq!(sumproduct(&[]).unwrap_err(), CellError::Value);
+    }
+
+    #[test]
+    fn sumproduct_bool_coerces_to_numeric() {
+        let a = [Value::Bool(true), Value::Bool(false), Value::Bool(true)];
+        let b = [Value::Number(10.0), Value::Number(20.0), Value::Number(30.0)];
+        assert_eq!(sumproduct(&[&a[..], &b[..]]).unwrap(), Value::Number(40.0));
+    }
+
+    #[test]
+    fn sumproduct_empty_cells_treated_as_zero() {
+        let a = [Value::Number(5.0), Value::Empty, Value::Number(3.0)];
+        let b = [Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)];
+        assert_eq!(sumproduct(&[&a[..], &b[..]]).unwrap(), Value::Number(28.0));
+    }
+
+    #[test]
+    fn sumproduct_error_propagates() {
+        let a = [Value::Number(1.0), Value::Error(CellError::Na)];
+        let b = [Value::Number(2.0), Value::Number(3.0)];
+        assert_eq!(sumproduct(&[&a[..], &b[..]]).unwrap_err(), CellError::Na);
+    }
+
+    #[test]
+    fn sumproduct_text_returns_value_error() {
+        let a = [Value::Number(1.0), Value::Text("x".into())];
+        let b = [Value::Number(2.0), Value::Number(3.0)];
+        assert_eq!(sumproduct(&[&a[..], &b[..]]).unwrap_err(), CellError::Value);
     }
 }

--- a/crates/xlstream-eval/src/builtins/mod.rs
+++ b/crates/xlstream-eval/src/builtins/mod.rs
@@ -204,6 +204,26 @@ pub(crate) fn dispatch(
         "NPV" => Some(financial::builtin_npv(args, interp, scope)),
         "IRR" => Some(financial::builtin_irr(args, interp, scope)),
         "RATE" => Some(financial::builtin_rate(&eval_args(args, interp, scope))),
+        // -- range-expanding aggregate --
+        "SUMPRODUCT" => Some(builtin_sumproduct(args, interp, scope)),
         _ => None,
     }
+}
+
+/// `SUMPRODUCT(array1, array2, ...)` — sum of element-wise products.
+///
+/// Expands each arg via [`expand_range`] to collect arrays, then
+/// delegates to [`aggregate::sumproduct`].
+fn builtin_sumproduct(
+    args: &[NodeRef<'_>],
+    interp: &Interpreter<'_>,
+    scope: &RowScope<'_>,
+) -> Value {
+    if args.is_empty() {
+        return Value::Error(CellError::Value);
+    }
+
+    let arrays: Vec<Vec<Value>> = args.iter().map(|&a| expand_range(a, interp, scope)).collect();
+    let slices: Vec<&[Value]> = arrays.iter().map(Vec::as_slice).collect();
+    aggregate::sumproduct(&slices).unwrap_or_else(Value::Error)
 }

--- a/crates/xlstream-eval/tests/range_expansion.rs
+++ b/crates/xlstream-eval/tests/range_expansion.rs
@@ -268,3 +268,158 @@ fn irr_with_cell_refs_still_works() {
     let result = read_cell(&output, "Main", 1, 5);
     assert_approx(&result, 0.1532, 0.01);
 }
+
+// ---------------------------------------------------------------------------
+// SUMPRODUCT
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sumproduct_two_ranges_produces_correct_result() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "A").unwrap();
+    ws.write_string(0, 1, "B").unwrap();
+    ws.write_string(0, 2, "Result").unwrap();
+
+    ws.write_number(1, 0, 1.0).unwrap();
+    ws.write_number(2, 0, 2.0).unwrap();
+    ws.write_number(3, 0, 3.0).unwrap();
+    ws.write_number(1, 1, 4.0).unwrap();
+    ws.write_number(2, 1, 5.0).unwrap();
+    ws.write_number(3, 1, 6.0).unwrap();
+
+    // C2 = SUMPRODUCT(A2:A4, B2:B4) -> 1*4 + 2*5 + 3*6 = 32
+    ws.write_formula(1, 2, Formula::new("SUMPRODUCT(A2:A4, B2:B4)")).unwrap();
+
+    wb.save(&input).unwrap();
+    let summary = evaluate(&input, &output, None).unwrap();
+    assert_eq!(summary.formulas_evaluated, 3);
+
+    let result = read_cell(&output, "Main", 1, 2);
+    assert_eq!(result, Value::Number(32.0));
+}
+
+#[test]
+fn sumproduct_single_range_sums_values() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "Value").unwrap();
+    ws.write_string(0, 1, "Result").unwrap();
+
+    ws.write_number(1, 0, 10.0).unwrap();
+    ws.write_number(2, 0, 20.0).unwrap();
+    ws.write_number(3, 0, 30.0).unwrap();
+
+    // B2 = SUMPRODUCT(A2:A4) -> 10 + 20 + 30 = 60
+    ws.write_formula(1, 1, Formula::new("SUMPRODUCT(A2:A4)")).unwrap();
+
+    wb.save(&input).unwrap();
+    evaluate(&input, &output, None).unwrap();
+
+    let result = read_cell(&output, "Main", 1, 1);
+    assert_eq!(result, Value::Number(60.0));
+}
+
+#[test]
+fn sumproduct_three_ranges_triple_product() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "A").unwrap();
+    ws.write_string(0, 1, "B").unwrap();
+    ws.write_string(0, 2, "C").unwrap();
+    ws.write_string(0, 3, "Result").unwrap();
+
+    ws.write_number(1, 0, 1.0).unwrap();
+    ws.write_number(2, 0, 2.0).unwrap();
+    ws.write_number(1, 1, 3.0).unwrap();
+    ws.write_number(2, 1, 4.0).unwrap();
+    ws.write_number(1, 2, 5.0).unwrap();
+    ws.write_number(2, 2, 6.0).unwrap();
+
+    // D2 = SUMPRODUCT(A2:A3, B2:B3, C2:C3) -> 1*3*5 + 2*4*6 = 15 + 48 = 63
+    ws.write_formula(1, 3, Formula::new("SUMPRODUCT(A2:A3, B2:B3, C2:C3)")).unwrap();
+
+    wb.save(&input).unwrap();
+    evaluate(&input, &output, None).unwrap();
+
+    let result = read_cell(&output, "Main", 1, 3);
+    assert_eq!(result, Value::Number(63.0));
+}
+
+#[test]
+fn sumproduct_with_boolean_conditional_idiom() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+
+    ws.write_string(0, 0, "Value").unwrap();
+    ws.write_string(0, 1, "Flag").unwrap();
+    ws.write_string(0, 2, "Result").unwrap();
+
+    ws.write_number(1, 0, 10.0).unwrap();
+    ws.write_number(2, 0, 20.0).unwrap();
+    ws.write_number(3, 0, 30.0).unwrap();
+    ws.write_boolean(1, 1, true).unwrap();
+    ws.write_boolean(2, 1, false).unwrap();
+    ws.write_boolean(3, 1, true).unwrap();
+
+    // C2 = SUMPRODUCT(A2:A4, B2:B4) -> 10*1 + 20*0 + 30*1 = 40
+    ws.write_formula(1, 2, Formula::new("SUMPRODUCT(A2:A4, B2:B4)")).unwrap();
+
+    wb.save(&input).unwrap();
+    evaluate(&input, &output, None).unwrap();
+
+    let result = read_cell(&output, "Main", 1, 2);
+    assert_eq!(result, Value::Number(40.0));
+}
+
+#[test]
+fn sumproduct_cross_sheet_bounded_range() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.xlsx");
+    let output = dir.path().join("output.xlsx");
+
+    let mut wb = Workbook::new();
+
+    // Lookup sheet with weights
+    let ws_weights = wb.add_worksheet().set_name("Weights").unwrap();
+    ws_weights.write_number(0, 0, 2.0).unwrap();
+    ws_weights.write_number(1, 0, 3.0).unwrap();
+    ws_weights.write_number(2, 0, 4.0).unwrap();
+
+    // Main sheet
+    let ws = wb.add_worksheet().set_name("Main").unwrap();
+    ws.write_string(0, 0, "Value").unwrap();
+    ws.write_string(0, 1, "Result").unwrap();
+
+    ws.write_number(1, 0, 10.0).unwrap();
+    ws.write_number(2, 0, 20.0).unwrap();
+    ws.write_number(3, 0, 30.0).unwrap();
+
+    // B2 = SUMPRODUCT(A2:A4, Weights!A1:A3) -> 10*2 + 20*3 + 30*4 = 200
+    ws.write_formula(1, 1, Formula::new("SUMPRODUCT(A2:A4, Weights!A1:A3)")).unwrap();
+
+    wb.save(&input).unwrap();
+    evaluate(&input, &output, None).unwrap();
+
+    let result = read_cell(&output, "Main", 1, 1);
+    assert_eq!(result, Value::Number(200.0));
+}

--- a/crates/xlstream-eval/tests/regression_base.rs
+++ b/crates/xlstream-eval/tests/regression_base.rs
@@ -234,6 +234,9 @@ const FORMULAS: &[Spec] = &[
     f("fin_fv",    "=FV(0.06/12,240,-200)"),
     f("fin_npv",   "=NPV(0.1,A{r},B{r},C{r})"),
     f("fin_rate",  "=RATE(120,-500,50000)"),
+
+    // ---- Range-expanding (1; requires bounded range args) ----
+    f("re_sumprod", "=SUMPRODUCT(A2:A6,B2:B6)"),
 ];
 
 // ---------------------------------------------------------------------------

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -873,4 +873,61 @@ mod tests {
         );
         assert_eq!(c, Classification::Mixed);
     }
+
+    // -- SUMPRODUCT classification --
+
+    #[test]
+    fn sumproduct_two_bounded_ranges_classifies_as_streamable() {
+        let ast = crate::parse("SUMPRODUCT(A1:A3, B1:B3)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        let result = classify(&ast, &ctx);
+        assert!(
+            !matches!(result, Classification::Unsupported(_)),
+            "expected streamable, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sumproduct_single_bounded_range_classifies_as_streamable() {
+        let ast = crate::parse("SUMPRODUCT(A1:A5)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        let result = classify(&ast, &ctx);
+        assert!(
+            !matches!(result, Classification::Unsupported(_)),
+            "expected streamable, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sumproduct_three_bounded_ranges_classifies_as_streamable() {
+        let ast = crate::parse("SUMPRODUCT(A1:A3, B1:B3, C1:C3)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        let result = classify(&ast, &ctx);
+        assert!(
+            !matches!(result, Classification::Unsupported(_)),
+            "expected streamable, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sumproduct_case_insensitive() {
+        let ast = crate::parse("sumproduct(A1:A5, B1:B5)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        let result = classify(&ast, &ctx);
+        assert!(
+            !matches!(result, Classification::Unsupported(_)),
+            "expected streamable, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sumproduct_nested_inside_if() {
+        let ast = crate::parse("IF(D2, SUMPRODUCT(A1:A3, B1:B3), 0)").unwrap();
+        let ctx = ClassificationContext::for_cell("Sheet1", 2, 5);
+        let result = classify(&ast, &ctx);
+        assert!(
+            !matches!(result, Classification::Unsupported(_)),
+            "expected streamable, got {result:?}"
+        );
+    }
 }

--- a/crates/xlstream-parse/src/sets.rs
+++ b/crates/xlstream-parse/src/sets.rs
@@ -137,7 +137,7 @@ pub fn is_volatile_unsupported(name: &str) -> bool {
 /// multi-column ranges are still refused.
 pub(crate) static RANGE_EXPANDING_FUNCTIONS: Set<&'static str> = phf_set! {
     "IRR", "NPV", "CONCAT", "CONCATENATE", "TEXTJOIN",
-    "NETWORKDAYS", "WORKDAY", "AND", "OR",
+    "NETWORKDAYS", "WORKDAY", "AND", "OR", "SUMPRODUCT",
 };
 
 /// `true` if `name` is in `RANGE_EXPANDING_FUNCTIONS` (case-insensitive).
@@ -219,6 +219,8 @@ mod tests {
         assert!(is_range_expanding("AND"));
         assert!(is_range_expanding("OR"));
         assert!(is_range_expanding("NPV"));
+        assert!(is_range_expanding("SUMPRODUCT"));
+        assert!(is_range_expanding("sumproduct"));
         assert!(!is_range_expanding("SUM"));
     }
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -111,7 +111,7 @@ Every Excel function (~493), organized by category. Cross-referenced against xls
 | SUM | x | yes | v0.1 | x | x | |
 | SUMIF | x | yes | v0.1 | x | x | |
 | SUMIFS | x | yes | v0.1 | x | | |
-| SUMPRODUCT | . | yes | v0.2 | x | x | |
+| SUMPRODUCT | x | yes | v0.2 | x | x | |
 | SUMSQ | . | yes | v0.3 | | | |
 | SUMX2MY2 | . | yes | v0.3 | | | |
 | SUMX2PY2 | . | yes | v0.3 | | | |

--- a/docs/roadmap/v0.2/README.md
+++ b/docs/roadmap/v0.2/README.md
@@ -10,7 +10,7 @@
 
 - [x] **Named ranges** — resolve `MyRange` via `defined_names()` at classification time. ~1 day.
 - [ ] **Table references** — `Table[Column]`, `Table[@Column]`. Parse `tables/table*.xml`, resolve to ranges. ~2 days.
-- [ ] **SUMPRODUCT** — sum of element-wise products. Requires bounded-range evaluation. ~1 day.
+- [x] **SUMPRODUCT** — sum of element-wise products. Requires bounded-range evaluation. ~1 day.
 - [x] **MINIFS / MAXIFS** — conditional min/max. Same pattern as SUMIFS/COUNTIFS. ~0.5 day.
 - [ ] **ROWS / COLUMNS** — return row/column count. Uses `EXCEL_MAX_ROWS`/`EXCEL_MAX_COLS` constants (already in xlstream-core). ~0.5 day.
 


### PR DESCRIPTION
## Summary
- Implements: SUMPRODUCT
- Spec: `docs/roadmap/v0.2/03-sumproduct.md`
- Adds `SUMPRODUCT` to `RANGE_EXPANDING_FUNCTIONS` for prelude bounded-range caching
- Pure `sumproduct(&[&[Value]])` function in `aggregate.rs` — coerces Bool to 1/0, Empty to 0, propagates errors, rejects non-numeric text
- Dispatch via `expand_range` in `builtins/mod.rs` (same pattern as IRR/NPV)
- 5 classification tests, 9 unit tests, 5 end-to-end tests (two-range, single, triple, boolean conditional, cross-sheet)
- Golden-file regression spec entry added (fixture needs Excel re-save for new column; existing columns unaffected)

## Test plan
- [x] Unit tests pass (`cargo test -p xlstream-eval -- sumproduct`)
- [x] Integration tests pass
- [x] Golden-file regression passes (existing columns)
- [x] `cargo test -p xlstream-eval` passes
- [x] `make check` passes
- [x] Docs updated per spec
- [x] Roadmap checkbox ticked
- [x] Fixture needs Excel re-save for new SUMPRODUCT column