### PR TITLE
xlstream-parse: upgrade formualizer-parse to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,15 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,12 +259,8 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link",
 ]
 
 [[package]]
@@ -357,12 +344,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -529,18 +510,18 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "formualizer-common"
-version = "1.1.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f89ff5c5a3b71cd6c684feac9ded5503d698c1d699d924b5e6c7efeb65147de"
+checksum = "2efd0a60e70b483da2650bac6715b9d1aae0c6d9443454d59a88cefb83f5133a"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "formualizer-parse"
-version = "1.1.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263bc7dfe928ddc7fd9f5f590a39822705d7f3f03bdeee42df0947cb9e293e94"
+checksum = "1c8b67fa2c3bdb311c5c49b076eddf3fe9e69dc02902542f2312d472b6109c5f"
 dependencies = [
  "formualizer-common",
  "once_cell",
@@ -634,30 +615,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "id-arena"
@@ -1774,63 +1731,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ calamine = "0.34"
 rust_xlsxwriter = { version = "0.94", features = ["constant_memory", "zlib", "ryu"] }
 
 # formula parser — pinned exactly per ADR docs/decisions/2026-04-18-phase-02-toolchain-bump.md.
-formualizer-parse = "=1.1.2"
-formualizer-common = "=1.1.2"
+formualizer-parse = "=2.0.0"
+formualizer-common = "=2.0.0"
 
 # Python binding
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }

--- a/crates/xlstream-eval/src/interp.rs
+++ b/crates/xlstream-eval/src/interp.rs
@@ -93,9 +93,10 @@ impl<'ctx> Interpreter<'ctx> {
             NodeView::RangeRef { .. } => Value::Error(CellError::Ref),
 
             // Named/External/Table -> #NAME?
-            NodeView::NamedRef(_) | NodeView::ExternalRef { .. } | NodeView::TableRef { .. } => {
-                Value::Error(CellError::Name)
-            }
+            NodeView::NamedRef(_)
+            | NodeView::ExternalRef { .. }
+            | NodeView::TableRef { .. }
+            | NodeView::ThreeDimensionalRef { .. } => Value::Error(CellError::Name),
 
             NodeView::BinaryOp { op } => {
                 let (Some(left_node), Some(right_node)) = (node.left(), node.right()) else {

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -49,6 +49,8 @@ pub enum UnsupportedReason {
     LookupSheetNotPrepared,
     /// Lookup range points at the main streaming sheet.
     LookupIntoStreamingSheet,
+    /// `Sheet1:Sheet3!A1`-style 3D sheet reference.
+    ThreeDimensionalRef,
 }
 
 impl std::fmt::Display for UnsupportedReason {
@@ -83,6 +85,9 @@ impl std::fmt::Display for UnsupportedReason {
             Self::LookupIntoStreamingSheet => {
                 write!(f, "lookup range points at the main streaming sheet")
             }
+            Self::ThreeDimensionalRef => {
+                write!(f, "3D sheet references are incompatible with streaming")
+            }
         }
     }
 }
@@ -108,7 +113,8 @@ impl UnsupportedReason {
             Self::NonStaticCriteria => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#aggregate-pre-pass",
             Self::LookupSheetNotPrepared => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md#lookup-index-pre-pass",
             Self::TableReference | Self::NamedRange => "https://github.com/cilladev/xlstream/blob/main/docs/roadmap/v0.2/README.md",
-            Self::NestedUnsupported => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md",
+            Self::NestedUnsupported
+            | Self::ThreeDimensionalRef => "https://github.com/cilladev/xlstream/blob/main/docs/architecture/streaming-model.md",
         }
     }
 }
@@ -438,6 +444,9 @@ fn classify_reference(
             Disposition::Unsupported(UnsupportedReason::ExternalReference)
         }
         Reference::Table { .. } => Disposition::Unsupported(UnsupportedReason::TableReference),
+        Reference::ThreeDimensional { .. } => {
+            Disposition::Unsupported(UnsupportedReason::ThreeDimensionalRef)
+        }
     }
 }
 

--- a/crates/xlstream-parse/src/parser.rs
+++ b/crates/xlstream-parse/src/parser.rs
@@ -55,6 +55,12 @@ pub(crate) fn lower(node: &formualizer_parse::ASTNode) -> Node {
         }
         T::Array(rows) => Node::Array(rows.iter().map(|r| r.iter().map(lower).collect()).collect()),
         T::Reference { reference, .. } => Node::Reference(lower_reference(reference)),
+        T::Call { callee, args } => {
+            let mut all_args = Vec::with_capacity(args.len() + 1);
+            all_args.push(lower(callee));
+            all_args.extend(args.iter().map(lower));
+            Node::Function { name: "LAMBDA".into(), args: all_args }
+        }
     }
 }
 
@@ -81,6 +87,12 @@ fn lower_reference(r: &formualizer_parse::parser::ReferenceType) -> Reference {
             name: t.name.clone(),
             specifier: t.specifier.as_ref().map(|s| format!("{s}")),
         },
+        R::Cell3D { sheet_first, sheet_last, .. } | R::Range3D { sheet_first, sheet_last, .. } => {
+            Reference::ThreeDimensional {
+                sheet_first: sheet_first.clone(),
+                sheet_last: sheet_last.clone(),
+            }
+        }
     }
 }
 
@@ -170,5 +182,21 @@ mod tests {
             let e = ExcelError::from(kind);
             assert_eq!(map_excel_error(&e), expected, "kind={kind:?}");
         }
+    }
+
+    #[test]
+    fn lower_handles_3d_cell_reference() {
+        let upstream = formualizer_parse::parse("=SUM(Sheet1:Sheet3!A1)").unwrap();
+        let node = lower(&upstream);
+        let dbg = format!("{node:?}");
+        assert!(dbg.contains("ThreeDimensional"), "expected 3D ref: {dbg}");
+    }
+
+    #[test]
+    fn lower_handles_lambda_call() {
+        let upstream = formualizer_parse::parse("=LAMBDA(x, x+1)(5)").unwrap();
+        let node = lower(&upstream);
+        let dbg = format!("{node:?}");
+        assert!(dbg.contains("LAMBDA"), "expected LAMBDA function: {dbg}");
     }
 }

--- a/crates/xlstream-parse/src/references.rs
+++ b/crates/xlstream-parse/src/references.rs
@@ -66,6 +66,15 @@ pub enum Reference {
         /// `None` = whole table.
         specifier: Option<String>,
     },
+    /// `Sheet1:Sheet3!A1` — 3D sheet reference spanning multiple sheets.
+    /// Refused at classification with
+    /// [`crate::UnsupportedReason::ThreeDimensionalRef`].
+    ThreeDimensional {
+        /// First sheet name.
+        sheet_first: String,
+        /// Last sheet name.
+        sheet_last: String,
+    },
 }
 
 /// References surfaced by the (Chunk 1) `extract_references` walker.
@@ -149,6 +158,14 @@ fn collect_view(rv: formualizer_parse::parser::RefView<'_>, out: &mut References
         V::NamedRange { name } => {
             out.ranges.push(Reference::Named(name.to_owned()));
         }
+        V::Cell3D { sheet_first, sheet_last, .. } | V::Range3D { sheet_first, sheet_last, .. } => {
+            push_sheet(Some(sheet_first), out);
+            push_sheet(Some(sheet_last), out);
+            out.ranges.push(Reference::ThreeDimensional {
+                sheet_first: sheet_first.to_owned(),
+                sheet_last: sheet_last.to_owned(),
+            });
+        }
     }
 }
 
@@ -186,6 +203,12 @@ fn walk_functions(root: &formualizer_parse::ASTNode, out: &mut References) {
                     }
                 }
             }
+            T::Call { callee, args } => {
+                stack.push(callee);
+                for a in args.iter().rev() {
+                    stack.push(a);
+                }
+            }
         }
     }
 }
@@ -205,7 +228,7 @@ impl Reference {
         match self {
             Self::Cell { sheet, .. } | Self::Range { sheet, .. } => sheet.as_deref(),
             Self::External { sheet, .. } => Some(sheet.as_str()),
-            Self::Named(_) | Self::Table { .. } => None,
+            Self::Named(_) | Self::Table { .. } | Self::ThreeDimensional { .. } => None,
         }
     }
 
@@ -325,5 +348,17 @@ mod tests {
         };
         assert!(!r.is_whole_column());
         assert!(!r.is_whole_row());
+    }
+
+    #[test]
+    fn extract_references_captures_3d_ref() {
+        let ast = crate::parse("SUM(Sheet1:Sheet3!A1)").unwrap();
+        let refs = extract_references(&ast);
+        assert!(
+            refs.ranges.iter().any(|r| matches!(r, Reference::ThreeDimensional { .. })),
+            "expected ThreeDimensional ref in ranges: {refs:?}"
+        );
+        assert!(refs.sheets.iter().any(|s| s == "Sheet1"), "expected Sheet1 in sheets");
+        assert!(refs.sheets.iter().any(|s| s == "Sheet3"), "expected Sheet3 in sheets");
     }
 }

--- a/crates/xlstream-parse/src/view.rs
+++ b/crates/xlstream-parse/src/view.rs
@@ -92,6 +92,13 @@ pub enum NodeView<'a> {
         /// Number of columns.
         cols: usize,
     },
+    /// 3D sheet reference (`Sheet1:Sheet3!A1`).
+    ThreeDimensionalRef {
+        /// First sheet name.
+        sheet_first: &'a str,
+        /// Last sheet name.
+        sheet_last: &'a str,
+    },
     /// Prelude-computed reference.
     PreludeRef(&'a PreludeKey),
 }
@@ -147,6 +154,12 @@ impl<'a> NodeRef<'a> {
             },
             Node::Reference(Reference::Table { name, specifier }) => {
                 NodeView::TableRef { name: name.as_str(), specifier: specifier.as_deref() }
+            }
+            Node::Reference(Reference::ThreeDimensional { sheet_first, sheet_last }) => {
+                NodeView::ThreeDimensionalRef {
+                    sheet_first: sheet_first.as_str(),
+                    sheet_last: sheet_last.as_str(),
+                }
             }
             Node::BinaryOp { op, .. } => NodeView::BinaryOp { op: op.as_str() },
             Node::UnaryOp { op, .. } => NodeView::UnaryOp { op: op.as_str() },

--- a/docs/architecture/evaluator.md
+++ b/docs/architecture/evaluator.md
@@ -36,7 +36,7 @@ fn eval(&self, node: NodeRef<'_>, scope: &RowScope<'_>) -> Value {
         NodeView::Function { name }        => crate::builtins::dispatch(name, &node.args(), self, scope)
                                                   .unwrap_or(Value::Error(CellError::Value)),
         NodeView::PreludeRef(key)          => self.resolve_prelude(key),
-        // NamedRef, ExternalRef, TableRef -> #NAME?
+        // NamedRef, ExternalRef, TableRef, ThreeDimensionalRef -> #NAME?
         // Array -> #VALUE!
     }
 }


### PR DESCRIPTION
## Summary
- Bumps formualizer-parse and formualizer-common from 1.1.2 to 2.0.0
- Handles new `Cell3D`/`Range3D` variants as `ThreeDimensionalRef` — refused at classification
- Handles new `Call` variant (LAMBDA IIFE) by lowering to `Function("LAMBDA")` — already refused
- Adds `NodeView::ThreeDimensionalRef` for completeness in eval
- Adds tests for all three new code paths

## What changed upstream
- `ReferenceType::Cell3D`/`Range3D` — 3D sheet refs like `Sheet1:Sheet3!A1`
- `RefView::Cell3D`/`Range3D` — borrowed view equivalents
- `ASTNodeType::Call` — LAMBDA immediate-invocation (IIFE)
- `structured_ref` module (private, useful for v0.2 table refs)
- `CoordHasher` perf optimization (transparent)

## Test plan
- [x] New tests for 3D ref lowering, LAMBDA IIFE lowering, 3D ref extraction
- [x] Full `cargo test -p xlstream-parse` — no regressions
- [x] Full `cargo test -p xlstream-eval` — no regressions
- [x] `make check` passes

Closes #74