### PR TITLE
xlstream-io: preserve formulas via copy-and-replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Semver.
 - ROWS and COLUMNS: return row/column count from range references
 - Self-referential formula support via iterative calculation (e.g., `=IF(G2="Risk_KC",O2*-1,O2)` in cell O2)
 - `EvaluateOptions` with `iterative_calc`, `max_iterations`, `max_change` settings
-- CLI: `--max-iterations`, `--max-change`, `--no-iterative-calc`
-- Python: `iterative_calc`, `max_iterations`, `max_change` kwargs
+- CLI: `--max-iterations`, `--max-change`, `--no-iterative-calc`, `--values-only`
+- Python: `iterative_calc`, `max_iterations`, `max_change`, `values_only` kwargs
+- Formula preservation in output (default): `<f>` elements pass through from input xlsx via copy-and-replace, `<v>` values updated with re-evaluated results
 
 ### Changed
 - `evaluate()` signature now takes `&EvaluateOptions` instead of `Option<usize>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,9 +1988,11 @@ name = "xlstream-io"
 version = "0.2.0"
 dependencies = [
  "calamine",
+ "quick-xml",
  "rust_xlsxwriter",
  "tempfile",
  "xlstream-core",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ authors = ["Priscilla Emasoga"]
 # xlsx I/O
 calamine = "0.34"
 rust_xlsxwriter = { version = "0.94", features = ["constant_memory", "zlib", "ryu"] }
+quick-xml = "0.39"
+zip = { version = "7.2", default-features = false, features = ["deflate"] }
 
 # formula parser — pinned exactly per ADR docs/decisions/2026-04-18-phase-02-toolchain-bump.md.
 formualizer-parse = "=2.0.0"

--- a/bindings/python/py_src/xlstream/_xlstream.pyi
+++ b/bindings/python/py_src/xlstream/_xlstream.pyi
@@ -10,6 +10,10 @@ def evaluate(
     output_path: str,
     *,
     workers: Optional[int] = None,
+    iterative_calc: bool = True,
+    max_iterations: int = 100,
+    max_change: float = 0.001,
+    values_only: bool = False,
 ) -> EvaluateResult:
     """Evaluate formulas in an xlsx workbook and write the results.
 
@@ -17,6 +21,10 @@ def evaluate(
         input_path: Path to the source xlsx file.
         output_path: Path where the evaluated xlsx is written.
         workers: Number of parallel worker threads. None = auto-detect.
+        iterative_calc: Enable iterative calculation for self-referential formulas.
+        max_iterations: Maximum iterations for iterative calculation.
+        max_change: Convergence threshold for iterative calculation.
+        values_only: Write only computed values, discarding formula text.
 
     Returns:
         Dict with rows_processed, formulas_evaluated, and duration_ms.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -72,7 +72,7 @@ fn to_pyerr(e: RustXlStreamError) -> PyErr {
 /// The GIL is released for the entire Rust evaluation so other Python
 /// threads can run concurrently.
 #[pyfunction]
-#[pyo3(signature = (input_path, output_path, *, workers=None, iterative_calc=true, max_iterations=100, max_change=0.001))]
+#[pyo3(signature = (input_path, output_path, *, workers=None, iterative_calc=true, max_iterations=100, max_change=0.001, values_only=false))]
 fn evaluate(
     py: Python<'_>,
     input_path: &str,
@@ -81,6 +81,7 @@ fn evaluate(
     iterative_calc: bool,
     max_iterations: u32,
     max_change: f64,
+    values_only: bool,
 ) -> PyResult<Py<PyDict>> {
     let input = PathBuf::from(input_path);
     let output = PathBuf::from(output_path);
@@ -89,7 +90,7 @@ fn evaluate(
         iterative_calc,
         max_iterations,
         max_change,
-        values_only: false,
+        values_only,
     };
 
     let summary =

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -84,8 +84,13 @@ fn evaluate(
 ) -> PyResult<Py<PyDict>> {
     let input = PathBuf::from(input_path);
     let output = PathBuf::from(output_path);
-    let options =
-        xlstream_eval::EvaluateOptions { workers, iterative_calc, max_iterations, max_change };
+    let options = xlstream_eval::EvaluateOptions {
+        workers,
+        iterative_calc,
+        max_iterations,
+        max_change,
+        values_only: false,
+    };
 
     let summary =
         py.detach(move || xlstream_eval::evaluate(&input, &output, &options)).map_err(to_pyerr)?;

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -50,6 +50,9 @@ enum Command {
         /// Disable iterative calculation (self-referential formulas will error).
         #[arg(long)]
         no_iterative_calc: bool,
+        /// Write only computed values — no formulas in output.
+        #[arg(long)]
+        values_only: bool,
         /// Print phase timings and evaluation summary.
         #[arg(long, short = 'v')]
         verbose: bool,
@@ -109,6 +112,7 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
             max_iterations,
             max_change,
             no_iterative_calc,
+            values_only,
             verbose,
         } => {
             let options = xlstream_eval::EvaluateOptions {
@@ -117,7 +121,7 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
                 max_iterations: max_iterations
                     .unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS),
                 max_change: max_change.unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_CHANGE),
-                values_only: false,
+                values_only,
             };
             let summary = xlstream_eval::evaluate(&input, &output, &options)?;
             if verbose {
@@ -197,6 +201,33 @@ mod tests {
                 assert_eq!(workers, Some(4));
                 assert!(verbose);
             }
+            Command::Classify { .. } => panic!("expected Evaluate"),
+        }
+    }
+
+    #[test]
+    fn evaluate_subcommand_parses_values_only_flag() {
+        let cli = Cli::try_parse_from([
+            "xlstream",
+            "evaluate",
+            "in.xlsx",
+            "--output",
+            "out.xlsx",
+            "--values-only",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Evaluate { values_only, .. } => assert!(values_only),
+            Command::Classify { .. } => panic!("expected Evaluate"),
+        }
+    }
+
+    #[test]
+    fn evaluate_subcommand_values_only_defaults_to_false() {
+        let cli = Cli::try_parse_from(["xlstream", "evaluate", "in.xlsx", "--output", "out.xlsx"])
+            .unwrap();
+        match cli.command {
+            Command::Evaluate { values_only, .. } => assert!(!values_only),
             Command::Classify { .. } => panic!("expected Evaluate"),
         }
     }

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -117,6 +117,7 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
                 max_iterations: max_iterations
                     .unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS),
                 max_change: max_change.unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_CHANGE),
+                values_only: false,
             };
             let summary = xlstream_eval::evaluate(&input, &output, &options)?;
             if verbose {

--- a/crates/xlstream-core/src/address.rs
+++ b/crates/xlstream-core/src/address.rs
@@ -20,3 +20,95 @@ pub fn col_row_to_a1(col: u32, row: u32) -> String {
     }
     format!("{letters}{row}")
 }
+
+/// Parse an A1-notation cell reference into 0-based `(row, col)`.
+///
+/// Returns `None` if the reference is malformed (no letters, no digits,
+/// row is zero, or overflow).
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::a1_to_col_row;
+/// assert_eq!(a1_to_col_row("A1"), Some((0, 0)));
+/// assert_eq!(a1_to_col_row("C5"), Some((4, 2)));
+/// assert_eq!(a1_to_col_row("AA1"), Some((0, 26)));
+/// ```
+#[must_use]
+pub fn a1_to_col_row(cell_ref: &str) -> Option<(u32, u16)> {
+    let bytes = cell_ref.as_bytes();
+    let mut col: u32 = 0;
+    let mut i = 0;
+
+    while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+        col = col
+            .checked_mul(26)?
+            .checked_add(u32::from(bytes[i].to_ascii_uppercase() - b'A') + 1)?;
+        i += 1;
+    }
+    if i == 0 || col == 0 {
+        return None;
+    }
+
+    let row_str = &cell_ref[i..];
+    if row_str.is_empty() {
+        return None;
+    }
+    let row: u32 = row_str.parse().ok()?;
+    if row == 0 {
+        return None;
+    }
+
+    Some((row - 1, u16::try_from(col - 1).ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+
+    #[test]
+    fn a1_to_col_row_simple() {
+        assert_eq!(a1_to_col_row("A1"), Some((0, 0)));
+        assert_eq!(a1_to_col_row("B2"), Some((1, 1)));
+        assert_eq!(a1_to_col_row("Z1"), Some((0, 25)));
+    }
+
+    #[test]
+    fn a1_to_col_row_multi_letter() {
+        assert_eq!(a1_to_col_row("AA1"), Some((0, 26)));
+        assert_eq!(a1_to_col_row("AZ1"), Some((0, 51)));
+        assert_eq!(a1_to_col_row("BA1"), Some((0, 52)));
+    }
+
+    #[test]
+    fn a1_to_col_row_large_row() {
+        assert_eq!(a1_to_col_row("A1048576"), Some((1_048_575, 0)));
+    }
+
+    #[test]
+    fn a1_to_col_row_invalid() {
+        assert_eq!(a1_to_col_row(""), None);
+        assert_eq!(a1_to_col_row("1A"), None);
+        assert_eq!(a1_to_col_row("A0"), None);
+        assert_eq!(a1_to_col_row("A"), None);
+    }
+
+    #[test]
+    fn a1_to_col_row_lowercase() {
+        assert_eq!(a1_to_col_row("a1"), Some((0, 0)));
+        assert_eq!(a1_to_col_row("ab10"), Some((9, 27)));
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn round_trip_col_row() {
+        for col in [1u32, 2, 26, 27, 52, 702] {
+            for row in [1u32, 2, 100, 1_048_576] {
+                let a1 = col_row_to_a1(col, row);
+                let (r, c) = a1_to_col_row(&a1).unwrap();
+                assert_eq!((r, c), (row - 1, (col - 1) as u16), "round-trip failed for {a1}");
+            }
+        }
+    }
+}

--- a/crates/xlstream-core/src/lib.rs
+++ b/crates/xlstream-core/src/lib.rs
@@ -29,7 +29,7 @@ mod error;
 mod options;
 mod value;
 
-pub use address::col_row_to_a1;
+pub use address::{a1_to_col_row, col_row_to_a1};
 pub use cell_error::CellError;
 pub use date::ExcelDate;
 pub use error::XlStreamError;

--- a/crates/xlstream-core/src/options.rs
+++ b/crates/xlstream-core/src/options.rs
@@ -25,6 +25,10 @@ pub struct EvaluateOptions {
     pub max_iterations: u32,
     /// Convergence threshold — stop when delta < this (only for numeric results).
     pub max_change: f64,
+    /// Write only computed values, discarding formula text. When `false`
+    /// (the default), output preserves the original `<f>` element
+    /// alongside the re-evaluated `<v>` cached value.
+    pub values_only: bool,
 }
 
 impl Default for EvaluateOptions {
@@ -34,6 +38,7 @@ impl Default for EvaluateOptions {
             iterative_calc: true,
             max_iterations: ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS,
             max_change: ITERATIVE_CALC_DEFAULT_MAX_CHANGE,
+            values_only: false,
         }
     }
 }
@@ -50,6 +55,12 @@ mod tests {
         assert_eq!(opts.max_iterations, 100);
         assert!((opts.max_change - 0.001).abs() < f64::EPSILON);
         assert!(opts.workers.is_none());
+    }
+
+    #[test]
+    fn default_options_values_only_is_false() {
+        let opts = EvaluateOptions::default();
+        assert!(!opts.values_only);
     }
 
     #[test]

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -143,6 +143,7 @@ pub fn evaluate(
                         iterative_calc: plan.iterative_calc,
                         max_iterations: plan.max_iterations,
                         max_change: plan.max_change,
+                        values_only: false,
                     };
                     let mut header_pending = true;
                     while let Some((row_idx, mut row_values)) = stream.next_row()? {
@@ -185,6 +186,7 @@ pub fn evaluate(
             iterative_calc: plan.iterative_calc,
             max_iterations: plan.max_iterations,
             max_change: plan.max_change,
+            values_only: false,
         });
         let self_referential_cols_arc = Arc::new(plan.self_referential_cols);
         let prelude = Arc::new(plan.prelude);
@@ -519,6 +521,7 @@ fn stream_single_threaded(
         iterative_calc: plan.iterative_calc,
         max_iterations: plan.max_iterations,
         max_change: plan.max_change,
+        values_only: false,
     };
     let mut rows_processed: u64 = 0;
     let mut formulas_evaluated: u64 = 0;

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use xlstream_core::{col_row_to_a1, EvaluateOptions, Value, XlStreamError, PARALLEL_ROW_THRESHOLD};
+use xlstream_io::convert::{value_to_cell_result, CellResult};
 use xlstream_io::{Reader, Writer};
 use xlstream_parse::{
     classify, collect_lookup_keys, extract_references, parse, resolve_named_ranges, rewrite,
@@ -20,6 +21,9 @@ use crate::topo::topo_sort;
 
 /// Message type sent from parallel workers to the writer loop.
 type WorkerMsg = Result<(u32, Vec<Value>, u64), XlStreamError>;
+
+/// Per-sheet formula results: sheet name → (0-based row, 0-based col) → result.
+type SheetResults = HashMap<String, HashMap<(u32, u16), CellResult>>;
 
 /// Summary of a completed evaluation run.
 ///
@@ -108,111 +112,35 @@ pub fn evaluate(
     plan.iterative_calc = options.iterative_calc;
     plan.max_iterations = options.max_iterations;
     plan.max_change = options.max_change;
-    let mut writer = Writer::create(output)?;
 
     let num_workers = options.workers.unwrap_or_else(num_cpus::get).max(1);
-
     let use_parallel = num_workers > 1
         && plan.main_sheet.is_some()
         && !plan.col_asts.is_empty()
         && plan.total_data_rows >= PARALLEL_ROW_THRESHOLD;
 
-    let (rows_processed, formulas_evaluated) = if use_parallel {
-        let main_sheet_name = plan
-            .main_sheet
-            .as_ref()
-            .ok_or_else(|| XlStreamError::Internal("no main sheet".into()))?
-            .clone();
-
-        tracing::info!(
-            workers = num_workers,
-            total_rows = plan.total_data_rows,
-            "parallel evaluation: spawning workers"
-        );
-
-        // Write non-main sheets — evaluate formulas on secondary formula sheets.
-        for name in &plan.sheet_names {
-            if Some(name.as_str()) != plan.main_sheet.as_deref() {
-                let mut sh = writer.add_sheet(name)?;
-                let mut stream = reader.cells(name)?;
-
-                if let Some(sp) = plan.secondary_plans.get(name.as_str()) {
-                    let sec_interp = Interpreter::new(&plan.prelude);
-                    let sec_options = EvaluateOptions {
-                        workers: None,
-                        iterative_calc: plan.iterative_calc,
-                        max_iterations: plan.max_iterations,
-                        max_change: plan.max_change,
-                        values_only: false,
-                    };
-                    let mut header_pending = true;
-                    while let Some((row_idx, mut row_values)) = stream.next_row()? {
-                        if header_pending {
-                            sh.write_row(row_idx, &row_values)?;
-                            header_pending = false;
-                            continue;
-                        }
-                        for &fcol in &sp.topo_order {
-                            let ast = sp
-                                .row_overrides
-                                .get(&fcol)
-                                .and_then(|overrides| overrides.get(&row_idx))
-                                .or_else(|| sp.col_asts.get(&fcol));
-                            let Some(ast) = ast else { continue };
-                            eval_column(
-                                &sec_interp,
-                                ast,
-                                &mut row_values,
-                                row_idx,
-                                fcol,
-                                sp.self_referential_cols.contains(&fcol),
-                                &sec_options,
-                            );
-                        }
-                        sh.write_row(row_idx, &row_values)?;
-                    }
-                } else {
-                    while let Some((row_idx, row_values)) = stream.next_row()? {
-                        sh.write_row(row_idx, &row_values)?;
-                    }
-                }
-
-                drop(sh);
-            }
-        }
-
-        let eval_options = Arc::new(EvaluateOptions {
-            workers: options.workers,
-            iterative_calc: plan.iterative_calc,
-            max_iterations: plan.max_iterations,
-            max_change: plan.max_change,
-            values_only: false,
-        });
-        let self_referential_cols_arc = Arc::new(plan.self_referential_cols);
-        let prelude = Arc::new(plan.prelude);
-        let col_asts = Arc::new(plan.col_asts);
-        let row_overrides_arc = Arc::new(plan.row_overrides);
-
-        stream_parallel(
-            input,
-            &mut writer,
-            &prelude,
-            &col_asts,
-            &row_overrides_arc,
-            &plan.topo_order,
-            &self_referential_cols_arc,
-            &eval_options,
-            &main_sheet_name,
-            plan.total_data_rows,
-            num_workers,
-        )?
+    if options.values_only {
+        // Values-only: write from scratch via rust_xlsxwriter (no <f> elements).
+        let mut writer = Writer::create(output)?;
+        let (rows_processed, formulas_evaluated) = if use_parallel {
+            stream_parallel_write(input, &mut reader, &mut writer, plan, options, num_workers)?
+        } else {
+            tracing::debug!("single-threaded evaluation (values-only)");
+            stream_single_threaded(&mut reader, &mut writer, &plan)?
+        };
+        writer.finish()?;
+        Ok(EvaluateSummary { rows_processed, formulas_evaluated, duration: start.elapsed() })
     } else {
-        tracing::debug!("single-threaded evaluation");
-        stream_single_threaded(&mut reader, &mut writer, &plan)?
-    };
-
-    writer.finish()?;
-    Ok(EvaluateSummary { rows_processed, formulas_evaluated, duration: start.elapsed() })
+        // Keep-formulas: collect results, then copy-and-replace.
+        let (rows_processed, formulas_evaluated, results) = if use_parallel {
+            collect_parallel(input, &mut reader, plan, options, num_workers)?
+        } else {
+            tracing::debug!("single-threaded evaluation (keep-formulas)");
+            collect_single_threaded(&mut reader, &plan)?
+        };
+        xlstream_io::formula_preserve::copy_and_replace(input, output, &results)?;
+        Ok(EvaluateSummary { rows_processed, formulas_evaluated, duration: start.elapsed() })
+    }
 }
 
 /// Build the full evaluation plan: open reader, find main sheet, parse +
@@ -599,6 +527,388 @@ fn stream_single_threaded(
     }
 
     Ok((rows_processed, formulas_evaluated))
+}
+
+/// Values-only parallel write: evaluate secondary sheets, then spawn
+/// parallel workers for the main sheet, writing all results via Writer.
+#[allow(clippy::too_many_lines)]
+fn stream_parallel_write(
+    input: &Path,
+    reader: &mut Reader,
+    writer: &mut Writer,
+    plan: EvalPlan,
+    options: &EvaluateOptions,
+    num_workers: usize,
+) -> Result<(u64, u64), XlStreamError> {
+    let main_sheet_name = plan
+        .main_sheet
+        .as_ref()
+        .ok_or_else(|| XlStreamError::Internal("no main sheet".into()))?
+        .clone();
+
+    tracing::info!(
+        workers = num_workers,
+        total_rows = plan.total_data_rows,
+        "parallel evaluation (values-only): spawning workers"
+    );
+
+    for name in &plan.sheet_names {
+        if Some(name.as_str()) != plan.main_sheet.as_deref() {
+            let mut sh = writer.add_sheet(name)?;
+            let mut stream = reader.cells(name)?;
+
+            if let Some(sp) = plan.secondary_plans.get(name.as_str()) {
+                let sec_interp = Interpreter::new(&plan.prelude);
+                let sec_options = EvaluateOptions {
+                    workers: None,
+                    iterative_calc: plan.iterative_calc,
+                    max_iterations: plan.max_iterations,
+                    max_change: plan.max_change,
+                    values_only: true,
+                };
+                let mut header_pending = true;
+                while let Some((row_idx, mut row_values)) = stream.next_row()? {
+                    if header_pending {
+                        sh.write_row(row_idx, &row_values)?;
+                        header_pending = false;
+                        continue;
+                    }
+                    for &fcol in &sp.topo_order {
+                        let ast = sp
+                            .row_overrides
+                            .get(&fcol)
+                            .and_then(|overrides| overrides.get(&row_idx))
+                            .or_else(|| sp.col_asts.get(&fcol));
+                        let Some(ast) = ast else { continue };
+                        eval_column(
+                            &sec_interp,
+                            ast,
+                            &mut row_values,
+                            row_idx,
+                            fcol,
+                            sp.self_referential_cols.contains(&fcol),
+                            &sec_options,
+                        );
+                    }
+                    sh.write_row(row_idx, &row_values)?;
+                }
+            } else {
+                while let Some((row_idx, row_values)) = stream.next_row()? {
+                    sh.write_row(row_idx, &row_values)?;
+                }
+            }
+
+            drop(sh);
+        }
+    }
+
+    let eval_options = Arc::new(EvaluateOptions {
+        workers: options.workers,
+        iterative_calc: plan.iterative_calc,
+        max_iterations: plan.max_iterations,
+        max_change: plan.max_change,
+        values_only: true,
+    });
+    let self_referential_cols_arc = Arc::new(plan.self_referential_cols);
+    let prelude = Arc::new(plan.prelude);
+    let col_asts = Arc::new(plan.col_asts);
+    let row_overrides_arc = Arc::new(plan.row_overrides);
+
+    stream_parallel(
+        input,
+        writer,
+        &prelude,
+        &col_asts,
+        &row_overrides_arc,
+        &plan.topo_order,
+        &self_referential_cols_arc,
+        &eval_options,
+        &main_sheet_name,
+        plan.total_data_rows,
+        num_workers,
+    )
+}
+
+/// Evaluate all sheets single-threaded and collect formula results for
+/// the copy-and-replace path (keep-formulas mode).
+#[allow(clippy::cast_possible_truncation)]
+fn collect_single_threaded(
+    reader: &mut Reader,
+    plan: &EvalPlan,
+) -> Result<(u64, u64, SheetResults), XlStreamError> {
+    let interp = Interpreter::new(&plan.prelude);
+    let eval_options = EvaluateOptions {
+        workers: None,
+        iterative_calc: plan.iterative_calc,
+        max_iterations: plan.max_iterations,
+        max_change: plan.max_change,
+        values_only: false,
+    };
+    let mut results: SheetResults = HashMap::new();
+    let mut rows_processed: u64 = 0;
+    let mut formulas_evaluated: u64 = 0;
+
+    for name in &plan.sheet_names {
+        let mut stream = reader.cells(name)?;
+
+        let is_main = plan.main_sheet.as_deref() == Some(name.as_str());
+        #[allow(clippy::type_complexity)]
+        let sheet_plan: Option<(
+            &HashMap<u32, Ast>,
+            &HashMap<u32, HashMap<u32, Ast>>,
+            &[u32],
+            &HashSet<u32>,
+        )> = if is_main {
+            if plan.col_asts.is_empty() {
+                None
+            } else {
+                Some((
+                    &plan.col_asts,
+                    &plan.row_overrides,
+                    &plan.topo_order,
+                    &plan.self_referential_cols,
+                ))
+            }
+        } else {
+            plan.secondary_plans.get(name.as_str()).map(|sp| {
+                (
+                    &sp.col_asts,
+                    &sp.row_overrides,
+                    sp.topo_order.as_slice(),
+                    &sp.self_referential_cols,
+                )
+            })
+        };
+
+        let mut header_pending = sheet_plan.is_some();
+        let sheet_results = results.entry(name.clone()).or_default();
+
+        while let Some((row_idx, mut row_values)) = stream.next_row()? {
+            if header_pending {
+                header_pending = false;
+                rows_processed += 1;
+                continue;
+            }
+
+            if let Some((col_asts, row_overrides, topo_order, self_ref_cols)) = &sheet_plan {
+                for &fcol in *topo_order {
+                    let ast = row_overrides
+                        .get(&fcol)
+                        .and_then(|overrides| overrides.get(&row_idx))
+                        .or_else(|| col_asts.get(&fcol));
+                    let Some(ast) = ast else { continue };
+                    eval_column(
+                        &interp,
+                        ast,
+                        &mut row_values,
+                        row_idx,
+                        fcol,
+                        self_ref_cols.contains(&fcol),
+                        &eval_options,
+                    );
+                    let fcol_idx = fcol as usize;
+                    sheet_results.insert(
+                        (row_idx, fcol as u16),
+                        value_to_cell_result(&row_values[fcol_idx]),
+                    );
+                    formulas_evaluated += 1;
+                }
+            }
+
+            rows_processed += 1;
+        }
+    }
+
+    Ok((rows_processed, formulas_evaluated, results))
+}
+
+/// Parallel formula result collection for the keep-formulas path.
+/// Workers evaluate rows and send them through a channel; the main
+/// thread extracts formula cell results.
+#[allow(clippy::too_many_lines, clippy::cast_possible_truncation)]
+fn collect_parallel(
+    input: &Path,
+    reader: &mut Reader,
+    plan: EvalPlan,
+    options: &EvaluateOptions,
+    num_workers: usize,
+) -> Result<(u64, u64, SheetResults), XlStreamError> {
+    let main_sheet_name = plan
+        .main_sheet
+        .as_ref()
+        .ok_or_else(|| XlStreamError::Internal("no main sheet".into()))?
+        .clone();
+
+    tracing::info!(
+        workers = num_workers,
+        total_rows = plan.total_data_rows,
+        "parallel evaluation (keep-formulas): spawning workers"
+    );
+
+    let mut results: SheetResults = HashMap::new();
+
+    // Collect secondary sheets.
+    for name in &plan.sheet_names {
+        if Some(name.as_str()) != plan.main_sheet.as_deref() {
+            let mut stream = reader.cells(name)?;
+            if let Some(sp) = plan.secondary_plans.get(name.as_str()) {
+                let sec_interp = Interpreter::new(&plan.prelude);
+                let sec_options = EvaluateOptions {
+                    workers: None,
+                    iterative_calc: plan.iterative_calc,
+                    max_iterations: plan.max_iterations,
+                    max_change: plan.max_change,
+                    values_only: false,
+                };
+                let sheet_results = results.entry(name.clone()).or_default();
+                let mut header_pending = true;
+                while let Some((row_idx, mut row_values)) = stream.next_row()? {
+                    if header_pending {
+                        header_pending = false;
+                        continue;
+                    }
+                    for &fcol in &sp.topo_order {
+                        let ast = sp
+                            .row_overrides
+                            .get(&fcol)
+                            .and_then(|o| o.get(&row_idx))
+                            .or_else(|| sp.col_asts.get(&fcol));
+                        let Some(ast) = ast else { continue };
+                        eval_column(
+                            &sec_interp,
+                            ast,
+                            &mut row_values,
+                            row_idx,
+                            fcol,
+                            sp.self_referential_cols.contains(&fcol),
+                            &sec_options,
+                        );
+                        let fcol_idx = fcol as usize;
+                        sheet_results.insert(
+                            (row_idx, fcol as u16),
+                            value_to_cell_result(&row_values[fcol_idx]),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Parallel main sheet.
+    let topo_order = plan.topo_order.clone();
+    let eval_options = Arc::new(EvaluateOptions {
+        workers: options.workers,
+        iterative_calc: plan.iterative_calc,
+        max_iterations: plan.max_iterations,
+        max_change: plan.max_change,
+        values_only: false,
+    });
+    let self_referential_cols_arc = Arc::new(plan.self_referential_cols);
+    let prelude = Arc::new(plan.prelude);
+    let col_asts = Arc::new(plan.col_asts);
+    let row_overrides_arc = Arc::new(plan.row_overrides);
+
+    let chunk_size = (plan.total_data_rows as usize).div_ceil(num_workers);
+    let (tx, rx) = crossbeam_channel::bounded::<WorkerMsg>(num_workers * 1024);
+
+    let input_path = input.to_path_buf();
+    let main_name = main_sheet_name.clone();
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_workers)
+        .build()
+        .map_err(|e| XlStreamError::Internal(format!("failed to build thread pool: {e}")))?;
+
+    for worker_id in 0..num_workers {
+        let tx = tx.clone();
+        let prelude = Arc::clone(&prelude);
+        let col_asts = Arc::clone(&col_asts);
+        let row_overrides = Arc::clone(&row_overrides_arc);
+        let self_ref_cols = Arc::clone(&self_referential_cols_arc);
+        let opts = Arc::clone(&eval_options);
+        let topo_order = topo_order.clone();
+        let input_path = input_path.clone();
+        let main_name = main_name.clone();
+
+        let start_row = 1 + u32::try_from(worker_id * chunk_size).unwrap_or(u32::MAX - 1);
+        let end_row = u32::try_from(1 + (worker_id + 1) * chunk_size)
+            .unwrap_or(u32::MAX)
+            .min(1 + plan.total_data_rows);
+
+        pool.spawn(move || {
+            if let Err(e) = run_worker(
+                &input_path,
+                &main_name,
+                &prelude,
+                &col_asts,
+                &row_overrides,
+                &topo_order,
+                &self_ref_cols,
+                &opts,
+                start_row,
+                end_row,
+                &tx,
+            ) {
+                let _ = tx.send(Err(e));
+            }
+        });
+    }
+
+    drop(tx);
+
+    let sheet_results = results.entry(main_sheet_name).or_default();
+    let mut rows_processed: u64 = 1;
+    let mut formulas_evaluated: u64 = 0;
+    let mut expected_row: u32 = 1;
+    let mut buffer: BTreeMap<u32, (Vec<Value>, u64)> = BTreeMap::new();
+    let mut first_error: Option<XlStreamError> = None;
+
+    for msg in &rx {
+        match msg {
+            Ok((row_idx, values, formulas_count)) => {
+                buffer.insert(row_idx, (values, formulas_count));
+                while let Some((vals, fc)) = buffer.remove(&expected_row) {
+                    for &fcol in &topo_order {
+                        let fcol_idx = fcol as usize;
+                        if fcol_idx < vals.len() {
+                            sheet_results.insert(
+                                (expected_row, fcol as u16),
+                                value_to_cell_result(&vals[fcol_idx]),
+                            );
+                        }
+                    }
+                    rows_processed += 1;
+                    formulas_evaluated += fc;
+                    expected_row += 1;
+                }
+            }
+            Err(e) => {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
+    }
+
+    while let Some((row_idx, (vals, fc))) = buffer.pop_first() {
+        if first_error.is_some() {
+            break;
+        }
+        for &fcol in &topo_order {
+            let fcol_idx = fcol as usize;
+            if fcol_idx < vals.len() {
+                sheet_results.insert((row_idx, fcol as u16), value_to_cell_result(&vals[fcol_idx]));
+            }
+        }
+        rows_processed += 1;
+        formulas_evaluated += fc;
+    }
+
+    if let Some(e) = first_error {
+        return Err(e);
+    }
+
+    Ok((rows_processed, formulas_evaluated, results))
 }
 
 /// Parallel row evaluation. Spawns `num_workers` threads, each with its

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -707,10 +707,12 @@ fn collect_single_threaded(
                         &eval_options,
                     );
                     let fcol_idx = fcol as usize;
-                    sheet_results.insert(
-                        (row_idx, fcol as u16),
-                        value_to_cell_result(&row_values[fcol_idx]),
-                    );
+                    if fcol_idx < row_values.len() {
+                        sheet_results.insert(
+                            (row_idx, fcol as u16),
+                            value_to_cell_result(&row_values[fcol_idx]),
+                        );
+                    }
                     formulas_evaluated += 1;
                 }
             }
@@ -784,10 +786,12 @@ fn collect_parallel(
                             &sec_options,
                         );
                         let fcol_idx = fcol as usize;
-                        sheet_results.insert(
-                            (row_idx, fcol as u16),
-                            value_to_cell_result(&row_values[fcol_idx]),
-                        );
+                        if fcol_idx < row_values.len() {
+                            sheet_results.insert(
+                                (row_idx, fcol as u16),
+                                value_to_cell_result(&row_values[fcol_idx]),
+                            );
+                        }
                     }
                 }
             }

--- a/crates/xlstream-eval/tests/conformance/issues.rs
+++ b/crates/xlstream-eval/tests/conformance/issues.rs
@@ -1,6 +1,3 @@
-// Issue-specific conformance fixtures go here.
-// Each test points at a fixture in fixtures/issues/.
-
 use calamine::{open_workbook, Data, Reader as CalReader, Xlsx};
 use rust_xlsxwriter::{Formula, Workbook};
 use tempfile::NamedTempFile;
@@ -11,9 +8,6 @@ fn issue_76_self_referential_formulas() {
     super::conformance::run_conformance("issues/issue-76-self-referential-formulas.xlsx");
 }
 
-/// Proves iterative calc transforms values: seed=500 -> -500 after one negation.
-/// Can't use conformance for this — oscillating formulas phase-shift when
-/// re-seeded from their own output.
 #[test]
 fn issue_76_negation_max_iter_1() {
     let input = NamedTempFile::with_suffix(".xlsx").unwrap();
@@ -35,4 +29,69 @@ fn issue_76_negation_max_iter_1() {
     let rows: Vec<_> = range.rows().collect();
     let b2 = &rows[1][1];
     assert!(matches!(b2, Data::Float(v) if (*v + 500.0).abs() < 1e-6), "expected -500, got {b2:?}");
+}
+
+fn make_formula_workbook() -> NamedTempFile {
+    let tmp = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+    ws.set_name("Sheet1").unwrap();
+    ws.write_string(0, 0, "Value").unwrap();
+    ws.write_string(0, 1, "Double").unwrap();
+    ws.write_number(1, 0, 10.0).unwrap();
+    ws.write_formula(1, 1, Formula::new("A2*2").set_result("20")).unwrap();
+    ws.write_number(2, 0, 30.0).unwrap();
+    ws.write_formula(2, 1, Formula::new("A3*2").set_result("60")).unwrap();
+    wb.save(tmp.path()).unwrap();
+    tmp
+}
+
+#[test]
+fn keep_formulas_preserves_formula_elements() {
+    let input = make_formula_workbook();
+    let output = NamedTempFile::with_suffix(".xlsx").unwrap();
+
+    let opts = EvaluateOptions::default();
+    evaluate(input.path(), output.path(), &opts).unwrap();
+
+    let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();
+    let formula_range = wb.worksheet_formula("Sheet1").unwrap();
+    let formulas: Vec<_> =
+        formula_range.rows().flat_map(|row| row.iter()).filter(|s| !s.is_empty()).collect();
+
+    assert!(!formulas.is_empty(), "output must contain formulas in default mode");
+}
+
+#[test]
+fn keep_formulas_produces_correct_values() {
+    let input = make_formula_workbook();
+    let output = NamedTempFile::with_suffix(".xlsx").unwrap();
+
+    let opts = EvaluateOptions::default();
+    evaluate(input.path(), output.path(), &opts).unwrap();
+
+    let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();
+    let range = wb.worksheet_range("Sheet1").unwrap();
+    let rows: Vec<_> = range.rows().collect();
+
+    assert_eq!(rows[1][0], Data::Float(10.0));
+    assert_eq!(rows[1][1], Data::Float(20.0));
+    assert_eq!(rows[2][0], Data::Float(30.0));
+    assert_eq!(rows[2][1], Data::Float(60.0));
+}
+
+#[test]
+fn values_only_strips_formula_elements() {
+    let input = make_formula_workbook();
+    let output = NamedTempFile::with_suffix(".xlsx").unwrap();
+
+    let opts = EvaluateOptions { values_only: true, ..Default::default() };
+    evaluate(input.path(), output.path(), &opts).unwrap();
+
+    let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();
+    let formula_range = wb.worksheet_formula("Sheet1").unwrap();
+    let formulas: Vec<_> =
+        formula_range.rows().flat_map(|row| row.iter()).filter(|s| !s.is_empty()).collect();
+
+    assert!(formulas.is_empty(), "values_only output must not contain formulas");
 }

--- a/crates/xlstream-eval/tests/conformance/issues.rs
+++ b/crates/xlstream-eval/tests/conformance/issues.rs
@@ -36,12 +36,24 @@ fn make_formula_workbook() -> NamedTempFile {
     let mut wb = Workbook::new();
     let ws = wb.add_worksheet();
     ws.set_name("Sheet1").unwrap();
+    // Headers
     ws.write_string(0, 0, "Value").unwrap();
     ws.write_string(0, 1, "Double").unwrap();
+    ws.write_string(0, 2, "Label").unwrap();
+    ws.write_string(0, 3, "Check").unwrap();
+    ws.write_string(0, 4, "Inverse").unwrap();
+    // Row 2: numeric, text, boolean, error formulas
     ws.write_number(1, 0, 10.0).unwrap();
     ws.write_formula(1, 1, Formula::new("A2*2").set_result("20")).unwrap();
-    ws.write_number(2, 0, 30.0).unwrap();
-    ws.write_formula(2, 1, Formula::new("A3*2").set_result("60")).unwrap();
+    ws.write_formula(1, 2, Formula::new("IF(A2>5,\"high\",\"low\")").set_result("high")).unwrap();
+    ws.write_formula(1, 3, Formula::new("A2>5").set_result("TRUE")).unwrap();
+    ws.write_formula(1, 4, Formula::new("1/0").set_result("#DIV/0!")).unwrap();
+    // Row 3: different values
+    ws.write_number(2, 0, 0.0).unwrap();
+    ws.write_formula(2, 1, Formula::new("A3*2").set_result("0")).unwrap();
+    ws.write_formula(2, 2, Formula::new("IF(A3>5,\"high\",\"low\")").set_result("low")).unwrap();
+    ws.write_formula(2, 3, Formula::new("A3>5").set_result("FALSE")).unwrap();
+    ws.write_formula(2, 4, Formula::new("1/A3").set_result("#DIV/0!")).unwrap();
     wb.save(tmp.path()).unwrap();
     tmp
 }
@@ -74,10 +86,19 @@ fn keep_formulas_produces_correct_values() {
     let range = wb.worksheet_range("Sheet1").unwrap();
     let rows: Vec<_> = range.rows().collect();
 
+    // Numeric
     assert_eq!(rows[1][0], Data::Float(10.0));
     assert_eq!(rows[1][1], Data::Float(20.0));
-    assert_eq!(rows[2][0], Data::Float(30.0));
-    assert_eq!(rows[2][1], Data::Float(60.0));
+    // Text
+    assert_eq!(rows[1][2], Data::String("high".into()));
+    // Boolean
+    assert_eq!(rows[1][3], Data::Bool(true));
+    // Error
+    assert!(matches!(rows[1][4], Data::Error(_)), "expected error, got {:?}", rows[1][4]);
+    // Row 3
+    assert_eq!(rows[2][1], Data::Float(0.0));
+    assert_eq!(rows[2][2], Data::String("low".into()));
+    assert_eq!(rows[2][3], Data::Bool(false));
 }
 
 #[test]

--- a/crates/xlstream-io/Cargo.toml
+++ b/crates/xlstream-io/Cargo.toml
@@ -15,9 +15,13 @@ authors.workspace = true
 xlstream-core = { path = "../xlstream-core", version = "0.2.0" }
 calamine.workspace = true
 rust_xlsxwriter.workspace = true
+quick-xml.workspace = true
+zip.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }
+calamine = { workspace = true }
+rust_xlsxwriter = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/xlstream-io/src/convert.rs
+++ b/crates/xlstream-io/src/convert.rs
@@ -33,7 +33,8 @@ fn convert_cell_error(e: &CellErrorType) -> CellError {
 }
 
 /// Render a [`CellError`] as the Excel error string.
-pub(crate) fn cell_error_to_excel_string(e: CellError) -> &'static str {
+#[must_use]
+pub fn cell_error_to_excel_string(e: CellError) -> &'static str {
     match e {
         CellError::Div0 => "#DIV/0!",
         CellError::Value => "#VALUE!",
@@ -46,7 +47,8 @@ pub(crate) fn cell_error_to_excel_string(e: CellError) -> &'static str {
 }
 
 /// Render a [`Value`] as a result string for `Formula::set_result()`.
-pub(crate) fn value_to_result_string(val: &Value) -> String {
+#[must_use]
+pub fn value_to_result_string(val: &Value) -> String {
     match val {
         Value::Number(n) => format!("{n}"),
         Value::Integer(i) => format!("{i}"),
@@ -56,6 +58,55 @@ pub(crate) fn value_to_result_string(val: &Value) -> String {
         Value::Date(d) => format!("{}", d.serial),
         Value::Error(e) => cell_error_to_excel_string(*e).to_owned(),
         Value::Empty => String::new(),
+    }
+}
+
+/// Cached formula result for XML replacement. Holds the `<v>` text
+/// content and the `t` attribute value for the enclosing `<c>` element.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::Value;
+/// use xlstream_io::convert::value_to_cell_result;
+/// let r = value_to_cell_result(&Value::Number(42.0));
+/// assert_eq!(r.value, "42");
+/// assert_eq!(r.cell_type, None);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CellResult {
+    /// Text content for the `<v>` element.
+    pub value: String,
+    /// Value of the `t` attribute on `<c>`. `None` for numbers/dates
+    /// (omit `t`), `Some("str")` for text, `Some("b")` for boolean,
+    /// `Some("e")` for error.
+    pub cell_type: Option<&'static str>,
+}
+
+/// Convert a [`Value`] to a [`CellResult`] for XML replacement.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::Value;
+/// use xlstream_io::convert::value_to_cell_result;
+/// let r = value_to_cell_result(&Value::Bool(true));
+/// assert_eq!(r.value, "1");
+/// assert_eq!(r.cell_type, Some("b"));
+/// ```
+#[must_use]
+pub fn value_to_cell_result(val: &Value) -> CellResult {
+    match val {
+        Value::Number(n) => CellResult { value: format!("{n}"), cell_type: None },
+        Value::Integer(i) => CellResult { value: format!("{i}"), cell_type: None },
+        Value::Text(s) => CellResult { value: s.to_string(), cell_type: Some("str") },
+        Value::Bool(true) => CellResult { value: "1".into(), cell_type: Some("b") },
+        Value::Bool(false) => CellResult { value: "0".into(), cell_type: Some("b") },
+        Value::Date(d) => CellResult { value: format!("{}", d.serial), cell_type: None },
+        Value::Error(e) => {
+            CellResult { value: cell_error_to_excel_string(*e).to_owned(), cell_type: Some("e") }
+        }
+        Value::Empty => CellResult { value: String::new(), cell_type: None },
     }
 }
 
@@ -138,5 +189,57 @@ mod tests {
         assert_eq!(value_to_result_string(&Value::Text("hi".into())), "hi");
         assert_eq!(value_to_result_string(&Value::Empty), "");
         assert_eq!(value_to_result_string(&Value::Error(CellError::Div0)), "#DIV/0!");
+    }
+
+    #[test]
+    fn cell_result_from_number() {
+        let r = value_to_cell_result(&Value::Number(42.5));
+        assert_eq!(r.value, "42.5");
+        assert_eq!(r.cell_type, None);
+    }
+
+    #[test]
+    fn cell_result_from_integer() {
+        let r = value_to_cell_result(&Value::Integer(7));
+        assert_eq!(r.value, "7");
+        assert_eq!(r.cell_type, None);
+    }
+
+    #[test]
+    fn cell_result_from_text() {
+        let r = value_to_cell_result(&Value::Text("hello".into()));
+        assert_eq!(r.value, "hello");
+        assert_eq!(r.cell_type, Some("str"));
+    }
+
+    #[test]
+    fn cell_result_from_bool() {
+        let r = value_to_cell_result(&Value::Bool(true));
+        assert_eq!(r.value, "1");
+        assert_eq!(r.cell_type, Some("b"));
+        let r = value_to_cell_result(&Value::Bool(false));
+        assert_eq!(r.value, "0");
+        assert_eq!(r.cell_type, Some("b"));
+    }
+
+    #[test]
+    fn cell_result_from_error() {
+        let r = value_to_cell_result(&Value::Error(CellError::Div0));
+        assert_eq!(r.value, "#DIV/0!");
+        assert_eq!(r.cell_type, Some("e"));
+    }
+
+    #[test]
+    fn cell_result_from_date() {
+        let r = value_to_cell_result(&Value::Date(ExcelDate { serial: 44927.0 }));
+        assert_eq!(r.value, "44927");
+        assert_eq!(r.cell_type, None);
+    }
+
+    #[test]
+    fn cell_result_from_empty() {
+        let r = value_to_cell_result(&Value::Empty);
+        assert_eq!(r.value, "");
+        assert_eq!(r.cell_type, None);
     }
 }

--- a/crates/xlstream-io/src/convert.rs
+++ b/crates/xlstream-io/src/convert.rs
@@ -33,6 +33,14 @@ fn convert_cell_error(e: &CellErrorType) -> CellError {
 }
 
 /// Render a [`CellError`] as the Excel error string.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::CellError;
+/// use xlstream_io::convert::cell_error_to_excel_string;
+/// assert_eq!(cell_error_to_excel_string(CellError::Na), "#N/A");
+/// ```
 #[must_use]
 pub fn cell_error_to_excel_string(e: CellError) -> &'static str {
     match e {
@@ -47,6 +55,14 @@ pub fn cell_error_to_excel_string(e: CellError) -> &'static str {
 }
 
 /// Render a [`Value`] as a result string for `Formula::set_result()`.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::Value;
+/// use xlstream_io::convert::value_to_result_string;
+/// assert_eq!(value_to_result_string(&Value::Number(5.0)), "5");
+/// ```
 #[must_use]
 pub fn value_to_result_string(val: &Value) -> String {
     match val {
@@ -61,26 +77,58 @@ pub fn value_to_result_string(val: &Value) -> String {
     }
 }
 
+/// The `t` attribute value for the `<c>` element in xlsx XML.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_io::convert::XmlCellType;
+/// assert_eq!(XmlCellType::Number.as_attr(), None);
+/// assert_eq!(XmlCellType::InlineString.as_attr(), Some("str"));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XmlCellType {
+    /// Numeric value (no `t` attribute).
+    Number,
+    /// Inline string result (`t="str"`).
+    InlineString,
+    /// Boolean result (`t="b"`).
+    Boolean,
+    /// Error result (`t="e"`).
+    Error,
+}
+
+impl XmlCellType {
+    /// The `t` attribute value, or `None` for numbers (omit `t`).
+    #[must_use]
+    pub fn as_attr(self) -> Option<&'static str> {
+        match self {
+            Self::Number => None,
+            Self::InlineString => Some("str"),
+            Self::Boolean => Some("b"),
+            Self::Error => Some("e"),
+        }
+    }
+}
+
 /// Cached formula result for XML replacement. Holds the `<v>` text
-/// content and the `t` attribute value for the enclosing `<c>` element.
+/// content and the cell type for the enclosing `<c>` element.
 ///
 /// # Examples
 ///
 /// ```
 /// use xlstream_core::Value;
-/// use xlstream_io::convert::value_to_cell_result;
+/// use xlstream_io::convert::{value_to_cell_result, XmlCellType};
 /// let r = value_to_cell_result(&Value::Number(42.0));
 /// assert_eq!(r.value, "42");
-/// assert_eq!(r.cell_type, None);
+/// assert_eq!(r.cell_type, XmlCellType::Number);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CellResult {
     /// Text content for the `<v>` element.
     pub value: String,
-    /// Value of the `t` attribute on `<c>`. `None` for numbers/dates
-    /// (omit `t`), `Some("str")` for text, `Some("b")` for boolean,
-    /// `Some("e")` for error.
-    pub cell_type: Option<&'static str>,
+    /// Cell type for the `t` attribute on `<c>`.
+    pub cell_type: XmlCellType,
 }
 
 /// Convert a [`Value`] to a [`CellResult`] for XML replacement.
@@ -89,24 +137,27 @@ pub struct CellResult {
 ///
 /// ```
 /// use xlstream_core::Value;
-/// use xlstream_io::convert::value_to_cell_result;
+/// use xlstream_io::convert::{value_to_cell_result, XmlCellType};
 /// let r = value_to_cell_result(&Value::Bool(true));
 /// assert_eq!(r.value, "1");
-/// assert_eq!(r.cell_type, Some("b"));
+/// assert_eq!(r.cell_type, XmlCellType::Boolean);
 /// ```
 #[must_use]
 pub fn value_to_cell_result(val: &Value) -> CellResult {
     match val {
-        Value::Number(n) => CellResult { value: format!("{n}"), cell_type: None },
-        Value::Integer(i) => CellResult { value: format!("{i}"), cell_type: None },
-        Value::Text(s) => CellResult { value: s.to_string(), cell_type: Some("str") },
-        Value::Bool(true) => CellResult { value: "1".into(), cell_type: Some("b") },
-        Value::Bool(false) => CellResult { value: "0".into(), cell_type: Some("b") },
-        Value::Date(d) => CellResult { value: format!("{}", d.serial), cell_type: None },
-        Value::Error(e) => {
-            CellResult { value: cell_error_to_excel_string(*e).to_owned(), cell_type: Some("e") }
+        Value::Number(n) => CellResult { value: format!("{n}"), cell_type: XmlCellType::Number },
+        Value::Integer(i) => CellResult { value: format!("{i}"), cell_type: XmlCellType::Number },
+        Value::Text(s) => CellResult { value: s.to_string(), cell_type: XmlCellType::InlineString },
+        Value::Bool(true) => CellResult { value: "1".into(), cell_type: XmlCellType::Boolean },
+        Value::Bool(false) => CellResult { value: "0".into(), cell_type: XmlCellType::Boolean },
+        Value::Date(d) => {
+            CellResult { value: format!("{}", d.serial), cell_type: XmlCellType::Number }
         }
-        Value::Empty => CellResult { value: String::new(), cell_type: None },
+        Value::Error(e) => CellResult {
+            value: cell_error_to_excel_string(*e).to_owned(),
+            cell_type: XmlCellType::Error,
+        },
+        Value::Empty => CellResult { value: String::new(), cell_type: XmlCellType::Number },
     }
 }
 
@@ -195,51 +246,51 @@ mod tests {
     fn cell_result_from_number() {
         let r = value_to_cell_result(&Value::Number(42.5));
         assert_eq!(r.value, "42.5");
-        assert_eq!(r.cell_type, None);
+        assert_eq!(r.cell_type, XmlCellType::Number);
     }
 
     #[test]
     fn cell_result_from_integer() {
         let r = value_to_cell_result(&Value::Integer(7));
         assert_eq!(r.value, "7");
-        assert_eq!(r.cell_type, None);
+        assert_eq!(r.cell_type, XmlCellType::Number);
     }
 
     #[test]
     fn cell_result_from_text() {
         let r = value_to_cell_result(&Value::Text("hello".into()));
         assert_eq!(r.value, "hello");
-        assert_eq!(r.cell_type, Some("str"));
+        assert_eq!(r.cell_type, XmlCellType::InlineString);
     }
 
     #[test]
     fn cell_result_from_bool() {
         let r = value_to_cell_result(&Value::Bool(true));
         assert_eq!(r.value, "1");
-        assert_eq!(r.cell_type, Some("b"));
+        assert_eq!(r.cell_type, XmlCellType::Boolean);
         let r = value_to_cell_result(&Value::Bool(false));
         assert_eq!(r.value, "0");
-        assert_eq!(r.cell_type, Some("b"));
+        assert_eq!(r.cell_type, XmlCellType::Boolean);
     }
 
     #[test]
     fn cell_result_from_error() {
         let r = value_to_cell_result(&Value::Error(CellError::Div0));
         assert_eq!(r.value, "#DIV/0!");
-        assert_eq!(r.cell_type, Some("e"));
+        assert_eq!(r.cell_type, XmlCellType::Error);
     }
 
     #[test]
     fn cell_result_from_date() {
         let r = value_to_cell_result(&Value::Date(ExcelDate { serial: 44927.0 }));
         assert_eq!(r.value, "44927");
-        assert_eq!(r.cell_type, None);
+        assert_eq!(r.cell_type, XmlCellType::Number);
     }
 
     #[test]
     fn cell_result_from_empty() {
         let r = value_to_cell_result(&Value::Empty);
         assert_eq!(r.value, "");
-        assert_eq!(r.cell_type, None);
+        assert_eq!(r.cell_type, XmlCellType::Number);
     }
 }

--- a/crates/xlstream-io/src/formula_preserve.rs
+++ b/crates/xlstream-io/src/formula_preserve.rs
@@ -1,0 +1,525 @@
+//! Copy-and-replace engine for preserving formulas in output xlsx.
+//!
+//! Streams worksheet XML through `quick_xml`, replacing only the `<v>`
+//! (cached value) content for formula cells. The `<f>` (formula text)
+//! passes through untouched.
+
+use std::collections::HashMap;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
+
+use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::Reader as XmlReader;
+use quick_xml::Writer as XmlWriter;
+use xlstream_core::{a1_to_col_row, XlStreamError};
+use zip::write::SimpleFileOptions;
+use zip::{ZipArchive, ZipWriter};
+
+use crate::convert::CellResult;
+
+/// State machine for tracking position within `<c>` elements.
+enum CellState {
+    Normal,
+    /// Inside a `<c>` whose (row, col) is in the results map.
+    FormulaCell {
+        row: u32,
+        col: u16,
+        has_value: bool,
+    },
+    /// Inside the `<v>` of a formula cell.
+    InValue {
+        row: u32,
+        col: u16,
+    },
+}
+
+/// Stream worksheet XML, replacing `<v>` content for cells in `results`.
+///
+/// The `<f>` element passes through byte-for-byte. Only `<v>` text and
+/// the `t` attribute on `<c>` are modified.
+///
+/// `results` is keyed by 0-based `(row, col)`.
+///
+/// # Errors
+///
+/// Returns [`XlStreamError::Internal`] on XML parse or write failures.
+#[allow(clippy::implicit_hasher)]
+pub fn replace_sheet_values(
+    xml_in: &[u8],
+    results: &HashMap<(u32, u16), CellResult>,
+) -> Result<Vec<u8>, XlStreamError> {
+    let mut reader = XmlReader::from_reader(xml_in);
+    reader.config_mut().trim_text_start = false;
+    reader.config_mut().trim_text_end = false;
+
+    let mut writer = XmlWriter::new(Vec::with_capacity(xml_in.len()));
+    let mut state = CellState::Normal;
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) if e.name().as_ref() == b"c" => {
+                if let Some((row, col)) = parse_cell_position(e) {
+                    if let Some(result) = results.get(&(row, col)) {
+                        let modified = rewrite_cell_start(e, result.cell_type);
+                        write_event(&mut writer, Event::Start(modified))?;
+                        state = CellState::FormulaCell { row, col, has_value: false };
+                        buf.clear();
+                        continue;
+                    }
+                }
+                write_event(&mut writer, Event::Start(e.clone().into_owned()))?;
+                state = CellState::Normal;
+            }
+
+            Ok(Event::Start(ref e)) if e.name().as_ref() == b"v" => {
+                write_event(&mut writer, Event::Start(e.clone().into_owned()))?;
+                if let CellState::FormulaCell { row, col, ref mut has_value } = state {
+                    *has_value = true;
+                    state = CellState::InValue { row, col };
+                }
+            }
+
+            Ok(Event::Text(ref _t)) if matches!(state, CellState::InValue { .. }) => {
+                let CellState::InValue { row, col } = state else {
+                    return Err(XlStreamError::Internal("unexpected state".into()));
+                };
+                let result = &results[&(row, col)];
+                write_event(&mut writer, Event::Text(BytesText::new(&result.value)))?;
+                state = CellState::FormulaCell { row, col, has_value: true };
+            }
+
+            Ok(Event::End(ref e))
+                if e.name().as_ref() == b"v" && matches!(state, CellState::InValue { .. }) =>
+            {
+                let CellState::InValue { row, col } = state else {
+                    return Err(XlStreamError::Internal("unexpected state".into()));
+                };
+                write_event(&mut writer, Event::End(e.clone().into_owned()))?;
+                state = CellState::FormulaCell { row, col, has_value: true };
+            }
+
+            Ok(Event::Empty(ref e))
+                if e.name().as_ref() == b"v" && matches!(state, CellState::FormulaCell { .. }) =>
+            {
+                if let CellState::FormulaCell { row, col, ref mut has_value } = state {
+                    *has_value = true;
+                    let result = &results[&(row, col)];
+                    write_event(&mut writer, Event::Start(BytesStart::new("v")))?;
+                    write_event(&mut writer, Event::Text(BytesText::new(&result.value)))?;
+                    write_event(&mut writer, Event::End(BytesEnd::new("v")))?;
+                }
+            }
+
+            Ok(Event::End(ref e)) if e.name().as_ref() == b"c" => {
+                if let CellState::FormulaCell { row, col, has_value: false } = state {
+                    let result = &results[&(row, col)];
+                    write_event(&mut writer, Event::Start(BytesStart::new("v")))?;
+                    write_event(&mut writer, Event::Text(BytesText::new(&result.value)))?;
+                    write_event(&mut writer, Event::End(BytesEnd::new("v")))?;
+                }
+                write_event(&mut writer, Event::End(e.clone().into_owned()))?;
+                state = CellState::Normal;
+            }
+
+            Ok(Event::Eof) => break,
+
+            Ok(event) => {
+                write_event(&mut writer, event.into_owned())?;
+            }
+
+            Err(e) => return Err(XlStreamError::Internal(format!("XML parse error: {e}"))),
+        }
+        buf.clear();
+    }
+
+    Ok(writer.into_inner())
+}
+
+/// Map sheet names to their zip entry paths by parsing `xl/workbook.xml`
+/// and `xl/_rels/workbook.xml.rels`.
+///
+/// # Errors
+///
+/// Returns [`XlStreamError::Internal`] if the archive lacks the
+/// expected workbook XML entries.
+pub fn resolve_sheet_paths<R: Read + std::io::Seek>(
+    archive: &mut ZipArchive<R>,
+) -> Result<HashMap<String, String>, XlStreamError> {
+    let name_to_rid = parse_workbook_sheets(archive)?;
+    let rid_to_target = parse_workbook_rels(archive)?;
+
+    let mut result = HashMap::new();
+    for (rid, sheet_name) in &name_to_rid {
+        if let Some(target) = rid_to_target.get(rid) {
+            let full_path = if let Some(stripped) = target.strip_prefix('/') {
+                stripped.to_string()
+            } else {
+                format!("xl/{target}")
+            };
+            result.insert(sheet_name.clone(), full_path);
+        }
+    }
+    Ok(result)
+}
+
+/// Copy an xlsx from `input` to `output`, replacing `<v>` values for
+/// formula cells according to `results`.
+///
+/// Non-worksheet entries (styles, shared strings, images, etc.) are
+/// copied byte-for-byte from the input archive.
+///
+/// # Errors
+///
+/// - [`XlStreamError::Io`] on filesystem errors.
+/// - [`XlStreamError::Internal`] on zip or XML parse failures.
+#[allow(clippy::implicit_hasher)]
+pub fn copy_and_replace(
+    input: &Path,
+    output: &Path,
+    results: &HashMap<String, HashMap<(u32, u16), CellResult>>,
+) -> Result<(), XlStreamError> {
+    let input_file = std::fs::File::open(input)
+        .map_err(|e| XlStreamError::Io { path: input.to_path_buf(), source: e })?;
+    let mut archive = ZipArchive::new(BufReader::new(input_file))
+        .map_err(|e| XlStreamError::Internal(format!("zip open: {e}")))?;
+
+    let sheet_paths = resolve_sheet_paths(&mut archive)?;
+    let path_to_sheet: HashMap<String, String> =
+        sheet_paths.into_iter().map(|(name, path)| (path, name)).collect();
+
+    let output_file = std::fs::File::create(output)
+        .map_err(|e| XlStreamError::Io { path: output.to_path_buf(), source: e })?;
+    let mut zip_writer = ZipWriter::new(BufWriter::new(output_file));
+
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| XlStreamError::Internal(format!("zip entry {i}: {e}")))?;
+        let entry_name = entry.name().to_string();
+
+        let sheet_results = path_to_sheet.get(&entry_name).and_then(|name| results.get(name));
+
+        if let Some(sr) = sheet_results {
+            if !sr.is_empty() {
+                let mut xml_in = Vec::new();
+                entry
+                    .read_to_end(&mut xml_in)
+                    .map_err(|e| XlStreamError::Internal(format!("read {entry_name}: {e}")))?;
+
+                let xml_out = replace_sheet_values(&xml_in, sr)?;
+
+                let options = SimpleFileOptions::default().compression_method(entry.compression());
+                zip_writer
+                    .start_file(&entry_name, options)
+                    .map_err(|e| XlStreamError::Internal(format!("zip write {entry_name}: {e}")))?;
+                zip_writer
+                    .write_all(&xml_out)
+                    .map_err(|e| XlStreamError::Internal(e.to_string()))?;
+                continue;
+            }
+        }
+
+        zip_writer
+            .raw_copy_file(entry)
+            .map_err(|e| XlStreamError::Internal(format!("zip copy {entry_name}: {e}")))?;
+    }
+
+    zip_writer.finish().map_err(|e| XlStreamError::Internal(format!("zip finish: {e}")))?;
+
+    Ok(())
+}
+
+// -- helpers --
+
+fn write_event<W: std::io::Write>(
+    writer: &mut XmlWriter<W>,
+    event: Event<'_>,
+) -> Result<(), XlStreamError> {
+    writer.write_event(event).map_err(|e| XlStreamError::Internal(e.to_string()))
+}
+
+fn parse_cell_position(elem: &BytesStart<'_>) -> Option<(u32, u16)> {
+    for attr in elem.attributes().filter_map(Result::ok) {
+        if attr.key.as_ref() == b"r" {
+            let ref_str = std::str::from_utf8(&attr.value).ok()?;
+            return a1_to_col_row(ref_str);
+        }
+    }
+    None
+}
+
+fn rewrite_cell_start(
+    elem: &BytesStart<'_>,
+    cell_type: Option<&'static str>,
+) -> BytesStart<'static> {
+    let name = std::str::from_utf8(elem.name().as_ref()).unwrap_or("c").to_owned();
+    let mut new_elem = BytesStart::new(name);
+    for attr in elem.attributes().filter_map(Result::ok) {
+        if attr.key.as_ref() != b"t" {
+            new_elem.push_attribute((
+                std::str::from_utf8(attr.key.as_ref()).unwrap_or(""),
+                std::str::from_utf8(&attr.value).unwrap_or(""),
+            ));
+        }
+    }
+    if let Some(t) = cell_type {
+        new_elem.push_attribute(("t", t));
+    }
+    new_elem
+}
+
+fn parse_workbook_sheets<R: Read + std::io::Seek>(
+    archive: &mut ZipArchive<R>,
+) -> Result<HashMap<String, String>, XlStreamError> {
+    let mut map = HashMap::new();
+    let entry = archive
+        .by_name("xl/workbook.xml")
+        .map_err(|e| XlStreamError::Internal(format!("missing workbook.xml: {e}")))?;
+    let mut xml = String::new();
+    BufReader::new(entry)
+        .read_to_string(&mut xml)
+        .map_err(|e| XlStreamError::Internal(e.to_string()))?;
+
+    let mut reader = XmlReader::from_str(&xml);
+    loop {
+        match reader.read_event() {
+            Ok(Event::Empty(ref e) | Event::Start(ref e)) if e.name().as_ref() == b"sheet" => {
+                let mut name = None;
+                let mut rid = None;
+                for attr in e.attributes().filter_map(Result::ok) {
+                    match attr.key.as_ref() {
+                        b"name" => {
+                            name = std::str::from_utf8(&attr.value).ok().map(String::from);
+                        }
+                        // The namespace-prefixed form (r:id) is the standard.
+                        k if k.ends_with(b"id") && k != b"sheetId" => {
+                            rid = std::str::from_utf8(&attr.value).ok().map(String::from);
+                        }
+                        _ => {}
+                    }
+                }
+                if let (Some(n), Some(r)) = (name, rid) {
+                    map.insert(r, n);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(XlStreamError::Internal(format!("workbook.xml parse: {e}")));
+            }
+            _ => {}
+        }
+    }
+    Ok(map)
+}
+
+fn parse_workbook_rels<R: Read + std::io::Seek>(
+    archive: &mut ZipArchive<R>,
+) -> Result<HashMap<String, String>, XlStreamError> {
+    let mut map = HashMap::new();
+    let entry = archive
+        .by_name("xl/_rels/workbook.xml.rels")
+        .map_err(|e| XlStreamError::Internal(format!("missing workbook.xml.rels: {e}")))?;
+    let mut xml = String::new();
+    BufReader::new(entry)
+        .read_to_string(&mut xml)
+        .map_err(|e| XlStreamError::Internal(e.to_string()))?;
+
+    let mut reader = XmlReader::from_str(&xml);
+    loop {
+        match reader.read_event() {
+            Ok(Event::Empty(ref e) | Event::Start(ref e))
+                if e.name().as_ref() == b"Relationship" =>
+            {
+                let mut rid = None;
+                let mut target = None;
+                for attr in e.attributes().filter_map(Result::ok) {
+                    match attr.key.as_ref() {
+                        b"Id" => {
+                            rid = std::str::from_utf8(&attr.value).ok().map(String::from);
+                        }
+                        b"Target" => {
+                            target = std::str::from_utf8(&attr.value).ok().map(String::from);
+                        }
+                        _ => {}
+                    }
+                }
+                if let (Some(r), Some(t)) = (rid, target) {
+                    map.insert(r, t);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(XlStreamError::Internal(format!("rels parse: {e}")));
+            }
+            _ => {}
+        }
+    }
+    Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use std::collections::HashMap;
+
+    use calamine::Reader as CalReader;
+
+    use super::*;
+    use crate::convert::CellResult;
+
+    fn make_results(
+        entries: &[(u32, u16, &str, Option<&'static str>)],
+    ) -> HashMap<(u32, u16), CellResult> {
+        entries
+            .iter()
+            .map(|(r, c, v, t)| ((*r, *c), CellResult { value: (*v).to_string(), cell_type: *t }))
+            .collect()
+    }
+
+    #[test]
+    fn replaces_number_value_in_formula_cell() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="A2"><v>10</v></c><c r="B2"><f>A2*2</f><v>20</v></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "42", None)]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains("<f>A2*2</f>"), "formula must be preserved");
+        assert!(out_str.contains("<v>42</v>"), "value must be replaced, got: {out_str}");
+        assert!(!out_str.contains("<v>20</v>"), "old value must not appear");
+    }
+
+    #[test]
+    fn preserves_data_cells_unchanged() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="A2"><v>10</v></c></row></sheetData></worksheet>"#;
+        let results = HashMap::new();
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains("<v>10</v>"), "data cell must be unchanged");
+    }
+
+    #[test]
+    fn updates_cell_type_for_string_result() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>A2&amp;"!"</f><v>hi</v></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "hello", Some("str"))]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(r#"t="str""#), "t must be set to str: {out_str}");
+        assert!(out_str.contains("<v>hello</v>"), "value must be replaced");
+    }
+
+    #[test]
+    fn updates_cell_type_for_boolean_result() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>A2&gt;0</f><v>0</v></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "1", Some("b"))]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(r#"t="b""#), "t must be set to b: {out_str}");
+        assert!(out_str.contains("<v>1</v>"));
+    }
+
+    #[test]
+    fn updates_cell_type_for_error_result() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>1/0</f><v>0</v></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "#DIV/0!", Some("e"))]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(r#"t="e""#));
+        assert!(out_str.contains("<v>#DIV/0!</v>"));
+    }
+
+    #[test]
+    fn inserts_value_when_no_v_element_exists() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>A2*2</f></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "42", None)]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains("<v>42</v>"), "must insert <v>: {out_str}");
+    }
+
+    #[test]
+    fn removes_old_type_for_number_result() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2" t="e"><f>1/0</f><v>#DIV/0!</v></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "42", None)]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(!out_str.contains(r#"t="e""#), "old t must be removed: {out_str}");
+        assert!(out_str.contains("<v>42</v>"));
+    }
+
+    #[test]
+    fn preserves_style_attribute() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2" s="4"><f>A2*2</f><v>20</v></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "42", None)]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(r#"s="4""#), "style must be preserved: {out_str}");
+    }
+
+    #[test]
+    fn handles_mixed_formula_and_data_rows() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row><row r="2"><c r="A2"><v>10</v></c><c r="B2"><f>A2*2</f><v>20</v></c></row><row r="3"><c r="A3"><v>30</v></c><c r="B3"><f>A3*2</f><v>60</v></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "42", None), (2, 1, "99", None)]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains(r#"<c r="A1" t="s"><v>0</v></c>"#));
+        assert!(out_str.contains("<v>42</v>"));
+        assert!(out_str.contains("<v>99</v>"));
+    }
+
+    #[test]
+    fn resolve_sheet_paths_parses_workbook_xml() {
+        let tmp = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+        {
+            let mut wb = rust_xlsxwriter::Workbook::new();
+            let ws1 = wb.add_worksheet();
+            ws1.set_name("Data").unwrap();
+            ws1.write_number(0, 0, 1.0).unwrap();
+            let ws2 = wb.add_worksheet();
+            ws2.set_name("Summary").unwrap();
+            ws2.write_number(0, 0, 2.0).unwrap();
+            wb.save(tmp.path()).unwrap();
+        }
+        let file = std::fs::File::open(tmp.path()).unwrap();
+        let mut archive = ZipArchive::new(BufReader::new(file)).unwrap();
+        let paths = resolve_sheet_paths(&mut archive).unwrap();
+        assert!(paths.contains_key("Data"), "missing Data: {paths:?}");
+        assert!(paths.contains_key("Summary"), "missing Summary: {paths:?}");
+        for path in paths.values() {
+            assert!(path.contains("worksheets/"), "bad path: {path}");
+        }
+    }
+
+    #[test]
+    fn copy_and_replace_round_trips_simple_workbook() {
+        let input = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+        {
+            let mut wb = rust_xlsxwriter::Workbook::new();
+            let ws = wb.add_worksheet();
+            ws.set_name("Sheet1").unwrap();
+            ws.write_number(0, 0, 10.0).unwrap();
+            ws.write_formula(0, 1, "=A1*2").unwrap();
+            ws.write_number(1, 0, 30.0).unwrap();
+            ws.write_formula(1, 1, "=A2*2").unwrap();
+            wb.save(input.path()).unwrap();
+        }
+
+        let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+
+        let mut sheet_results = HashMap::new();
+        let mut cells = HashMap::new();
+        cells.insert((0u32, 1u16), CellResult { value: "42".into(), cell_type: None });
+        cells.insert((1, 1), CellResult { value: "99".into(), cell_type: None });
+        sheet_results.insert("Sheet1".to_string(), cells);
+
+        copy_and_replace(input.path(), output.path(), &sheet_results).unwrap();
+
+        let mut wb: calamine::Xlsx<_> = calamine::open_workbook(output.path()).unwrap();
+        let range = wb.worksheet_range("Sheet1").unwrap();
+        let rows: Vec<_> = range.rows().collect();
+
+        assert_eq!(rows[0][1], calamine::Data::Float(42.0));
+        assert_eq!(rows[1][1], calamine::Data::Float(99.0));
+        assert_eq!(rows[0][0], calamine::Data::Float(10.0));
+    }
+}

--- a/crates/xlstream-io/src/formula_preserve.rs
+++ b/crates/xlstream-io/src/formula_preserve.rs
@@ -15,7 +15,7 @@ use xlstream_core::{a1_to_col_row, XlStreamError};
 use zip::write::SimpleFileOptions;
 use zip::{ZipArchive, ZipWriter};
 
-use crate::convert::CellResult;
+use crate::convert::{CellResult, XmlCellType};
 
 /// State machine for tracking position within `<c>` elements.
 enum CellState {
@@ -48,14 +48,14 @@ enum CellState {
 ///
 /// ```
 /// use std::collections::HashMap;
-/// use xlstream_io::convert::CellResult;
+/// use xlstream_io::convert::{CellResult, XmlCellType};
 /// use xlstream_io::formula_preserve::replace_sheet_values;
 ///
 /// let xml = br#"<?xml version="1.0"?><worksheet><sheetData>
 /// <row r="2"><c r="A2"><v>10</v></c><c r="B2"><f>A2*2</f><v>20</v></c></row>
 /// </sheetData></worksheet>"#;
 /// let mut results = HashMap::new();
-/// results.insert((1u32, 1u16), CellResult { value: "42".into(), cell_type: None });
+/// results.insert((1u32, 1u16), CellResult { value: "42".into(), cell_type: XmlCellType::Number });
 /// let out = replace_sheet_values(xml, &results).unwrap();
 /// assert!(String::from_utf8_lossy(&out).contains("<v>42</v>"));
 /// ```
@@ -77,7 +77,7 @@ pub fn replace_sheet_values(
             Ok(Event::Start(ref e)) if e.name().as_ref() == b"c" => {
                 if let Some((row, col)) = parse_cell_position(e) {
                     if let Some(result) = results.get(&(row, col)) {
-                        let modified = rewrite_cell_start(e, result.cell_type);
+                        let modified = rewrite_cell_start(e, result.cell_type)?;
                         write_event(&mut writer, Event::Start(modified))?;
                         state = CellState::FormulaCell { row, col, has_value: false };
                         buf.clear();
@@ -100,7 +100,7 @@ pub fn replace_sheet_values(
                 let CellState::InValue { row, col } = state else {
                     return Err(XlStreamError::Internal("unexpected state".into()));
                 };
-                let result = &results[&(row, col)];
+                let result = lookup_result(results, row, col)?;
                 write_event(&mut writer, Event::Text(BytesText::new(&result.value)))?;
                 state = CellState::FormulaCell { row, col, has_value: true };
             }
@@ -120,7 +120,7 @@ pub fn replace_sheet_values(
             {
                 if let CellState::FormulaCell { row, col, ref mut has_value } = state {
                     *has_value = true;
-                    let result = &results[&(row, col)];
+                    let result = lookup_result(results, row, col)?;
                     write_event(&mut writer, Event::Start(BytesStart::new("v")))?;
                     write_event(&mut writer, Event::Text(BytesText::new(&result.value)))?;
                     write_event(&mut writer, Event::End(BytesEnd::new("v")))?;
@@ -129,7 +129,7 @@ pub fn replace_sheet_values(
 
             Ok(Event::End(ref e)) if e.name().as_ref() == b"c" => {
                 if let CellState::FormulaCell { row, col, has_value: false } = state {
-                    let result = &results[&(row, col)];
+                    let result = lookup_result(results, row, col)?;
                     write_event(&mut writer, Event::Start(BytesStart::new("v")))?;
                     write_event(&mut writer, Event::Text(BytesText::new(&result.value)))?;
                     write_event(&mut writer, Event::End(BytesEnd::new("v")))?;
@@ -209,12 +209,12 @@ pub fn resolve_sheet_paths<R: Read + std::io::Seek>(
 /// ```no_run
 /// use std::collections::HashMap;
 /// use std::path::Path;
-/// use xlstream_io::convert::CellResult;
+/// use xlstream_io::convert::{CellResult, XmlCellType};
 /// use xlstream_io::formula_preserve::copy_and_replace;
 ///
 /// let mut results = HashMap::new();
 /// let mut cells = HashMap::new();
-/// cells.insert((0u32, 1u16), CellResult { value: "42".into(), cell_type: None });
+/// cells.insert((0u32, 1u16), CellResult { value: "42".into(), cell_type: XmlCellType::Number });
 /// results.insert("Sheet1".to_string(), cells);
 /// copy_and_replace(Path::new("in.xlsx"), Path::new("out.xlsx"), &results).unwrap();
 /// ```
@@ -293,6 +293,16 @@ fn write_event<W: std::io::Write>(
     writer.write_event(event).map_err(|e| XlStreamError::Internal(e.to_string()))
 }
 
+fn lookup_result(
+    results: &HashMap<(u32, u16), CellResult>,
+    row: u32,
+    col: u16,
+) -> Result<&CellResult, XlStreamError> {
+    results
+        .get(&(row, col))
+        .ok_or_else(|| XlStreamError::Internal(format!("missing result for cell ({row}, {col})")))
+}
+
 fn parse_cell_position(elem: &BytesStart<'_>) -> Option<(u32, u16)> {
     for attr in elem.attributes().filter_map(Result::ok) {
         if attr.key.as_ref() == b"r" {
@@ -305,22 +315,27 @@ fn parse_cell_position(elem: &BytesStart<'_>) -> Option<(u32, u16)> {
 
 fn rewrite_cell_start(
     elem: &BytesStart<'_>,
-    cell_type: Option<&'static str>,
-) -> BytesStart<'static> {
-    let name = std::str::from_utf8(elem.name().as_ref()).unwrap_or("c").to_owned();
+    cell_type: XmlCellType,
+) -> Result<BytesStart<'static>, XlStreamError> {
+    let name = std::str::from_utf8(elem.name().as_ref())
+        .map_err(|e| XlStreamError::Internal(format!("non-UTF8 element name: {e}")))?
+        .to_owned();
     let mut new_elem = BytesStart::new(name);
-    for attr in elem.attributes().filter_map(Result::ok) {
+    for attr_result in elem.attributes() {
+        let attr = attr_result
+            .map_err(|e| XlStreamError::Internal(format!("malformed XML attribute: {e}")))?;
         if attr.key.as_ref() != b"t" {
-            new_elem.push_attribute((
-                std::str::from_utf8(attr.key.as_ref()).unwrap_or(""),
-                std::str::from_utf8(&attr.value).unwrap_or(""),
-            ));
+            let key = std::str::from_utf8(attr.key.as_ref())
+                .map_err(|e| XlStreamError::Internal(format!("non-UTF8 attr key: {e}")))?;
+            let val = std::str::from_utf8(&attr.value)
+                .map_err(|e| XlStreamError::Internal(format!("non-UTF8 attr value: {e}")))?;
+            new_elem.push_attribute((key, val));
         }
     }
-    if let Some(t) = cell_type {
+    if let Some(t) = cell_type.as_attr() {
         new_elem.push_attribute(("t", t));
     }
-    new_elem
+    Ok(new_elem)
 }
 
 fn parse_workbook_sheets<R: Read + std::io::Seek>(
@@ -420,11 +435,9 @@ mod tests {
     use calamine::Reader as CalReader;
 
     use super::*;
-    use crate::convert::CellResult;
+    use crate::convert::{CellResult, XmlCellType};
 
-    fn make_results(
-        entries: &[(u32, u16, &str, Option<&'static str>)],
-    ) -> HashMap<(u32, u16), CellResult> {
+    fn make_results(entries: &[(u32, u16, &str, XmlCellType)]) -> HashMap<(u32, u16), CellResult> {
         entries
             .iter()
             .map(|(r, c, v, t)| ((*r, *c), CellResult { value: (*v).to_string(), cell_type: *t }))
@@ -434,7 +447,7 @@ mod tests {
     #[test]
     fn replaces_number_value_in_formula_cell() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="A2"><v>10</v></c><c r="B2"><f>A2*2</f><v>20</v></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "42", None)]);
+        let results = make_results(&[(1, 1, "42", XmlCellType::Number)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(out_str.contains("<f>A2*2</f>"), "formula must be preserved");
@@ -454,7 +467,7 @@ mod tests {
     #[test]
     fn updates_cell_type_for_string_result() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>A2&amp;"!"</f><v>hi</v></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "hello", Some("str"))]);
+        let results = make_results(&[(1, 1, "hello", XmlCellType::InlineString)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(out_str.contains(r#"t="str""#), "t must be set to str: {out_str}");
@@ -464,7 +477,7 @@ mod tests {
     #[test]
     fn updates_cell_type_for_boolean_result() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>A2&gt;0</f><v>0</v></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "1", Some("b"))]);
+        let results = make_results(&[(1, 1, "1", XmlCellType::Boolean)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(out_str.contains(r#"t="b""#), "t must be set to b: {out_str}");
@@ -474,7 +487,7 @@ mod tests {
     #[test]
     fn updates_cell_type_for_error_result() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>1/0</f><v>0</v></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "#DIV/0!", Some("e"))]);
+        let results = make_results(&[(1, 1, "#DIV/0!", XmlCellType::Error)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(out_str.contains(r#"t="e""#));
@@ -484,7 +497,7 @@ mod tests {
     #[test]
     fn inserts_value_when_no_v_element_exists() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>A2*2</f></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "42", None)]);
+        let results = make_results(&[(1, 1, "42", XmlCellType::Number)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(out_str.contains("<v>42</v>"), "must insert <v>: {out_str}");
@@ -493,7 +506,7 @@ mod tests {
     #[test]
     fn removes_old_type_for_number_result() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2" t="e"><f>1/0</f><v>#DIV/0!</v></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "42", None)]);
+        let results = make_results(&[(1, 1, "42", XmlCellType::Number)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(!out_str.contains(r#"t="e""#), "old t must be removed: {out_str}");
@@ -503,7 +516,7 @@ mod tests {
     #[test]
     fn preserves_style_attribute() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2" s="4"><f>A2*2</f><v>20</v></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "42", None)]);
+        let results = make_results(&[(1, 1, "42", XmlCellType::Number)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(out_str.contains(r#"s="4""#), "style must be preserved: {out_str}");
@@ -512,7 +525,8 @@ mod tests {
     #[test]
     fn handles_mixed_formula_and_data_rows() {
         let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row><row r="2"><c r="A2"><v>10</v></c><c r="B2"><f>A2*2</f><v>20</v></c></row><row r="3"><c r="A3"><v>30</v></c><c r="B3"><f>A3*2</f><v>60</v></c></row></sheetData></worksheet>"#;
-        let results = make_results(&[(1, 1, "42", None), (2, 1, "99", None)]);
+        let results =
+            make_results(&[(1, 1, "42", XmlCellType::Number), (2, 1, "99", XmlCellType::Number)]);
         let out = replace_sheet_values(xml, &results).unwrap();
         let out_str = std::str::from_utf8(&out).unwrap();
         assert!(out_str.contains(r#"<c r="A1" t="s"><v>0</v></c>"#));
@@ -561,8 +575,11 @@ mod tests {
 
         let mut sheet_results = HashMap::new();
         let mut cells = HashMap::new();
-        cells.insert((0u32, 1u16), CellResult { value: "42".into(), cell_type: None });
-        cells.insert((1, 1), CellResult { value: "99".into(), cell_type: None });
+        cells.insert(
+            (0u32, 1u16),
+            CellResult { value: "42".into(), cell_type: XmlCellType::Number },
+        );
+        cells.insert((1, 1), CellResult { value: "99".into(), cell_type: XmlCellType::Number });
         sheet_results.insert("Sheet1".to_string(), cells);
 
         copy_and_replace(input.path(), output.path(), &sheet_results).unwrap();
@@ -574,5 +591,37 @@ mod tests {
         assert_eq!(rows[0][1], calamine::Data::Float(42.0));
         assert_eq!(rows[1][1], calamine::Data::Float(99.0));
         assert_eq!(rows[0][0], calamine::Data::Float(10.0));
+    }
+
+    #[test]
+    fn replaces_self_closing_v_element() {
+        let xml = br#"<?xml version="1.0"?><worksheet><sheetData><row r="2"><c r="B2"><f>A2*2</f><v/></c></row></sheetData></worksheet>"#;
+        let results = make_results(&[(1, 1, "42", XmlCellType::Number)]);
+        let out = replace_sheet_values(xml, &results).unwrap();
+        let out_str = std::str::from_utf8(&out).unwrap();
+        assert!(out_str.contains("<v>42</v>"), "self-closing <v/> must expand: {out_str}");
+    }
+
+    #[test]
+    fn copy_and_replace_errors_on_unknown_sheet() {
+        let input = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+        {
+            let mut wb = rust_xlsxwriter::Workbook::new();
+            let ws = wb.add_worksheet();
+            ws.set_name("Sheet1").unwrap();
+            ws.write_number(0, 0, 1.0).unwrap();
+            wb.save(input.path()).unwrap();
+        }
+        let output = tempfile::NamedTempFile::with_suffix(".xlsx").unwrap();
+
+        let mut results = HashMap::new();
+        let mut cells = HashMap::new();
+        cells
+            .insert((0u32, 0u16), CellResult { value: "1".into(), cell_type: XmlCellType::Number });
+        results.insert("NoSuchSheet".to_string(), cells);
+
+        let err = copy_and_replace(input.path(), output.path(), &results).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("NoSuchSheet"), "error must name the sheet: {msg}");
     }
 }

--- a/crates/xlstream-io/src/formula_preserve.rs
+++ b/crates/xlstream-io/src/formula_preserve.rs
@@ -43,6 +43,22 @@ enum CellState {
 /// # Errors
 ///
 /// Returns [`XlStreamError::Internal`] on XML parse or write failures.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+/// use xlstream_io::convert::CellResult;
+/// use xlstream_io::formula_preserve::replace_sheet_values;
+///
+/// let xml = br#"<?xml version="1.0"?><worksheet><sheetData>
+/// <row r="2"><c r="A2"><v>10</v></c><c r="B2"><f>A2*2</f><v>20</v></c></row>
+/// </sheetData></worksheet>"#;
+/// let mut results = HashMap::new();
+/// results.insert((1u32, 1u16), CellResult { value: "42".into(), cell_type: None });
+/// let out = replace_sheet_values(xml, &results).unwrap();
+/// assert!(String::from_utf8_lossy(&out).contains("<v>42</v>"));
+/// ```
 #[allow(clippy::implicit_hasher)]
 pub fn replace_sheet_values(
     xml_in: &[u8],
@@ -143,6 +159,18 @@ pub fn replace_sheet_values(
 ///
 /// Returns [`XlStreamError::Internal`] if the archive lacks the
 /// expected workbook XML entries.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::io::BufReader;
+/// use xlstream_io::formula_preserve::resolve_sheet_paths;
+///
+/// let file = std::fs::File::open("workbook.xlsx").unwrap();
+/// let mut archive = zip::ZipArchive::new(BufReader::new(file)).unwrap();
+/// let paths = resolve_sheet_paths(&mut archive).unwrap();
+/// // e.g. {"Sheet1" => "xl/worksheets/sheet1.xml"}
+/// ```
 pub fn resolve_sheet_paths<R: Read + std::io::Seek>(
     archive: &mut ZipArchive<R>,
 ) -> Result<HashMap<String, String>, XlStreamError> {
@@ -167,12 +195,29 @@ pub fn resolve_sheet_paths<R: Read + std::io::Seek>(
 /// formula cells according to `results`.
 ///
 /// Non-worksheet entries (styles, shared strings, images, etc.) are
-/// copied byte-for-byte from the input archive.
+/// copied byte-for-byte from the input archive. Sheets absent from
+/// `results` pass through unchanged.
 ///
 /// # Errors
 ///
 /// - [`XlStreamError::Io`] on filesystem errors.
-/// - [`XlStreamError::Internal`] on zip or XML parse failures.
+/// - [`XlStreamError::Internal`] on zip or XML parse failures, or if a
+///   sheet in `results` has no matching zip entry.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::collections::HashMap;
+/// use std::path::Path;
+/// use xlstream_io::convert::CellResult;
+/// use xlstream_io::formula_preserve::copy_and_replace;
+///
+/// let mut results = HashMap::new();
+/// let mut cells = HashMap::new();
+/// cells.insert((0u32, 1u16), CellResult { value: "42".into(), cell_type: None });
+/// results.insert("Sheet1".to_string(), cells);
+/// copy_and_replace(Path::new("in.xlsx"), Path::new("out.xlsx"), &results).unwrap();
+/// ```
 #[allow(clippy::implicit_hasher)]
 pub fn copy_and_replace(
     input: &Path,
@@ -185,6 +230,15 @@ pub fn copy_and_replace(
         .map_err(|e| XlStreamError::Internal(format!("zip open: {e}")))?;
 
     let sheet_paths = resolve_sheet_paths(&mut archive)?;
+
+    for sheet_name in results.keys() {
+        if !sheet_paths.contains_key(sheet_name) {
+            return Err(XlStreamError::Internal(format!(
+                "sheet '{sheet_name}' has formula results but no matching zip entry"
+            )));
+        }
+    }
+
     let path_to_sheet: HashMap<String, String> =
         sheet_paths.into_iter().map(|(name, path)| (path, name)).collect();
 
@@ -292,8 +346,7 @@ fn parse_workbook_sheets<R: Read + std::io::Seek>(
                         b"name" => {
                             name = std::str::from_utf8(&attr.value).ok().map(String::from);
                         }
-                        // The namespace-prefixed form (r:id) is the standard.
-                        k if k.ends_with(b"id") && k != b"sheetId" => {
+                        b"r:id" => {
                             rid = std::str::from_utf8(&attr.value).ok().map(String::from);
                         }
                         _ => {}

--- a/crates/xlstream-io/src/lib.rs
+++ b/crates/xlstream-io/src/lib.rs
@@ -21,6 +21,7 @@
 #![allow(clippy::multiple_crate_versions)]
 
 pub mod convert;
+pub mod formula_preserve;
 mod reader;
 mod sheet_handle;
 mod stream;

--- a/crates/xlstream-io/src/lib.rs
+++ b/crates/xlstream-io/src/lib.rs
@@ -20,7 +20,7 @@
 // Phase-1 stub doesn't use either crate's API so we can't avoid the pull-in.
 #![allow(clippy::multiple_crate_versions)]
 
-pub(crate) mod convert;
+pub mod convert;
 mod reader;
 mod sheet_handle;
 mod stream;

--- a/docs/architecture/io.md
+++ b/docs/architecture/io.md
@@ -164,7 +164,7 @@ Why "all up front": constant_memory mode creates a tempfile per sheet; the order
 For sheets that xlstream doesn't evaluate (no formulas, or all unsupported), we can:
 
 - v0.1: copy the sheet's raw values through (read with calamine, write with rust_xlsxwriter). Styles are NOT preserved. Documented limitation.
-- v0.2: investigate copying the raw xlsx sheet XML bytes for perfect fidelity.
+- v0.2 (implemented): copy-and-replace — copy the input xlsx at the zip level, stream each worksheet's XML through `quick_xml`, replace `<v>` cached values for formula cells. `<f>` elements and all other XML pass through untouched. `--values-only` mode uses the v0.1 approach (rust_xlsxwriter from scratch).
 
 ## What we do not support
 

--- a/docs/roadmap/v0.2/README.md
+++ b/docs/roadmap/v0.2/README.md
@@ -16,7 +16,7 @@
 
 ### Output fidelity
 
-- [] **Keep formulas by default** — write `<f>formula</f><v>cached</v>` instead of just `<v>`. Add `--values-only` flag for static output. ~4 hours.
+- [x] **Keep formulas by default** — copy-and-replace preserves `<f>` elements, updates `<v>` with re-evaluated results. `--values-only` flag for static output.
 - [x] **PyPI description** — fix empty project page. ~30 min.
 - [ ] **MID empty string workaround** — `rust_xlsxwriter` drops empty string writes. Either patch upstream or work around. ~1 hour.
 


### PR DESCRIPTION
## Summary
- Implements keep-formulas-v2 (copy-and-replace approach)
- Spec: `docs/roadmap/v0.2/06-keep-formulas-v2.md`
- Replaces PR #83 approach (formula text storage — 3.5 GB regression)

Default mode now preserves `<f>` elements in output xlsx. The input file is copied at the zip level; each worksheet's XML is streamed through `quick_xml`, replacing only `<v>` cached values with re-evaluated results. Zero formula text memory. `--values-only` / `values_only=True` retains the previous rust_xlsxwriter-from-scratch behavior.

**Memory comparison (700k rows x 20 formula cols):**
| Approach | Formula text | Result values | Total extra |
|---|---|---|---|
| PR #83 | 900 MB | 0 | 900 MB |
| Copy-and-replace (this PR) | 0 | ~140 MB | ~140 MB |
| `--values-only` | 0 | 0 | 0 |

### Changes by crate
- **xlstream-core**: `values_only` field on `EvaluateOptions`, `a1_to_col_row()` parser
- **xlstream-io**: `CellResult` type, `formula_preserve` module (`replace_sheet_values`, `resolve_sheet_paths`, `copy_and_replace`), direct `quick-xml`/`zip` deps
- **xlstream-eval**: `collect_single_threaded`, `collect_parallel`, `stream_parallel_write`, branched `evaluate()` on `values_only`
- **xlstream-cli**: `--values-only` flag
- **xlstream-python**: `values_only` kwarg, updated type stubs

## Test plan
- [ ] Unit tests for XML replacement (8 tests in `formula_preserve::tests`)
- [ ] Unit tests for `a1_to_col_row` (6 tests including round-trip)
- [ ] Unit tests for `CellResult` conversion (7 tests)
- [ ] Integration: `keep_formulas_preserves_formula_elements` — output has `<f>`
- [ ] Integration: `keep_formulas_produces_correct_values` — output values match
- [ ] Integration: `values_only_strips_formula_elements` — no `<f>` in output
- [ ] All 35 existing conformance tests pass through keep-formulas path
- [ ] `make check` passes (fmt, clippy, test, doc-test)
- [ ] CLI `--values-only` flag parsing tests
- [ ] Docs updated: CHANGELOG, roadmap checkbox