### PR TITLE
xlstream-eval: preserve formulas by default via template-based write_formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ Semver.
 - `EvaluateOptions` with `iterative_calc`, `max_iterations`, `max_change` settings
 - CLI: `--max-iterations`, `--max-change`, `--no-iterative-calc`
 - Python: `iterative_calc`, `max_iterations`, `max_change` kwargs
+- Formula preservation: output now includes `<f>formula</f><v>cached</v>` for formula cells by default
+- `--values-only` CLI flag to write only cached values (old behavior)
+- `values_only` Python kwarg for the same
 
 ### Changed
 - `evaluate()` signature now takes `&EvaluateOptions` instead of `Option<usize>`
+- Default output mode changed from values-only to formula-preserving
 
 ### Fixed
 - Formulas on secondary sheets (not referenced by the main sheet) now evaluated instead of producing None (#42)

--- a/bindings/python/py_src/xlstream/_xlstream.pyi
+++ b/bindings/python/py_src/xlstream/_xlstream.pyi
@@ -10,6 +10,10 @@ def evaluate(
     output_path: str,
     *,
     workers: Optional[int] = None,
+    iterative_calc: bool = True,
+    max_iterations: int = 100,
+    max_change: float = 0.001,
+    values_only: bool = False,
 ) -> EvaluateResult:
     """Evaluate formulas in an xlsx workbook and write the results.
 
@@ -17,6 +21,10 @@ def evaluate(
         input_path: Path to the source xlsx file.
         output_path: Path where the evaluated xlsx is written.
         workers: Number of parallel worker threads. None = auto-detect.
+        iterative_calc: Enable iterative calculation for self-referential formulas.
+        max_iterations: Maximum iterations for iterative calculation.
+        max_change: Convergence threshold for iterative calculation.
+        values_only: Write only cached values, omitting formula text from output.
 
     Returns:
         Dict with rows_processed, formulas_evaluated, and duration_ms.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -72,7 +72,7 @@ fn to_pyerr(e: RustXlStreamError) -> PyErr {
 /// The GIL is released for the entire Rust evaluation so other Python
 /// threads can run concurrently.
 #[pyfunction]
-#[pyo3(signature = (input_path, output_path, *, workers=None, iterative_calc=true, max_iterations=100, max_change=0.001))]
+#[pyo3(signature = (input_path, output_path, *, workers=None, iterative_calc=true, max_iterations=100, max_change=0.001, values_only=false))]
 fn evaluate(
     py: Python<'_>,
     input_path: &str,
@@ -81,6 +81,7 @@ fn evaluate(
     iterative_calc: bool,
     max_iterations: u32,
     max_change: f64,
+    values_only: bool,
 ) -> PyResult<Py<PyDict>> {
     let input = PathBuf::from(input_path);
     let output = PathBuf::from(output_path);
@@ -89,7 +90,7 @@ fn evaluate(
         iterative_calc,
         max_iterations,
         max_change,
-        values_only: false,
+        values_only,
     };
 
     let summary =

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -84,8 +84,13 @@ fn evaluate(
 ) -> PyResult<Py<PyDict>> {
     let input = PathBuf::from(input_path);
     let output = PathBuf::from(output_path);
-    let options =
-        xlstream_eval::EvaluateOptions { workers, iterative_calc, max_iterations, max_change };
+    let options = xlstream_eval::EvaluateOptions {
+        workers,
+        iterative_calc,
+        max_iterations,
+        max_change,
+        values_only: false,
+    };
 
     let summary =
         py.detach(move || xlstream_eval::evaluate(&input, &output, &options)).map_err(to_pyerr)?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -90,7 +90,11 @@ fn evaluate(
         iterative_calc,
         max_iterations,
         max_change,
-        values_only,
+        output_mode: if values_only {
+            xlstream_core::OutputMode::ValuesOnly
+        } else {
+            xlstream_core::OutputMode::Formulas
+        },
     };
 
     let summary =

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -117,6 +117,7 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
                 max_iterations: max_iterations
                     .unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS),
                 max_change: max_change.unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_CHANGE),
+                values_only: false,
             };
             let summary = xlstream_eval::evaluate(&input, &output, &options)?;
             if verbose {

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -50,6 +50,9 @@ enum Command {
         /// Disable iterative calculation (self-referential formulas will error).
         #[arg(long)]
         no_iterative_calc: bool,
+        /// Write only cached values, omitting formula text from output.
+        #[arg(long)]
+        values_only: bool,
         /// Print phase timings and evaluation summary.
         #[arg(long, short = 'v')]
         verbose: bool,
@@ -109,6 +112,7 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
             max_iterations,
             max_change,
             no_iterative_calc,
+            values_only,
             verbose,
         } => {
             let options = xlstream_eval::EvaluateOptions {
@@ -117,7 +121,7 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
                 max_iterations: max_iterations
                     .unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS),
                 max_change: max_change.unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_CHANGE),
-                values_only: false,
+                values_only,
             };
             let summary = xlstream_eval::evaluate(&input, &output, &options)?;
             if verbose {
@@ -175,6 +179,26 @@ mod tests {
     use clap::Parser;
 
     use super::*;
+
+    #[test]
+    fn evaluate_values_only_flag_parsed() {
+        let cli = Cli::try_parse_from([
+            "xlstream",
+            "evaluate",
+            "in.xlsx",
+            "--output",
+            "out.xlsx",
+            "--values-only",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Evaluate { values_only, .. } => {
+                assert!(values_only);
+            }
+            Command::Classify { .. } => panic!("expected Evaluate"),
+        }
+    }
 
     #[test]
     fn evaluate_subcommand_parses_required_and_optional_args() {

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -121,7 +121,11 @@ fn run(cli: Cli) -> Result<(), xlstream_core::XlStreamError> {
                 max_iterations: max_iterations
                     .unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS),
                 max_change: max_change.unwrap_or(xlstream_core::ITERATIVE_CALC_DEFAULT_MAX_CHANGE),
-                values_only,
+                output_mode: if values_only {
+                    xlstream_core::OutputMode::ValuesOnly
+                } else {
+                    xlstream_core::OutputMode::Formulas
+                },
             };
             let summary = xlstream_eval::evaluate(&input, &output, &options)?;
             if verbose {

--- a/crates/xlstream-core/src/lib.rs
+++ b/crates/xlstream-core/src/lib.rs
@@ -34,7 +34,8 @@ pub use cell_error::CellError;
 pub use date::ExcelDate;
 pub use error::XlStreamError;
 pub use options::{
-    EvaluateOptions, ITERATIVE_CALC_DEFAULT_MAX_CHANGE, ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS,
+    EvaluateOptions, OutputMode, ITERATIVE_CALC_DEFAULT_MAX_CHANGE,
+    ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS,
 };
 pub use value::Value;
 

--- a/crates/xlstream-core/src/options.rs
+++ b/crates/xlstream-core/src/options.rs
@@ -25,6 +25,9 @@ pub struct EvaluateOptions {
     pub max_iterations: u32,
     /// Convergence threshold — stop when delta < this (only for numeric results).
     pub max_change: f64,
+    /// Write only cached values (`<v>`), omitting formula text (`<f>`).
+    /// When `false` (default), formula cells include both `<f>` and `<v>`.
+    pub values_only: bool,
 }
 
 impl Default for EvaluateOptions {
@@ -34,6 +37,7 @@ impl Default for EvaluateOptions {
             iterative_calc: true,
             max_iterations: ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS,
             max_change: ITERATIVE_CALC_DEFAULT_MAX_CHANGE,
+            values_only: false,
         }
     }
 }
@@ -50,6 +54,12 @@ mod tests {
         assert_eq!(opts.max_iterations, 100);
         assert!((opts.max_change - 0.001).abs() < f64::EPSILON);
         assert!(opts.workers.is_none());
+    }
+
+    #[test]
+    fn default_values_only_is_false() {
+        let opts = EvaluateOptions::default();
+        assert!(!opts.values_only);
     }
 
     #[test]

--- a/crates/xlstream-core/src/options.rs
+++ b/crates/xlstream-core/src/options.rs
@@ -5,15 +5,54 @@ pub const ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS: u32 = 100;
 /// Default convergence threshold for iterative calculation (matches Excel).
 pub const ITERATIVE_CALC_DEFAULT_MAX_CHANGE: f64 = 0.001;
 
+/// Controls what is written to formula cells in the output xlsx.
+///
+/// # Examples
+///
+/// ```
+/// use xlstream_core::OutputMode;
+/// assert_eq!(OutputMode::default(), OutputMode::Formulas);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputMode {
+    /// Write both formula text and cached values: `<f>formula</f><v>cached</v>`.
+    Formulas,
+    /// Write only cached values: `<v>cached</v>`.
+    ValuesOnly,
+}
+
+impl Default for OutputMode {
+    fn default() -> Self {
+        Self::Formulas
+    }
+}
+
+impl OutputMode {
+    /// Whether this mode omits formula text from the output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xlstream_core::OutputMode;
+    /// assert!(!OutputMode::Formulas.is_values_only());
+    /// assert!(OutputMode::ValuesOnly.is_values_only());
+    /// ```
+    #[must_use]
+    pub fn is_values_only(self) -> bool {
+        matches!(self, Self::ValuesOnly)
+    }
+}
+
 /// Options controlling formula evaluation behavior.
 ///
 /// # Examples
 ///
 /// ```
-/// use xlstream_core::EvaluateOptions;
+/// use xlstream_core::{EvaluateOptions, OutputMode};
 /// let opts = EvaluateOptions::default();
 /// assert!(opts.iterative_calc);
 /// assert_eq!(opts.max_iterations, 100);
+/// assert_eq!(opts.output_mode, OutputMode::Formulas);
 /// ```
 #[derive(Debug, Clone)]
 pub struct EvaluateOptions {
@@ -25,9 +64,8 @@ pub struct EvaluateOptions {
     pub max_iterations: u32,
     /// Convergence threshold — stop when delta < this (only for numeric results).
     pub max_change: f64,
-    /// Write only cached values (`<v>`), omitting formula text (`<f>`).
-    /// When `false` (default), formula cells include both `<f>` and `<v>`.
-    pub values_only: bool,
+    /// What to write in formula cells.
+    pub output_mode: OutputMode,
 }
 
 impl Default for EvaluateOptions {
@@ -37,7 +75,7 @@ impl Default for EvaluateOptions {
             iterative_calc: true,
             max_iterations: ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS,
             max_change: ITERATIVE_CALC_DEFAULT_MAX_CHANGE,
-            values_only: false,
+            output_mode: OutputMode::default(),
         }
     }
 }
@@ -57,9 +95,15 @@ mod tests {
     }
 
     #[test]
-    fn default_values_only_is_false() {
+    fn default_output_mode_is_formulas() {
         let opts = EvaluateOptions::default();
-        assert!(!opts.values_only);
+        assert_eq!(opts.output_mode, OutputMode::Formulas);
+    }
+
+    #[test]
+    fn output_mode_is_values_only() {
+        assert!(!OutputMode::Formulas.is_values_only());
+        assert!(OutputMode::ValuesOnly.is_values_only());
     }
 
     #[test]

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -143,6 +143,7 @@ pub fn evaluate(
                         iterative_calc: plan.iterative_calc,
                         max_iterations: plan.max_iterations,
                         max_change: plan.max_change,
+                        values_only: false,
                     };
                     let mut header_pending = true;
                     while let Some((row_idx, mut row_values)) = stream.next_row()? {
@@ -185,6 +186,7 @@ pub fn evaluate(
             iterative_calc: plan.iterative_calc,
             max_iterations: plan.max_iterations,
             max_change: plan.max_change,
+            values_only: false,
         });
         let self_referential_cols_arc = Arc::new(plan.self_referential_cols);
         let prelude = Arc::new(plan.prelude);
@@ -519,6 +521,7 @@ fn stream_single_threaded(
         iterative_calc: plan.iterative_calc,
         max_iterations: plan.max_iterations,
         max_change: plan.max_change,
+        values_only: false,
     };
     let mut rows_processed: u64 = 0;
     let mut formulas_evaluated: u64 = 0;

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -48,6 +48,9 @@ struct EvalPlan {
     row_overrides: HashMap<u32, HashMap<u32, Ast>>,
     topo_order: Vec<u32>,
     self_referential_cols: HashSet<u32>,
+    col_templates: HashMap<u32, crate::formula_template::FormulaTemplate>,
+    row_override_texts: HashMap<u32, HashMap<u32, String>>,
+    values_only: bool,
     secondary_plans: HashMap<String, SheetEvalPlan>,
     main_sheet: Option<String>,
     sheet_names: Vec<String>,
@@ -65,6 +68,20 @@ struct SheetEvalPlan {
     row_overrides: HashMap<u32, HashMap<u32, Ast>>,
     topo_order: Vec<u32>,
     self_referential_cols: HashSet<u32>,
+    col_templates: HashMap<u32, crate::formula_template::FormulaTemplate>,
+    row_override_texts: HashMap<u32, HashMap<u32, String>>,
+}
+
+/// Output of [`build_eval_plan`]: topo order, ASTs, overrides, lookup keys,
+/// self-referential columns, formula templates, and override texts.
+struct BuildPlanResult {
+    topo_order: Vec<u32>,
+    col_asts: HashMap<u32, Ast>,
+    row_overrides: HashMap<u32, HashMap<u32, Ast>>,
+    lookup_keys: Vec<LookupKey>,
+    self_referential_cols: HashSet<u32>,
+    col_templates: HashMap<u32, crate::formula_template::FormulaTemplate>,
+    row_override_texts: HashMap<u32, HashMap<u32, String>>,
 }
 
 /// Evaluate every formula in `input`, write results to `output`, and return
@@ -97,6 +114,7 @@ struct SheetEvalPlan {
 /// ).unwrap_err();
 /// assert!(matches!(err, xlstream_core::XlStreamError::Xlsx(_)));
 /// ```
+#[allow(clippy::too_many_lines)]
 #[must_use = "evaluation results must be inspected for errors"]
 pub fn evaluate(
     input: &Path,
@@ -108,6 +126,7 @@ pub fn evaluate(
     plan.iterative_calc = options.iterative_calc;
     plan.max_iterations = options.max_iterations;
     plan.max_change = options.max_change;
+    plan.values_only = options.values_only;
     let mut writer = Writer::create(output)?;
 
     let num_workers = options.workers.unwrap_or_else(num_cpus::get).max(1);
@@ -169,7 +188,17 @@ pub fn evaluate(
                                 &sec_options,
                             );
                         }
-                        sh.write_row(row_idx, &row_values)?;
+                        if plan.values_only || sp.col_templates.is_empty() {
+                            sh.write_row(row_idx, &row_values)?;
+                        } else {
+                            write_formula_cells(
+                                &mut sh,
+                                row_idx,
+                                &row_values,
+                                &sp.col_templates,
+                                &sp.row_override_texts,
+                            )?;
+                        }
                     }
                 } else {
                     while let Some((row_idx, row_values)) = stream.next_row()? {
@@ -186,12 +215,14 @@ pub fn evaluate(
             iterative_calc: plan.iterative_calc,
             max_iterations: plan.max_iterations,
             max_change: plan.max_change,
-            values_only: false,
+            values_only: plan.values_only,
         });
         let self_referential_cols_arc = Arc::new(plan.self_referential_cols);
         let prelude = Arc::new(plan.prelude);
         let col_asts = Arc::new(plan.col_asts);
         let row_overrides_arc = Arc::new(plan.row_overrides);
+        let col_templates_arc = Arc::new(plan.col_templates);
+        let row_override_texts_arc = Arc::new(plan.row_override_texts);
 
         stream_parallel(
             input,
@@ -205,6 +236,8 @@ pub fn evaluate(
             &main_sheet_name,
             plan.total_data_rows,
             num_workers,
+            &col_templates_arc,
+            &row_override_texts_arc,
         )?
     } else {
         tracing::debug!("single-threaded evaluation");
@@ -256,27 +289,35 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
         sheets_with_formulas.first().map(|(_, f)| f.clone()).unwrap_or_default();
 
     // Parse + classify formula columns; build topo order.
-    let (topo_order, col_asts, row_overrides, lookup_keys, self_referential_cols) =
-        if let Some(ref main) = main_sheet {
-            build_eval_plan(main, &main_formulas, &sheet_names, &named_ranges, &table_infos)?
-        } else {
-            (Vec::new(), HashMap::new(), HashMap::new(), Vec::new(), HashSet::new())
-        };
+    let main_result = if let Some(ref main) = main_sheet {
+        build_eval_plan(main, &main_formulas, &sheet_names, &named_ranges, &table_infos)?
+    } else {
+        BuildPlanResult {
+            topo_order: Vec::new(),
+            col_asts: HashMap::new(),
+            row_overrides: HashMap::new(),
+            lookup_keys: Vec::new(),
+            self_referential_cols: HashSet::new(),
+            col_templates: HashMap::new(),
+            row_override_texts: HashMap::new(),
+        }
+    };
 
     // Build eval plans for secondary formula-bearing sheets.
     let mut secondary_plans: HashMap<String, SheetEvalPlan> = HashMap::new();
     let mut secondary_lookup_keys: Vec<LookupKey> = Vec::new();
     for (sheet_name, formulas) in sheets_with_formulas.iter().skip(1) {
-        let (sec_topo, sec_asts, sec_overrides, lk, sec_self_ref_cols) =
+        let sec_result =
             build_eval_plan(sheet_name, formulas, &sheet_names, &named_ranges, &table_infos)?;
         // Detect cross-sheet cell references and add as lookup keys.
-        for ast in sec_asts.values() {
+        for ast in sec_result.col_asts.values() {
             let refs = extract_references(ast);
             for r in &refs.cells {
                 if let Reference::Cell { sheet: Some(ref s), .. } = r {
-                    let already =
-                        secondary_lookup_keys.iter().any(|k| k.sheet.eq_ignore_ascii_case(s))
-                            || lk.iter().any(|k| k.sheet.eq_ignore_ascii_case(s));
+                    let already = secondary_lookup_keys
+                        .iter()
+                        .any(|k| k.sheet.eq_ignore_ascii_case(s))
+                        || sec_result.lookup_keys.iter().any(|k| k.sheet.eq_ignore_ascii_case(s));
                     if !already {
                         secondary_lookup_keys.push(LookupKey {
                             kind: xlstream_parse::LookupKind::VLookup,
@@ -288,14 +329,17 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
                 }
             }
         }
-        for per_row in sec_overrides.values() {
+        for per_row in sec_result.row_overrides.values() {
             for ast in per_row.values() {
                 let refs = extract_references(ast);
                 for r in &refs.cells {
                     if let Reference::Cell { sheet: Some(ref s), .. } = r {
                         let already =
                             secondary_lookup_keys.iter().any(|k| k.sheet.eq_ignore_ascii_case(s))
-                                || lk.iter().any(|k| k.sheet.eq_ignore_ascii_case(s));
+                                || sec_result
+                                    .lookup_keys
+                                    .iter()
+                                    .any(|k| k.sheet.eq_ignore_ascii_case(s));
                         if !already {
                             secondary_lookup_keys.push(LookupKey {
                                 kind: xlstream_parse::LookupKind::VLookup,
@@ -308,14 +352,16 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
                 }
             }
         }
-        secondary_lookup_keys.extend(lk);
+        secondary_lookup_keys.extend(sec_result.lookup_keys);
         secondary_plans.insert(
             sheet_name.clone(),
             SheetEvalPlan {
-                col_asts: sec_asts,
-                row_overrides: sec_overrides,
-                topo_order: sec_topo,
-                self_referential_cols: sec_self_ref_cols,
+                col_asts: sec_result.col_asts,
+                row_overrides: sec_result.row_overrides,
+                topo_order: sec_result.topo_order,
+                self_referential_cols: sec_result.self_referential_cols,
+                col_templates: sec_result.col_templates,
+                row_override_texts: sec_result.row_override_texts,
             },
         );
     }
@@ -323,8 +369,8 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
     // Collect main sheet aggregate keys and run prelude.
     let main_agg_keys: Vec<AggregateKey> = {
         let mut seen = HashSet::new();
-        let primary = col_asts.values();
-        let overrides = row_overrides.values().flat_map(HashMap::values);
+        let primary = main_result.col_asts.values();
+        let overrides = main_result.row_overrides.values().flat_map(HashMap::values);
         primary
             .chain(overrides)
             .flat_map(crate::prelude_plan::collect_aggregate_keys)
@@ -333,8 +379,8 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
     };
     let main_multi_keys: Vec<crate::prelude::MultiConditionalAggKey> = {
         let mut seen = HashSet::new();
-        let primary = col_asts.values();
-        let overrides = row_overrides.values().flat_map(HashMap::values);
+        let primary = main_result.col_asts.values();
+        let overrides = main_result.row_overrides.values().flat_map(HashMap::values);
         primary
             .chain(overrides)
             .flat_map(crate::prelude_plan::collect_multi_conditional_keys)
@@ -343,8 +389,8 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
     };
     let main_range_keys: Vec<crate::prelude::BoundedRangeKey> = {
         let mut seen = HashSet::new();
-        let primary = col_asts.values();
-        let overrides = row_overrides.values().flat_map(HashMap::values);
+        let primary = main_result.col_asts.values();
+        let overrides = main_result.row_overrides.values().flat_map(HashMap::values);
         primary
             .chain(overrides)
             .flat_map(crate::prelude_plan::collect_bounded_range_keys)
@@ -418,7 +464,7 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
     // Cross-sheet bounded ranges in range-expanding functions (e.g.
     // NETWORKDAYS holidays) need the referenced sheet loaded as a lookup
     // sheet so expand_range can resolve them.
-    let mut extended_lookup_keys = lookup_keys;
+    let mut extended_lookup_keys = main_result.lookup_keys;
     for rk in &main_range_keys {
         if let Some(ref sheet_name) = rk.sheet {
             let already_present =
@@ -474,10 +520,13 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
 
     let plan = EvalPlan {
         prelude,
-        col_asts,
-        row_overrides,
-        topo_order,
-        self_referential_cols,
+        col_asts: main_result.col_asts,
+        row_overrides: main_result.row_overrides,
+        topo_order: main_result.topo_order,
+        self_referential_cols: main_result.self_referential_cols,
+        col_templates: main_result.col_templates,
+        row_override_texts: main_result.row_override_texts,
+        values_only: false,
         secondary_plans,
         main_sheet,
         sheet_names,
@@ -504,6 +553,59 @@ fn count_data_rows(reader: &mut Reader, main_sheet: &str) -> Result<u32, XlStrea
         count = count.saturating_add(1);
     }
     Ok(count)
+}
+
+/// Write a row with formula text for formula columns and plain values for
+/// data columns. Override texts take precedence over column templates.
+///
+/// `rust_xlsxwriter` infers cell type from the result string via
+/// `parse::<f64>`. Text results that look numeric and empty results would
+/// be mis-typed. For those cells, only the value is written (formula
+/// omitted) to preserve value correctness.
+fn write_formula_cells(
+    sh: &mut xlstream_io::SheetHandle<'_>,
+    row_idx: u32,
+    values: &[Value],
+    col_templates: &HashMap<u32, crate::formula_template::FormulaTemplate>,
+    row_override_texts: &HashMap<u32, HashMap<u32, String>>,
+) -> Result<(), XlStreamError> {
+    sh.enforce_row_order(row_idx)?;
+    for (col_idx, val) in values.iter().enumerate() {
+        let col = u16::try_from(col_idx).map_err(|_| {
+            XlStreamError::Internal(format!("column index {col_idx} exceeds u16::MAX"))
+        })?;
+        let col_u32 = u32::from(col);
+        let formula_text = row_override_texts
+            .get(&col_u32)
+            .and_then(|m| m.get(&row_idx))
+            .cloned()
+            .or_else(|| col_templates.get(&col_u32).map(|t| t.reconstruct(row_idx + 1)));
+        if let Some(text) = formula_text {
+            if result_cacheable(val) {
+                sh.write_formula(row_idx, col, &text, val)?;
+            } else {
+                sh.write_value(row_idx, col, val)?;
+            }
+        } else {
+            sh.write_value(row_idx, col, val)?;
+        }
+    }
+    Ok(())
+}
+
+/// Whether `rust_xlsxwriter` can cache this value type correctly in a
+/// formula cell. Numeric, boolean, error, and date results are fine.
+/// Text results that parse as f64 and empty results lose their type.
+fn result_cacheable(val: &Value) -> bool {
+    match val {
+        Value::Number(_)
+        | Value::Integer(_)
+        | Value::Date(_)
+        | Value::Bool(_)
+        | Value::Error(_) => true,
+        Value::Text(s) => s.parse::<f64>().is_err() && !s.is_empty(),
+        Value::Empty => false,
+    }
 }
 
 /// Stream all sheets single-threaded: evaluate formula columns on the main
@@ -591,7 +693,20 @@ fn stream_single_threaded(
                 }
             }
 
-            sh.write_row(row_idx, &row_values)?;
+            if plan.values_only || sheet_plan.is_none() {
+                sh.write_row(row_idx, &row_values)?;
+            } else {
+                let (templates, override_texts) = if is_main {
+                    (&plan.col_templates, &plan.row_override_texts)
+                } else if let Some(sp) = plan.secondary_plans.get(name.as_str()) {
+                    (&sp.col_templates, &sp.row_override_texts)
+                } else {
+                    sh.write_row(row_idx, &row_values)?;
+                    rows_processed += 1;
+                    continue;
+                };
+                write_formula_cells(&mut sh, row_idx, &row_values, templates, override_texts)?;
+            }
             rows_processed += 1;
         }
 
@@ -606,7 +721,7 @@ fn stream_single_threaded(
 /// bounded channel; the caller drains them in row order.
 ///
 /// Non-main sheets must be written by the caller before calling this.
-#[allow(clippy::too_many_arguments)] // worker contract: all args logically required
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn stream_parallel(
     input: &Path,
     output: &mut Writer,
@@ -619,6 +734,8 @@ fn stream_parallel(
     main_sheet: &str,
     total_data_rows: u32,
     num_workers: usize,
+    col_templates: &Arc<HashMap<u32, crate::formula_template::FormulaTemplate>>,
+    row_override_texts: &Arc<HashMap<u32, HashMap<u32, String>>>,
 ) -> Result<(u64, u64), XlStreamError> {
     let chunk_size = (total_data_rows as usize).div_ceil(num_workers);
 
@@ -692,7 +809,17 @@ fn stream_parallel(
             Ok((row_idx, values, formulas_count)) => {
                 buffer.insert(row_idx, (values, formulas_count));
                 while let Some((vals, fc)) = buffer.remove(&expected_row) {
-                    sh.write_row(expected_row, &vals)?;
+                    if eval_options.values_only || col_templates.is_empty() {
+                        sh.write_row(expected_row, &vals)?;
+                    } else {
+                        write_formula_cells(
+                            &mut sh,
+                            expected_row,
+                            &vals,
+                            col_templates,
+                            row_override_texts,
+                        )?;
+                    }
                     rows_processed += 1;
                     formulas_evaluated += fc;
                     expected_row += 1;
@@ -710,7 +837,11 @@ fn stream_parallel(
         if first_error.is_some() {
             break;
         }
-        sh.write_row(row_idx, &vals)?;
+        if eval_options.values_only || col_templates.is_empty() {
+            sh.write_row(row_idx, &vals)?;
+        } else {
+            write_formula_cells(&mut sh, row_idx, &vals, col_templates, row_override_texts)?;
+        }
         rows_processed += 1;
         formulas_evaluated += fc;
     }
@@ -848,10 +979,7 @@ fn build_eval_plan(
     all_sheet_names: &[String],
     named_ranges: &HashMap<String, String>,
     table_infos: &HashMap<String, xlstream_parse::TableInfo>,
-) -> Result<
-    (Vec<u32>, HashMap<u32, Ast>, HashMap<u32, HashMap<u32, Ast>>, Vec<LookupKey>, HashSet<u32>),
-    XlStreamError,
-> {
+) -> Result<BuildPlanResult, XlStreamError> {
     let mut col_formulas: HashMap<u32, Vec<(u32, String)>> = HashMap::new();
     for (row, col, text) in all_formulas {
         col_formulas.entry(*col).or_default().push((*row, text.clone()));
@@ -860,6 +988,8 @@ fn build_eval_plan(
     let mut col_asts: HashMap<u32, Ast> = HashMap::new();
     let mut row_overrides: HashMap<u32, HashMap<u32, Ast>> = HashMap::new();
     let mut all_lookup_keys: Vec<LookupKey> = Vec::new();
+    let mut col_templates: HashMap<u32, crate::formula_template::FormulaTemplate> = HashMap::new();
+    let mut row_override_texts: HashMap<u32, HashMap<u32, String>> = HashMap::new();
 
     for (&col, formulas) in &col_formulas {
         let (first_row, first_text) = &formulas[0];
@@ -895,6 +1025,10 @@ fn build_eval_plan(
         let rewritten = rewrite(first_ast.clone(), &ctx, &verdict);
         all_lookup_keys.extend(collect_lookup_keys(&rewritten));
         col_asts.insert(col, rewritten);
+        col_templates.insert(
+            col,
+            crate::formula_template::FormulaTemplate::new(formula_str.clone(), first_row + 1),
+        );
 
         for (row, text) in &formulas[1..] {
             if text == first_text {
@@ -936,6 +1070,7 @@ fn build_eval_plan(
             let rewritten = rewrite(ast, &row_ctx, &row_verdict);
             all_lookup_keys.extend(collect_lookup_keys(&rewritten));
             row_overrides.entry(col).or_default().insert(*row, rewritten);
+            row_override_texts.entry(col).or_default().insert(*row, formula_str.to_string());
         }
     }
 
@@ -967,7 +1102,15 @@ fn build_eval_plan(
         .collect();
 
     let topo_order = topo_sort(&deps, &formula_cols)?;
-    Ok((topo_order, col_asts, row_overrides, all_lookup_keys, self_referential_cols))
+    Ok(BuildPlanResult {
+        topo_order,
+        col_asts,
+        row_overrides,
+        lookup_keys: all_lookup_keys,
+        self_referential_cols,
+        col_templates,
+        row_override_texts,
+    })
 }
 
 /// Strip `_xlfn.` (and `_xlfn._xlws.`) prefixes that `rust_xlsxwriter`

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
-use xlstream_core::{col_row_to_a1, EvaluateOptions, Value, XlStreamError, PARALLEL_ROW_THRESHOLD};
+use xlstream_core::{
+    col_row_to_a1, EvaluateOptions, OutputMode, Value, XlStreamError, PARALLEL_ROW_THRESHOLD,
+};
 use xlstream_io::{Reader, Writer};
 use xlstream_parse::{
     classify, collect_lookup_keys, extract_references, parse, resolve_named_ranges, rewrite,
@@ -50,7 +52,7 @@ struct EvalPlan {
     self_referential_cols: HashSet<u32>,
     col_templates: HashMap<u32, crate::formula_template::FormulaTemplate>,
     row_override_texts: HashMap<u32, HashMap<u32, String>>,
-    values_only: bool,
+    output_mode: OutputMode,
     secondary_plans: HashMap<String, SheetEvalPlan>,
     main_sheet: Option<String>,
     sheet_names: Vec<String>,
@@ -125,7 +127,7 @@ pub fn evaluate(
     plan.iterative_calc = options.iterative_calc;
     plan.max_iterations = options.max_iterations;
     plan.max_change = options.max_change;
-    plan.values_only = options.values_only;
+    plan.output_mode = options.output_mode;
     let mut writer = Writer::create(output)?;
 
     let num_workers = options.workers.unwrap_or_else(num_cpus::get).max(1);
@@ -161,7 +163,7 @@ pub fn evaluate(
                         iterative_calc: plan.iterative_calc,
                         max_iterations: plan.max_iterations,
                         max_change: plan.max_change,
-                        values_only: plan.values_only,
+                        output_mode: plan.output_mode,
                     };
                     let mut header_pending = true;
                     while let Some((row_idx, mut row_values)) = stream.next_row()? {
@@ -187,7 +189,7 @@ pub fn evaluate(
                                 &sec_options,
                             );
                         }
-                        if plan.values_only || sp.col_templates.is_empty() {
+                        if plan.output_mode.is_values_only() || sp.col_templates.is_empty() {
                             sh.write_row(row_idx, &row_values)?;
                         } else {
                             write_formula_cells(
@@ -214,7 +216,7 @@ pub fn evaluate(
             iterative_calc: plan.iterative_calc,
             max_iterations: plan.max_iterations,
             max_change: plan.max_change,
-            values_only: plan.values_only,
+            output_mode: plan.output_mode,
         });
         let self_referential_cols_arc = Arc::new(plan.self_referential_cols);
         let prelude = Arc::new(plan.prelude);
@@ -525,7 +527,7 @@ fn build_plan(input: &Path) -> Result<(EvalPlan, Reader), XlStreamError> {
         self_referential_cols: main_result.self_referential_cols,
         col_templates: main_result.col_templates,
         row_override_texts: main_result.row_override_texts,
-        values_only: false,
+        output_mode: OutputMode::default(),
         secondary_plans,
         main_sheet,
         sheet_names,
@@ -627,7 +629,7 @@ fn stream_single_threaded(
         iterative_calc: plan.iterative_calc,
         max_iterations: plan.max_iterations,
         max_change: plan.max_change,
-        values_only: plan.values_only,
+        output_mode: plan.output_mode,
     };
     let mut rows_processed: u64 = 0;
     let mut formulas_evaluated: u64 = 0;
@@ -697,7 +699,7 @@ fn stream_single_threaded(
                 }
             }
 
-            if plan.values_only || sheet_plan.is_none() {
+            if plan.output_mode.is_values_only() || sheet_plan.is_none() {
                 sh.write_row(row_idx, &row_values)?;
             } else {
                 let (templates, override_texts) = if is_main {
@@ -813,7 +815,7 @@ fn stream_parallel(
             Ok((row_idx, values, formulas_count)) => {
                 buffer.insert(row_idx, (values, formulas_count));
                 while let Some((vals, fc)) = buffer.remove(&expected_row) {
-                    if eval_options.values_only || col_templates.is_empty() {
+                    if eval_options.output_mode.is_values_only() || col_templates.is_empty() {
                         sh.write_row(expected_row, &vals)?;
                     } else {
                         write_formula_cells(
@@ -841,7 +843,7 @@ fn stream_parallel(
         if first_error.is_some() {
             break;
         }
-        if eval_options.values_only || col_templates.is_empty() {
+        if eval_options.output_mode.is_values_only() || col_templates.is_empty() {
             sh.write_row(row_idx, &vals)?;
         } else {
             write_formula_cells(&mut sh, row_idx, &vals, col_templates, row_override_texts)?;

--- a/crates/xlstream-eval/src/evaluate.rs
+++ b/crates/xlstream-eval/src/evaluate.rs
@@ -72,8 +72,7 @@ struct SheetEvalPlan {
     row_override_texts: HashMap<u32, HashMap<u32, String>>,
 }
 
-/// Output of [`build_eval_plan`]: topo order, ASTs, overrides, lookup keys,
-/// self-referential columns, formula templates, and override texts.
+/// Output of [`build_eval_plan`].
 struct BuildPlanResult {
     topo_order: Vec<u32>,
     col_asts: HashMap<u32, Ast>,
@@ -162,7 +161,7 @@ pub fn evaluate(
                         iterative_calc: plan.iterative_calc,
                         max_iterations: plan.max_iterations,
                         max_change: plan.max_change,
-                        values_only: false,
+                        values_only: plan.values_only,
                     };
                     let mut header_pending = true;
                     while let Some((row_idx, mut row_values)) = stream.next_row()? {
@@ -584,6 +583,11 @@ fn write_formula_cells(
             if result_cacheable(val) {
                 sh.write_formula(row_idx, col, &text, val)?;
             } else {
+                tracing::debug!(
+                    row = row_idx,
+                    col = col_idx,
+                    "formula written as value-only: result type not cacheable by rust_xlsxwriter"
+                );
                 sh.write_value(row_idx, col, val)?;
             }
         } else {
@@ -623,7 +627,7 @@ fn stream_single_threaded(
         iterative_calc: plan.iterative_calc,
         max_iterations: plan.max_iterations,
         max_change: plan.max_change,
-        values_only: false,
+        values_only: plan.values_only,
     };
     let mut rows_processed: u64 = 0;
     let mut formulas_evaluated: u64 = 0;
@@ -1113,12 +1117,11 @@ fn build_eval_plan(
     })
 }
 
-/// Strip `_xlfn.` (and `_xlfn._xlws.`) prefixes that `rust_xlsxwriter`
-/// injects for "future" Excel functions (CONCAT, TEXTJOIN, IFS, etc.).
+/// Strip `_xlfn.` (and `_xlfn._xlws.`) prefixes from formula text.
 ///
-/// These prefixes are internal to the xlsx format and are not part of the
-/// canonical function name. Calamine preserves them verbatim, so we strip
-/// them here before parsing.
+/// These prefixes are part of the xlsx XML format for "future" Excel
+/// functions (CONCAT, TEXTJOIN, IFS, etc.). Calamine preserves them
+/// verbatim; we strip them before parsing.
 fn strip_xlfn_prefix(formula: &str) -> String {
     formula.replace("_xlfn._xlws.", "").replace("_xlfn.", "")
 }
@@ -1293,5 +1296,55 @@ mod tests {
         let a = parse("Sheet1!A2*2").unwrap();
         let b = parse("Sheet1!A3*2").unwrap();
         assert!(!super::ast_streaming_eq(a.root(), b.root()));
+    }
+
+    #[test]
+    fn result_cacheable_number() {
+        assert!(super::result_cacheable(&Value::Number(42.0)));
+    }
+
+    #[test]
+    fn result_cacheable_integer() {
+        assert!(super::result_cacheable(&Value::Integer(7)));
+    }
+
+    #[test]
+    fn result_cacheable_bool() {
+        assert!(super::result_cacheable(&Value::Bool(true)));
+        assert!(super::result_cacheable(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn result_cacheable_error() {
+        assert!(super::result_cacheable(&Value::Error(xlstream_core::CellError::Div0)));
+        assert!(super::result_cacheable(&Value::Error(xlstream_core::CellError::Na)));
+    }
+
+    #[test]
+    fn result_cacheable_date() {
+        assert!(super::result_cacheable(&Value::Date(xlstream_core::ExcelDate {
+            serial: 44927.0,
+        })));
+    }
+
+    #[test]
+    fn result_cacheable_text_normal() {
+        assert!(super::result_cacheable(&Value::Text("hello".into())));
+    }
+
+    #[test]
+    fn result_cacheable_text_numeric_string_rejected() {
+        assert!(!super::result_cacheable(&Value::Text("123".into())));
+        assert!(!super::result_cacheable(&Value::Text("3.14".into())));
+    }
+
+    #[test]
+    fn result_cacheable_text_empty_string_rejected() {
+        assert!(!super::result_cacheable(&Value::Text("".into())));
+    }
+
+    #[test]
+    fn result_cacheable_empty_rejected() {
+        assert!(!super::result_cacheable(&Value::Empty));
     }
 }

--- a/crates/xlstream-eval/src/formula_template.rs
+++ b/crates/xlstream-eval/src/formula_template.rs
@@ -1,5 +1,13 @@
 //! Formula template for reconstructing per-row formula text.
 
+/// Byte position of a relative row-number reference within formula text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RowRef {
+    byte_start: usize,
+    byte_end: usize,
+    row: u32,
+}
+
 /// A column-level formula template that reconstructs per-row formula text
 /// by substituting row numbers at known byte positions.
 ///
@@ -8,7 +16,7 @@
 /// byte positions of relative row-number references within it.
 pub(crate) struct FormulaTemplate {
     text: String,
-    row_refs: Vec<(usize, usize, u32)>,
+    row_refs: Vec<RowRef>,
     base_row: u32,
 }
 
@@ -32,11 +40,11 @@ impl FormulaTemplate {
         let mut result = String::with_capacity(self.text.len() + 8);
         let mut last_end = 0;
 
-        for &(start, end, base_ref_row) in &self.row_refs {
-            result.push_str(&self.text[last_end..start]);
-            let new_row = (i64::from(base_ref_row) + row_delta).clamp(1, max_row) as u32;
+        for r in &self.row_refs {
+            result.push_str(&self.text[last_end..r.byte_start]);
+            let new_row = (i64::from(r.row) + row_delta).clamp(1, max_row) as u32;
             result.push_str(&new_row.to_string());
-            last_end = end;
+            last_end = r.byte_end;
         }
         result.push_str(&self.text[last_end..]);
         result
@@ -50,7 +58,7 @@ impl FormulaTemplate {
 ///
 /// Calamine normalizes cell references to uppercase, so only uppercase
 /// column letters are matched.
-fn extract_row_refs(text: &str) -> Vec<(usize, usize, u32)> {
+fn extract_row_refs(text: &str) -> Vec<RowRef> {
     let bytes = text.as_bytes();
     let len = bytes.len();
     let mut refs = Vec::new();
@@ -75,14 +83,20 @@ fn extract_row_refs(text: &str) -> Vec<(usize, usize, u32)> {
             continue;
         }
 
-        // Skip single-quoted sheet names: 'Sheet Name'!
+        // Skip single-quoted sheet names (Excel escapes ' as '').
         if bytes[i] == b'\'' {
             i += 1;
-            while i < len && bytes[i] != b'\'' {
-                i += 1;
-            }
-            if i < len {
-                i += 1;
+            while i < len {
+                if bytes[i] == b'\'' {
+                    if i + 1 < len && bytes[i + 1] == b'\'' {
+                        i += 2;
+                    } else {
+                        i += 1;
+                        break;
+                    }
+                } else {
+                    i += 1;
+                }
             }
             if i < len && bytes[i] == b'!' {
                 i += 1;
@@ -147,7 +161,11 @@ fn extract_row_refs(text: &str) -> Vec<(usize, usize, u32)> {
         if !has_dollar {
             if let Ok(row_num) = text[digit_start..digit_end].parse::<u32>() {
                 if row_num > 0 {
-                    refs.push((digit_start, digit_end, row_num));
+                    refs.push(RowRef {
+                        byte_start: digit_start,
+                        byte_end: digit_end,
+                        row: row_num,
+                    });
                 }
             }
         }
@@ -164,25 +182,31 @@ mod tests {
     #[test]
     fn simple_refs_both_detected() {
         let refs = extract_row_refs("A2+B2");
-        assert_eq!(refs, vec![(1, 2, 2), (4, 5, 2)]);
+        assert_eq!(
+            refs,
+            vec![
+                RowRef { byte_start: 1, byte_end: 2, row: 2 },
+                RowRef { byte_start: 4, byte_end: 5, row: 2 },
+            ]
+        );
     }
 
     #[test]
     fn absolute_row_skipped() {
         let refs = extract_row_refs("$A$2+B2");
-        assert_eq!(refs, vec![(6, 7, 2)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 6, byte_end: 7, row: 2 }]);
     }
 
     #[test]
     fn mixed_absolute_and_relative_in_range() {
         let refs = extract_row_refs("SUM($A$1:A2)");
-        assert_eq!(refs, vec![(10, 11, 2)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 10, byte_end: 11, row: 2 }]);
     }
 
     #[test]
     fn cross_sheet_ref() {
         let refs = extract_row_refs("Sheet1!A2");
-        assert_eq!(refs, vec![(8, 9, 2)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 8, byte_end: 9, row: 2 }]);
     }
 
     #[test]
@@ -194,7 +218,7 @@ mod tests {
     #[test]
     fn multi_digit_row() {
         let refs = extract_row_refs("A100");
-        assert_eq!(refs, vec![(1, 4, 100)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 1, byte_end: 4, row: 100 }]);
     }
 
     #[test]
@@ -206,53 +230,66 @@ mod tests {
     #[test]
     fn quoted_sheet_name_skipped() {
         let refs = extract_row_refs("'My Sheet'!A2");
-        assert_eq!(refs, vec![(12, 13, 2)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 12, byte_end: 13, row: 2 }]);
     }
 
     #[test]
     fn function_name_not_matched() {
         let refs = extract_row_refs("SUM(A2)");
-        assert_eq!(refs, vec![(5, 6, 2)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 5, byte_end: 6, row: 2 }]);
     }
 
     #[test]
     fn range_both_endpoints_detected() {
         let refs = extract_row_refs("A2:B10");
-        assert_eq!(refs, vec![(1, 2, 2), (4, 6, 10)]);
+        assert_eq!(
+            refs,
+            vec![
+                RowRef { byte_start: 1, byte_end: 2, row: 2 },
+                RowRef { byte_start: 4, byte_end: 6, row: 10 },
+            ]
+        );
     }
 
     #[test]
     fn absolute_col_relative_row() {
         let refs = extract_row_refs("$A2");
-        assert_eq!(refs, vec![(2, 3, 2)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 2, byte_end: 3, row: 2 }]);
     }
 
     #[test]
     fn sheet_name_looks_like_cell_ref_skipped() {
         let refs = extract_row_refs("AB!C2");
-        assert_eq!(refs, vec![(4, 5, 2)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 4, byte_end: 5, row: 2 }]);
     }
 
     #[test]
     fn max_row_number() {
         let refs = extract_row_refs("A1048576");
-        assert_eq!(refs, vec![(1, 8, 1_048_576)]);
+        assert_eq!(refs, vec![RowRef { byte_start: 1, byte_end: 8, row: 1_048_576 }]);
     }
 
     #[test]
     fn string_literal_not_scanned() {
         let refs = extract_row_refs(r#"IF(A2="B3",C2,0)"#);
         assert_eq!(refs.len(), 2);
-        assert_eq!(refs[0].2, 2);
-        assert_eq!(refs[1].2, 2);
+        assert_eq!(refs[0].row, 2);
+        assert_eq!(refs[1].row, 2);
     }
 
     #[test]
     fn escaped_quotes_in_string_literal() {
         let refs = extract_row_refs(r#"IF(A2="""",C2,0)"#);
         assert_eq!(refs.len(), 2);
-        assert_eq!(refs[0].2, 2);
-        assert_eq!(refs[1].2, 2);
+        assert_eq!(refs[0].row, 2);
+        assert_eq!(refs[1].row, 2);
+    }
+
+    #[test]
+    fn escaped_single_quotes_in_sheet_name() {
+        // Excel escapes ' as '' inside single-quoted sheet names.
+        let refs = extract_row_refs("'It''s a sheet'!A2");
+        assert_eq!(refs, vec![RowRef { byte_start: 17, byte_end: 18, row: 2 }]);
     }
 
     #[test]

--- a/crates/xlstream-eval/src/formula_template.rs
+++ b/crates/xlstream-eval/src/formula_template.rs
@@ -1,0 +1,313 @@
+//! Formula template for reconstructing per-row formula text.
+
+/// A column-level formula template that reconstructs per-row formula text
+/// by substituting row numbers at known byte positions.
+///
+/// Created once per formula column during `build_eval_plan`. The template
+/// stores the normalized formula text from the column's first row and the
+/// byte positions of relative row-number references within it.
+pub(crate) struct FormulaTemplate {
+    text: String,
+    row_refs: Vec<(usize, usize, u32)>,
+    base_row: u32,
+}
+
+impl FormulaTemplate {
+    /// Build a template from normalized formula text and its 1-based source row.
+    pub(crate) fn new(text: String, base_row: u32) -> Self {
+        let row_refs = extract_row_refs(&text);
+        Self { text, row_refs, base_row }
+    }
+
+    /// Reconstruct formula text for `target_row` (1-based Excel row).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub(crate) fn reconstruct(&self, target_row: u32) -> String {
+        if self.row_refs.is_empty() {
+            return self.text.clone();
+        }
+
+        let row_delta: i64 = i64::from(target_row) - i64::from(self.base_row);
+        #[allow(clippy::cast_possible_wrap)]
+        let max_row = xlstream_core::EXCEL_MAX_ROWS as i64;
+        let mut result = String::with_capacity(self.text.len() + 8);
+        let mut last_end = 0;
+
+        for &(start, end, base_ref_row) in &self.row_refs {
+            result.push_str(&self.text[last_end..start]);
+            let new_row = (i64::from(base_ref_row) + row_delta).clamp(1, max_row) as u32;
+            result.push_str(&new_row.to_string());
+            last_end = end;
+        }
+        result.push_str(&self.text[last_end..]);
+        result
+    }
+}
+
+/// Scan formula text for cell-reference patterns and return byte positions
+/// of relative (non-`$`-locked) row-number substrings.
+///
+/// Each entry: `(byte_start, byte_end, row_number)`.
+///
+/// Calamine normalizes cell references to uppercase, so only uppercase
+/// column letters are matched.
+fn extract_row_refs(text: &str) -> Vec<(usize, usize, u32)> {
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut refs = Vec::new();
+    let mut i = 0;
+
+    while i < len {
+        // Skip double-quoted string literals (Excel escapes "" inside strings).
+        if bytes[i] == b'"' {
+            i += 1;
+            while i < len {
+                if bytes[i] == b'"' {
+                    if i + 1 < len && bytes[i + 1] == b'"' {
+                        i += 2;
+                    } else {
+                        i += 1;
+                        break;
+                    }
+                } else {
+                    i += 1;
+                }
+            }
+            continue;
+        }
+
+        // Skip single-quoted sheet names: 'Sheet Name'!
+        if bytes[i] == b'\'' {
+            i += 1;
+            while i < len && bytes[i] != b'\'' {
+                i += 1;
+            }
+            if i < len {
+                i += 1;
+            }
+            if i < len && bytes[i] == b'!' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // Boundary: preceding char must not be alphanumeric or underscore.
+        if i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_') {
+            i += 1;
+            continue;
+        }
+
+        let save = i;
+
+        // Optional '$' for absolute column.
+        if i < len && bytes[i] == b'$' {
+            i += 1;
+        }
+
+        // Column letters: 1-3 uppercase ASCII.
+        let col_start = i;
+        while i < len && bytes[i].is_ascii_uppercase() {
+            i += 1;
+        }
+        let letter_count = i - col_start;
+        if letter_count == 0 || letter_count > 3 {
+            i = save + 1;
+            continue;
+        }
+
+        // Optional '$' for absolute row.
+        let has_dollar = i < len && bytes[i] == b'$';
+        if has_dollar {
+            i += 1;
+        }
+
+        // Row digits.
+        let digit_start = i;
+        while i < len && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        let digit_end = i;
+
+        if digit_start == digit_end {
+            i = save + 1;
+            continue;
+        }
+
+        // Trailing boundary: must not be followed by alphanumeric/underscore.
+        if i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+            i = save + 1;
+            continue;
+        }
+
+        // If followed by '!', this is a sheet name prefix — not a cell ref.
+        if i < len && bytes[i] == b'!' {
+            i += 1;
+            continue;
+        }
+
+        if !has_dollar {
+            if let Ok(row_num) = text[digit_start..digit_end].parse::<u32>() {
+                if row_num > 0 {
+                    refs.push((digit_start, digit_end, row_num));
+                }
+            }
+        }
+    }
+
+    refs
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+
+    #[test]
+    fn simple_refs_both_detected() {
+        let refs = extract_row_refs("A2+B2");
+        assert_eq!(refs, vec![(1, 2, 2), (4, 5, 2)]);
+    }
+
+    #[test]
+    fn absolute_row_skipped() {
+        let refs = extract_row_refs("$A$2+B2");
+        assert_eq!(refs, vec![(6, 7, 2)]);
+    }
+
+    #[test]
+    fn mixed_absolute_and_relative_in_range() {
+        let refs = extract_row_refs("SUM($A$1:A2)");
+        assert_eq!(refs, vec![(10, 11, 2)]);
+    }
+
+    #[test]
+    fn cross_sheet_ref() {
+        let refs = extract_row_refs("Sheet1!A2");
+        assert_eq!(refs, vec![(8, 9, 2)]);
+    }
+
+    #[test]
+    fn whole_column_ref_has_no_row_refs() {
+        let refs = extract_row_refs("SUM(A:A)");
+        assert_eq!(refs, vec![]);
+    }
+
+    #[test]
+    fn multi_digit_row() {
+        let refs = extract_row_refs("A100");
+        assert_eq!(refs, vec![(1, 4, 100)]);
+    }
+
+    #[test]
+    fn no_cell_refs_in_pure_arithmetic() {
+        let refs = extract_row_refs("1+2");
+        assert_eq!(refs, vec![]);
+    }
+
+    #[test]
+    fn quoted_sheet_name_skipped() {
+        let refs = extract_row_refs("'My Sheet'!A2");
+        assert_eq!(refs, vec![(12, 13, 2)]);
+    }
+
+    #[test]
+    fn function_name_not_matched() {
+        let refs = extract_row_refs("SUM(A2)");
+        assert_eq!(refs, vec![(5, 6, 2)]);
+    }
+
+    #[test]
+    fn range_both_endpoints_detected() {
+        let refs = extract_row_refs("A2:B10");
+        assert_eq!(refs, vec![(1, 2, 2), (4, 6, 10)]);
+    }
+
+    #[test]
+    fn absolute_col_relative_row() {
+        let refs = extract_row_refs("$A2");
+        assert_eq!(refs, vec![(2, 3, 2)]);
+    }
+
+    #[test]
+    fn sheet_name_looks_like_cell_ref_skipped() {
+        let refs = extract_row_refs("AB!C2");
+        assert_eq!(refs, vec![(4, 5, 2)]);
+    }
+
+    #[test]
+    fn max_row_number() {
+        let refs = extract_row_refs("A1048576");
+        assert_eq!(refs, vec![(1, 8, 1_048_576)]);
+    }
+
+    #[test]
+    fn string_literal_not_scanned() {
+        let refs = extract_row_refs(r#"IF(A2="B3",C2,0)"#);
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].2, 2);
+        assert_eq!(refs[1].2, 2);
+    }
+
+    #[test]
+    fn escaped_quotes_in_string_literal() {
+        let refs = extract_row_refs(r#"IF(A2="""",C2,0)"#);
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].2, 2);
+        assert_eq!(refs[1].2, 2);
+    }
+
+    #[test]
+    fn reconstruct_shifts_row_forward() {
+        let t = FormulaTemplate::new("A2+B2".into(), 2);
+        assert_eq!(t.reconstruct(5), "A5+B5");
+    }
+
+    #[test]
+    fn reconstruct_shifts_row_backward() {
+        let t = FormulaTemplate::new("A10+B10".into(), 10);
+        assert_eq!(t.reconstruct(3), "A3+B3");
+    }
+
+    #[test]
+    fn reconstruct_absolute_refs_unchanged() {
+        let t = FormulaTemplate::new("$A$1+B2".into(), 2);
+        assert_eq!(t.reconstruct(5), "$A$1+B5");
+    }
+
+    #[test]
+    fn reconstruct_no_refs_returns_text_unchanged() {
+        let t = FormulaTemplate::new("SUM(A:A)".into(), 2);
+        assert_eq!(t.reconstruct(100), "SUM(A:A)");
+    }
+
+    #[test]
+    fn reconstruct_large_row_number() {
+        let t = FormulaTemplate::new("A2".into(), 2);
+        assert_eq!(t.reconstruct(1_048_576), "A1048576");
+    }
+
+    #[test]
+    fn reconstruct_same_row_returns_original() {
+        let t = FormulaTemplate::new("A5+B5".into(), 5);
+        assert_eq!(t.reconstruct(5), "A5+B5");
+    }
+
+    #[test]
+    fn reconstruct_multi_digit_to_single() {
+        let t = FormulaTemplate::new("A100".into(), 100);
+        assert_eq!(t.reconstruct(2), "A2");
+    }
+
+    #[test]
+    fn reconstruct_clamps_to_max_row() {
+        let t = FormulaTemplate::new("A1".into(), 1);
+        let result = t.reconstruct(1_048_577);
+        assert!(result.contains("1048576"));
+    }
+
+    #[test]
+    fn reconstruct_clamps_to_min_row() {
+        let t = FormulaTemplate::new("A2".into(), 100);
+        let result = t.reconstruct(1);
+        assert_eq!(result, "A1");
+    }
+}

--- a/crates/xlstream-eval/src/lib.rs
+++ b/crates/xlstream-eval/src/lib.rs
@@ -25,7 +25,6 @@
 pub mod builtins;
 pub mod criteria;
 mod evaluate;
-#[allow(dead_code)]
 mod formula_template;
 mod interp;
 pub mod lookup;

--- a/crates/xlstream-eval/src/lib.rs
+++ b/crates/xlstream-eval/src/lib.rs
@@ -25,6 +25,8 @@
 pub mod builtins;
 pub mod criteria;
 mod evaluate;
+#[allow(dead_code)]
+mod formula_template;
 mod interp;
 pub mod lookup;
 pub mod ops;

--- a/crates/xlstream-eval/tests/keep_formulas.rs
+++ b/crates/xlstream-eval/tests/keep_formulas.rs
@@ -94,7 +94,10 @@ fn default_mode_preserves_formulas() {
 #[test]
 fn values_only_omits_formulas() {
     let input = make_formula_workbook();
-    let opts = EvaluateOptions { values_only: true, ..Default::default() };
+    let opts = EvaluateOptions {
+        output_mode: xlstream_core::OutputMode::ValuesOnly,
+        ..Default::default()
+    };
     let output = eval_to_temp(input.path(), &opts);
 
     let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();

--- a/crates/xlstream-eval/tests/keep_formulas.rs
+++ b/crates/xlstream-eval/tests/keep_formulas.rs
@@ -1,0 +1,160 @@
+//! Integration tests for formula preservation (keep-formulas feature).
+#![allow(clippy::all, clippy::pedantic, clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::path::Path;
+
+use calamine::{open_workbook, Data, Reader as CalReader, Xlsx};
+use rust_xlsxwriter::{Formula, Workbook};
+use tempfile::NamedTempFile;
+use xlstream_eval::{evaluate, EvaluateOptions};
+
+/// Build a small workbook with data + formulas and return the temp file.
+fn make_formula_workbook() -> NamedTempFile {
+    let file = NamedTempFile::with_suffix(".xlsx").unwrap();
+    let mut wb = Workbook::new();
+    let ws = wb.add_worksheet();
+
+    ws.write_string(0, 0, "X").unwrap();
+    ws.write_string(0, 1, "Y").unwrap();
+    ws.write_string(0, 2, "Sum").unwrap();
+    ws.write_string(0, 3, "Product").unwrap();
+    ws.write_string(0, 4, "IsPositive").unwrap();
+    ws.write_string(0, 5, "Label").unwrap();
+    ws.write_string(0, 6, "DivError").unwrap();
+
+    for row in 1..=10u32 {
+        let x = row as f64;
+        let y = (row * 10) as f64;
+        ws.write_number(row, 0, x).unwrap();
+        ws.write_number(row, 1, y).unwrap();
+
+        ws.write_formula(
+            row,
+            2,
+            Formula::new(format!("=A{}+B{}", row + 1, row + 1)).set_result(format!("{}", x + y)),
+        )
+        .unwrap();
+
+        ws.write_formula(
+            row,
+            3,
+            Formula::new(format!("=A{}*B{}", row + 1, row + 1)).set_result(format!("{}", x * y)),
+        )
+        .unwrap();
+
+        let is_pos = x > 5.0;
+        ws.write_formula(
+            row,
+            4,
+            Formula::new(format!("=A{}>5", row + 1)).set_result(if is_pos {
+                "TRUE"
+            } else {
+                "FALSE"
+            }),
+        )
+        .unwrap();
+
+        let label = if x > 5.0 { "big" } else { "small" };
+        ws.write_formula(
+            row,
+            5,
+            Formula::new(format!(r#"=IF(A{}>5,"big","small")"#, row + 1)).set_result(label),
+        )
+        .unwrap();
+
+        ws.write_formula(
+            row,
+            6,
+            Formula::new(format!("=1/(A{}-A{})", row + 1, row + 1)).set_result("#DIV/0!"),
+        )
+        .unwrap();
+    }
+
+    wb.save(file.path()).unwrap();
+    file
+}
+
+fn eval_to_temp(input: &Path, opts: &EvaluateOptions) -> NamedTempFile {
+    let output = NamedTempFile::with_suffix(".xlsx").unwrap();
+    evaluate(input, output.path(), opts).unwrap();
+    output
+}
+
+#[test]
+fn default_mode_preserves_formulas() {
+    let input = make_formula_workbook();
+    let output = eval_to_temp(input.path(), &EvaluateOptions::default());
+
+    let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();
+    let formulas = wb.worksheet_formula("Sheet1").unwrap();
+    let has_formulas = formulas.rows().any(|row| row.iter().any(|c| !c.is_empty()));
+    assert!(has_formulas, "default mode should write formula elements");
+}
+
+#[test]
+fn values_only_omits_formulas() {
+    let input = make_formula_workbook();
+    let opts = EvaluateOptions { values_only: true, ..Default::default() };
+    let output = eval_to_temp(input.path(), &opts);
+
+    let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();
+    let formulas = wb.worksheet_formula("Sheet1").unwrap();
+    let has_formulas = formulas.rows().any(|row| row.iter().any(|c| !c.is_empty()));
+    assert!(!has_formulas, "values-only mode should not write formula elements");
+}
+
+#[test]
+fn preserved_formulas_have_correct_row_references() {
+    let input = make_formula_workbook();
+    let output = eval_to_temp(input.path(), &EvaluateOptions::default());
+
+    let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();
+    let formulas = wb.worksheet_formula("Sheet1").unwrap();
+    let start = formulas.start().unwrap();
+    let start_row = start.0 as usize;
+
+    let rows: Vec<_> = formulas.rows().collect();
+
+    // First data row (Excel row 2) has Sum formula "A2+B2"
+    let data_row_0 = &rows[0];
+    let sum_col = 2 - start.1 as usize;
+    let sum_formula = &data_row_0[sum_col];
+    assert!(
+        sum_formula.contains("A2") && sum_formula.contains("B2"),
+        "Sum formula row 2: {}",
+        sum_formula
+    );
+
+    // Fifth data row (Excel row 6) has Sum formula "A6+B6"
+    let data_row_4 = &rows[4];
+    let sum_formula = &data_row_4[sum_col];
+    assert!(
+        sum_formula.contains("A6") && sum_formula.contains("B6"),
+        "Sum formula row 6 (start_row={}): {}",
+        start_row,
+        sum_formula
+    );
+}
+
+#[test]
+fn formula_results_cover_numeric_and_boolean_types() {
+    let input = make_formula_workbook();
+    let output = eval_to_temp(input.path(), &EvaluateOptions::default());
+
+    let mut wb: Xlsx<_> = open_workbook(output.path()).unwrap();
+    let range = wb.worksheet_range("Sheet1").unwrap();
+    let rows: Vec<_> = range.rows().collect();
+
+    // Row 2 (index 1): Sum = 12.0 (number)
+    assert!(
+        matches!(rows[1][2], Data::Float(_) | Data::Int(_)),
+        "sum should be numeric: {:?}",
+        rows[1][2]
+    );
+
+    // Row 2 (index 1): IsPositive = false (boolean), X=1 <= 5
+    assert!(matches!(rows[1][4], Data::Bool(false)), "isPositive row 2: {:?}", rows[1][4]);
+
+    // Row 7 (index 7): IsPositive = true (boolean), X=7 > 5
+    assert!(matches!(rows[7][4], Data::Bool(true)), "isPositive row 8: {:?}", rows[7][4]);
+}

--- a/crates/xlstream-io/src/sheet_handle.rs
+++ b/crates/xlstream-io/src/sheet_handle.rs
@@ -108,8 +108,30 @@ impl<'a> SheetHandle<'a> {
         Ok(())
     }
 
-    /// Enforce strictly-increasing row order.
-    fn enforce_row_order(&mut self, row_idx: u32) -> Result<(), XlStreamError> {
+    /// Advance the row cursor, enforcing strictly-increasing order.
+    ///
+    /// Call this once before writing individual cells via [`write_value`] or
+    /// [`write_formula`]. Not needed when using [`write_row`] (which calls
+    /// this internally).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XlStreamError::Internal`] if `row_idx` is not strictly
+    /// greater than the previous row written.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_core::Value;
+    /// use xlstream_io::Writer;
+    ///
+    /// let mut w = Writer::create(Path::new("out.xlsx")).unwrap();
+    /// let mut sh = w.add_sheet("Sheet1").unwrap();
+    /// sh.enforce_row_order(0).unwrap();
+    /// sh.write_value(0, 0, &Value::Number(1.0)).unwrap();
+    /// ```
+    pub fn enforce_row_order(&mut self, row_idx: u32) -> Result<(), XlStreamError> {
         if let Some(last) = self.last_row {
             if row_idx <= last {
                 return Err(XlStreamError::Internal(format!(
@@ -121,9 +143,30 @@ impl<'a> SheetHandle<'a> {
         Ok(())
     }
 
-    /// Dispatch a single [`Value`] to the appropriate `rust_xlsxwriter` write
-    /// method.
-    fn write_value(&mut self, row: u32, col: u16, val: &Value) -> Result<(), XlStreamError> {
+    /// Write a single data value at `(row, col)`.
+    ///
+    /// Call [`enforce_row_order`](Self::enforce_row_order) once for the row
+    /// before calling this. Not needed when using [`write_row`] (which
+    /// handles both steps).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XlStreamError::XlsxWrite`] if the underlying write fails.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use xlstream_core::Value;
+    /// use xlstream_io::Writer;
+    ///
+    /// let mut w = Writer::create(Path::new("out.xlsx")).unwrap();
+    /// let mut sh = w.add_sheet("Sheet1").unwrap();
+    /// sh.enforce_row_order(0).unwrap();
+    /// sh.write_value(0, 0, &Value::Number(42.0)).unwrap();
+    /// sh.write_formula(0, 1, "A1*2", &Value::Number(84.0)).unwrap();
+    /// ```
+    pub fn write_value(&mut self, row: u32, col: u16, val: &Value) -> Result<(), XlStreamError> {
         match val {
             Value::Number(n) => {
                 self.worksheet

--- a/docs/roadmap/v0.2/README.md
+++ b/docs/roadmap/v0.2/README.md
@@ -16,7 +16,7 @@
 
 ### Output fidelity
 
-- [] **Keep formulas by default** — write `<f>formula</f><v>cached</v>` instead of just `<v>`. Add `--values-only` flag for static output. ~4 hours.
+- [x] **Keep formulas by default** — write `<f>formula</f><v>cached</v>` instead of just `<v>`. Add `--values-only` flag for static output. ~4 hours.
 - [x] **PyPI description** — fix empty project page. ~30 min.
 - [ ] **MID empty string workaround** — `rust_xlsxwriter` drops empty string writes. Either patch upstream or work around. ~1 hour.
 


### PR DESCRIPTION
## Summary
- Formula cells now write `<f>formula</f><v>cached</v>` by default instead of bare `<v>`
- Adds `--values-only` CLI flag and `values_only` Python kwarg to restore old values-only behavior
- Zero-overhead approach: one `FormulaTemplate` per formula column (~750 bytes for 30 cols), row-number substitution at write time
- Spec: `docs/roadmap/v0.2/06-keep-formulas-v3.md`

## Architecture
- `FormulaTemplate` extracts byte positions of relative row-number references from the column's first formula
- `reconstruct()` does string surgery to substitute row numbers per-row
- `write_formula_cells()` writes formula cells via `SheetHandle::write_formula` and data cells via `write_value`
- Text values that parse as f64 and empty values fall back to plain value write (rust_xlsxwriter type inference limitation)

## Test plan
- [x] 24 unit tests for `extract_row_refs` and `reconstruct`
- [x] Integration test: default mode writes `<f>` elements
- [x] Integration test: `values_only=true` omits `<f>` elements
- [x] Integration test: formula row references correct per-row
- [x] Integration test: numeric and boolean value types correct
- [x] 35 conformance tests pass
- [x] `make check` passes (fmt + clippy + test + doctest)
- [x] Docs updated (CHANGELOG, roadmap checkbox)
- [x] Python type stubs updated

## Notes
- Close PR #84 after merge — code preserved in git history for future `--preserve-formatting` work
- `rust_xlsxwriter` type inference limitation: formula cells with text results that parse as f64 (e.g., `"123"`) or empty results cannot have their cached value properly typed. These cells are written as plain values to preserve correctness.