### PR TITLE
release: v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,18 @@
 All notable changes to xlstream. Format: [Keep a Changelog](https://keepachangelog.com/).
 Semver.
 
-## [Unreleased]
+## [0.2.1] - 2026-05-11
 
 ### Added
-- Table reference support: `Table[Column]` and `[@Column]` structured references resolve to cell/range references at classification time
-- MINIFS and MAXIFS conditional aggregate functions
-- SUMPRODUCT: sum of element-wise products of bounded ranges
-- ROWS and COLUMNS: return row/column count from range references
-- Self-referential formula support via iterative calculation (e.g., `=IF(G2="Risk_KC",O2*-1,O2)` in cell O2)
-- `EvaluateOptions` with `iterative_calc`, `max_iterations`, `max_change` settings
-- CLI: `--max-iterations`, `--max-change`, `--no-iterative-calc`
-- Python: `iterative_calc`, `max_iterations`, `max_change` kwargs
-- Formula preservation: output now includes `<f>formula</f><v>cached</v>` for formula cells by default
-- `--values-only` CLI flag to write only cached values (old behavior)
-- `values_only` Python kwarg for the same
-
-### Changed
-- `evaluate()` signature now takes `&EvaluateOptions` instead of `Option<usize>`
-- Default output mode changed from values-only to formula-preserving
+- Table reference support (`Table[Column]`, `[@Column]`)
+- SUMPRODUCT, MINIFS, MAXIFS functions
+- Self-referential formula support via iterative calculation
+- Formula preservation: output includes `<f>` and `<v>` by default; `--values-only` for static output
+- Iterative calculation controls: `--max-iterations`, `--max-change`, `--no-iterative-calc`
 
 ### Fixed
-- Formulas on secondary sheets (not referenced by the main sheet) now evaluated instead of producing None (#42)
-- Mixed-column formulas: columns with structurally different formulas across rows now use per-row AST overrides
+- Formulas on secondary sheets now evaluated correctly (#42)
+- Mixed-column formulas with per-row variations now handled
 
 ## [0.2.0] - 2026-04-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3.workspace = true
-xlstream-core = { path = "../../crates/xlstream-core", version = "0.2.0" }
-xlstream-eval = { path = "../../crates/xlstream-eval", version = "0.2.0" }
-xlstream-io = { path = "../../crates/xlstream-io", version = "0.2.0" }
+xlstream-core = { path = "../../crates/xlstream-core", version = "0.2.1" }
+xlstream-eval = { path = "../../crates/xlstream-eval", version = "0.2.1" }
+xlstream-io = { path = "../../crates/xlstream-io", version = "0.2.1" }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/xlstream-cli/Cargo.toml
+++ b/crates/xlstream-cli/Cargo.toml
@@ -17,10 +17,10 @@ name = "xlstream"
 path = "src/main.rs"
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.2.0" }
-xlstream-eval = { path = "../xlstream-eval", version = "0.2.0" }
-xlstream-parse = { path = "../xlstream-parse", version = "0.2.0" }
-xlstream-io = { path = "../xlstream-io", version = "0.2.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.2.1" }
+xlstream-eval = { path = "../xlstream-eval", version = "0.2.1" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.2.1" }
+xlstream-io = { path = "../xlstream-io", version = "0.2.1" }
 clap.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/xlstream-eval/Cargo.toml
+++ b/crates/xlstream-eval/Cargo.toml
@@ -12,9 +12,9 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.2.0" }
-xlstream-parse = { path = "../xlstream-parse", version = "0.2.0" }
-xlstream-io = { path = "../xlstream-io", version = "0.2.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.2.1" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.2.1" }
+xlstream-io = { path = "../xlstream-io", version = "0.2.1" }
 rust_decimal.workspace = true
 ssfmt.workspace = true
 tracing.workspace = true

--- a/crates/xlstream-io/Cargo.toml
+++ b/crates/xlstream-io/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.2.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.2.1" }
 calamine.workspace = true
 rust_xlsxwriter.workspace = true
 

--- a/crates/xlstream-parse/Cargo.toml
+++ b/crates/xlstream-parse/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.2.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.2.1" }
 formualizer-parse = { workspace = true }
 formualizer-common = { workspace = true }
 smallvec = { workspace = true }

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -311,14 +311,14 @@ Every Excel function (~493), organized by category. Cross-referenced against xls
 |---|---|---|---|---|---|---|
 | ADDRESS | . | yes | v0.3 | | | Builds A1 string |
 | CHOOSE | x | yes | v0.1 | x | | |
-| COLUMN | . | yes | v0.2 | | | |
-| COLUMNS | . | yes | v0.2 | | | |
+| COLUMN | . | yes | v0.3 | | | |
+| COLUMNS | . | yes | v0.3 | | | |
 | HLOOKUP | x | yes | v0.1 | x | | |
 | INDEX | x | yes | v0.1 | x | x | |
 | LOOKUP | . | yes | v0.3 | x | | Legacy |
 | MATCH | x | yes | v0.1 | x | x | |
 | ROW | . | yes | v0.3 | | | |
-| ROWS | . | yes | v0.2 | | | |
+| ROWS | . | yes | v0.3 | | | |
 | VLOOKUP | x | yes | v0.1 | x | x | |
 | XLOOKUP | x | yes | v0.1 | x | | |
 | XMATCH | x | yes | v0.1 | x | | |

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -23,7 +23,7 @@ Each version gets its own folder with a checklist. When a version ships, its fol
 
 ### Where we are
 
-Excel has ~516 functions. xlstream implements 103 functions — covering all 15 functions that appear in 76% of real business spreadsheets (Enron Corpus, Hermans et al., IEEE ICSE 2015). See [functions.md](../functions.md) for the full cross-reference.
+Excel has ~516 functions. xlstream implements 106 functions — covering all 15 functions that appear in 76% of real business spreadsheets (Enron Corpus, Hermans et al., IEEE ICSE 2015). See [functions.md](../functions.md) for the full cross-reference.
 
 ### Where we're going
 
@@ -32,7 +32,7 @@ The goal is to support **every formula that fits the streaming model** — ~465 
 ### Version plan
 
 ```
-v0.1  ✓  Core engine (113 functions, streaming, Python bindings)
+v0.1  ✓  Core engine (103 functions, streaming, Python bindings)
 v0.2     Coverage + fidelity (named ranges, table refs, keep-formulas)
 v0.3     Statistical + engineering (STDEV, VAR, NORM.DIST, CONVERT, HEX2DEC)
 v0.4     LET + advanced financial (XNPV, XIRR, NPER, SLN, variable binding)
@@ -42,7 +42,7 @@ v1.0     API stability commitment — no breaking changes after this
 
 ### v0.2 — Coverage + fidelity
 
-Named ranges, table references, SUMPRODUCT, MINIFS/MAXIFS, ROWS/COLUMNS. Keep-formulas output mode. See [`v0.2/README.md`](v0.2/README.md).
+Named ranges, table references, SUMPRODUCT, MINIFS/MAXIFS. Keep-formulas output mode. Self-referential formula support. See [`v0.2/README.md`](v0.2/README.md).
 
 ### v0.3 — Statistical + engineering
 
@@ -96,8 +96,8 @@ These are architecturally incompatible with streaming. Users get a clear `Classi
 
 | Version | Functions | Operators | Total surfaces |
 |---|---|---|---|
-| v0.1 | 113 | 13 | 126 |
-| v0.2 | ~120 | 13 | ~133 |
+| v0.1 | 103 | 13 | 116 |
+| v0.2 | 106 | 13 | 119 |
 | v0.3 | ~265 | 13 | ~278 |
 | v0.4 | ~310 | 13 | ~323 |
 | v0.5 | ~360 | 13 | ~373 |

--- a/docs/roadmap/v0.2/README.md
+++ b/docs/roadmap/v0.2/README.md
@@ -12,7 +12,7 @@
 - [x] **Table references** — `Table[Column]`, `Table[@Column]`. Parse `tables/table*.xml`, resolve to ranges. ~2 days.
 - [x] **SUMPRODUCT** — sum of element-wise products. Requires bounded-range evaluation. ~1 day.
 - [x] **MINIFS / MAXIFS** — conditional min/max. Same pattern as SUMIFS/COUNTIFS. ~0.5 day.
-- [x] **ROWS / COLUMNS** — return row/column count. Uses `EXCEL_MAX_ROWS`/`EXCEL_MAX_COLS` constants (already in xlstream-core). ~0.5 day.
+- [ ] **ROWS / COLUMNS** — return row/column count. Uses `EXCEL_MAX_ROWS`/`EXCEL_MAX_COLS` constants (already in xlstream-core). ~0.5 day. *(moved to v0.3)*
 
 ### Output fidelity
 

--- a/docs/roadmap/v0.3/README.md
+++ b/docs/roadmap/v0.3/README.md
@@ -15,7 +15,7 @@ These didn't ship with v0.2:
 
 - [ ] **Auto-detect iterative calc settings** — parse `calcPr` from `xl/workbook.xml` in xlstream-io (#77). ~2 hours.
 - [ ] **Cross-column same-row circular references** — SCC detection in topo sort, iterate groups (#80). ~1 day.
-- [ ] **ROW / COLUMN** — return the row number / column number of a cell (single-cell variants of ROWS/COLUMNS). ~0.5 day.
+- [ ] **ROW / COLUMN / ROWS / COLUMNS** — ROW/COLUMN return row/col number of a cell; ROWS/COLUMNS return row/col count of a range. ROWS/COLUMNS carried from v0.2 (implemented on branch but never merged). ~1 day.
 
 ## Statistical functions (~30)
 


### PR DESCRIPTION
## Summary
- Version bump 0.2.0 -> 0.2.1
- Changelog: user-facing changes only
- Fix ROWS/COLUMNS checkbox (never merged, moved to v0.3)
- Correct function counts across roadmap docs (106, not 113)

## Changes since v0.2.0
- Table references (`Table[Column]`, `[@Column]`)
- SUMPRODUCT, MINIFS, MAXIFS
- Self-referential formula support via iterative calculation
- Formula preservation with `--values-only` opt-out
- Secondary sheet formula evaluation fix (#42)
- Mixed-column per-row formula handling

## Test plan
- [x] `make check` passes
- [x] Existing conformance tests pass
- [ ] Tag v0.2.1 after merge