### PR TITLE
docs: add detailed roadmaps for v0.4 through v1.0

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -35,9 +35,9 @@ The goal is to support **every formula that fits the streaming model** — ~465 
 v0.1  ✓  Core engine (103 functions, streaming, Python bindings)
 v0.2     Coverage + fidelity (named ranges, table refs, keep-formulas)
 v0.3     Statistical + engineering (STDEV, VAR, NORM.DIST, CONVERT, HEX2DEC)
-v0.4     LET + advanced financial (XNPV, XIRR, NPER, SLN, variable binding)
-v0.5     Compatibility layer (39 legacy function aliases) + database functions
-v1.0     API stability commitment — no breaking changes after this
+v0.4     LET + advanced financial (38 functions: XNPV, XIRR, NPER, SLN, bonds)
+v0.5     Compatibility aliases (39) + database functions (12)
+v1.0     API stability — no breaking changes after this
 ```
 
 ### v0.2 — Coverage + fidelity
@@ -56,25 +56,26 @@ All row-local (pure functions of their args). No streaming concerns. Mostly math
 
 ### v0.4 — LET + advanced financial
 
-**LET** is variable binding inside formulas: `=LET(x, A2*1.1, y, B2*0.9, IF(x>y, x, y))`. No spill, no closures, no recursion — just scoped name substitution. Compatible with streaming.
+**LET** is scoped variable binding: `=LET(x, A2*1.1, y, B2*0.9, IF(x>y, x, y))`. No spill, no closures, no recursion — just name substitution. Compatible with streaming.
 
-**Advanced financial (~20):** XNPV, XIRR, NPER, SLN, DDB, DB, EFFECT, NOMINAL, CUMIPMT, CUMPRINC, PPMT, IPMT, DISC, PRICE, YIELD, DURATION, MDURATION, ACCRINT, TBILLEQ, TBILLPRICE
-
-All row-local. Some iterative (XIRR uses Newton's method like IRR).
+**Financial (37 functions):** XNPV, XIRR, NPER, SLN, DDB, DB, EFFECT, NOMINAL, CUMIPMT, CUMPRINC, PPMT, IPMT, DISC, PRICE, YIELD, DURATION, MDURATION, ACCRINT, TBILLEQ, TBILLPRICE, VDB, MIRR, FVSCHEDULE, DOLLARDE, DOLLARFR, PDURATION, RRI, and more. All row-local. Some iterative (XIRR uses Newton's method). See [`v0.4/README.md`](v0.4/README.md).
 
 ### v0.5 — Compatibility + database
 
-**Compatibility (39 functions):** Old names that Excel keeps for backward compat. STDEV → STDEV.S, VAR → VAR.P, MODE → MODE.SNGL, PERCENTILE → PERCENTILE.INC, RANK → RANK.EQ, CONCATENATE → CONCAT, etc. Thin wrappers over v0.3/v0.4 implementations.
+**Compatibility (39 aliases):** Old function names Excel keeps for backward compat. STDEV → STDEV.S, VAR → VAR.P, MODE → MODE.SNGL, PERCENTILE → PERCENTILE.INC, RANK → RANK.EQ, etc. Thin dispatch aliases to v0.3 implementations. No new logic.
 
-**Database (12 functions):** DSUM, DAVERAGE, DCOUNT, DCOUNTA, DGET, DMAX, DMIN, DPRODUCT, DSTDEV, DSTDEVP, DVAR, DVARP. Range-based with criteria ranges — can be implemented as prelude aggregates with structured criteria parsing.
+**Database (12 functions):** DSUM, DAVERAGE, DCOUNT, DCOUNTA, DGET, DMAX, DMIN, DPRODUCT, DSTDEV, DSTDEVP, DVAR, DVARP. Prelude aggregates with structured criteria parsing. See [`v0.5/README.md`](v0.5/README.md).
 
 ### v1.0 — API stability
 
 No new functions. Focus:
-- API freeze — `evaluate()` signature, `EvalOptions`, Python bindings locked
-- Full documentation (mdBook site, per-crate READMEs)
-- Performance hardening (memory < 250 MB target for 700k rows)
+- API freeze — `evaluate()` signature, `EvaluateOptions`, `OutputMode`, Python bindings, CLI locked
+- Performance hardening — memory < 250 MB, wall-clock < 3 min for 700k rows
+- Documentation — mdBook site, migration guide, per-crate README audit
+- Quality — 100% conformance coverage, fuzz testing, property-based testing
 - 1-year semver stability commitment
+
+See [`v1.0/README.md`](v1.0/README.md).
 
 ### What we'll never support
 
@@ -90,15 +91,15 @@ These are architecturally incompatible with streaming. Users get a clear `Classi
 | **OLAP** | CUBE* family (7 functions) | Requires external OLAP connection |
 | **External refs** | `[Book.xlsx]Sheet1!A1` | Violates single-file model |
 
-**~51 functions permanently excluded.** ~465 are streaming-compatible. See [functions.md](../functions.md) for the complete breakdown.
+**~51 functions permanently excluded.** ~434 are streaming-compatible and planned through v0.5. See [functions.md](../functions.md) for the complete breakdown.
 
 ### Function count trajectory
 
-| Version | Functions | Operators | Total surfaces |
-|---|---|---|---|
-| v0.1 | 103 | 13 | 116 |
-| v0.2 | 106 | 13 | 119 |
-| v0.3 | ~265 | 13 | ~278 |
-| v0.4 | ~310 | 13 | ~323 |
-| v0.5 | ~360 | 13 | ~373 |
-| v1.0 | ~360 | 13 | ~373 (API frozen) |
+| Version | New | Cumulative | Operators | Total surfaces |
+|---|---|---|---|---|
+| v0.1 | 103 | 103 | 13 | 116 |
+| v0.2 | +3 | 106 | 13 | 119 |
+| v0.3 | +239 | 345 | 13 | 358 |
+| v0.4 | +38 | 383 | 13 | 396 |
+| v0.5 | +51 | 434 | 13 | 447 |
+| v1.0 | 0 | 434 | 13 | 447 (API frozen) |

--- a/docs/roadmap/v0.4/README.md
+++ b/docs/roadmap/v0.4/README.md
@@ -1,0 +1,76 @@
+# v0.4 Roadmap
+
+**Status:** planning
+**Target:** 2026 Q4
+**Theme:** LET variable binding + advanced financial functions
+
+## LET
+
+- [ ] **LET** — scoped variable binding inside formulas. `=LET(x, A2*1.1, y, B2*0.9, IF(x>y, x, y))`. No spill, no closures, no recursion — just name substitution evaluated left-to-right. ~2 days.
+
+## Financial — Core (~10)
+
+High-value functions that appear in real business workbooks.
+
+- [ ] **NPER** — number of periods for an investment. ~2 hours.
+- [ ] **IPMT** — interest portion of a payment. ~2 hours.
+- [ ] **PPMT** — principal portion of a payment. ~2 hours.
+- [ ] **CUMIPMT** — cumulative interest between two periods. ~2 hours.
+- [ ] **CUMPRINC** — cumulative principal between two periods. ~2 hours.
+- [ ] **EFFECT** — effective annual interest rate from nominal. ~1 hour.
+- [ ] **NOMINAL** — nominal rate from effective annual rate. ~1 hour.
+- [ ] **XNPV** — net present value with irregular dates. ~0.5 day.
+- [ ] **XIRR** — internal rate of return with irregular dates. Iterative (Newton's method, same pattern as IRR). ~0.5 day.
+- [ ] **MIRR** — modified internal rate of return. ~2 hours.
+
+## Financial — Depreciation (~5)
+
+- [ ] **SLN** — straight-line depreciation. ~1 hour.
+- [ ] **SYD** — sum-of-years-digits depreciation. ~1 hour.
+- [ ] **DB** — fixed-declining balance depreciation. ~2 hours.
+- [ ] **DDB** — double-declining balance depreciation. ~2 hours.
+- [ ] **VDB** — variable declining balance (flexible DDB). ~0.5 day.
+
+## Financial — Bonds & Securities (~15)
+
+- [ ] **PRICE** — price of a security paying periodic interest. ~0.5 day.
+- [ ] **YIELD** — yield of a security paying periodic interest. Iterative. ~0.5 day.
+- [ ] **DURATION** — Macaulay duration. ~0.5 day.
+- [ ] **MDURATION** — modified duration. ~2 hours.
+- [ ] **DISC** — discount rate for a security. ~2 hours.
+- [ ] **PRICEDISC** — price of a discounted security. ~2 hours.
+- [ ] **PRICEMAT** — price of a security paying interest at maturity. ~2 hours.
+- [ ] **YIELDDISC** — yield of a discounted security. ~2 hours.
+- [ ] **YIELDMAT** — yield of a security paying interest at maturity. ~2 hours.
+- [ ] **RECEIVED** — amount received at maturity for a fully invested security. ~2 hours.
+- [ ] **INTRATE** — interest rate for a fully invested security. ~2 hours.
+- [ ] **ACCRINT** — accrued interest for a periodic-coupon security. ~0.5 day.
+- [ ] **ACCRINTM** — accrued interest for a maturity-paying security. ~2 hours.
+- [ ] **TBILLEQ** — bond-equivalent yield for a T-bill. ~1 hour.
+- [ ] **TBILLPRICE** — price per $100 face value of a T-bill. ~1 hour.
+- [ ] **TBILLYIELD** — yield for a T-bill. ~1 hour.
+
+## Financial — Other (~4)
+
+- [ ] **DOLLARDE** — dollar price as decimal from fraction. ~1 hour.
+- [ ] **DOLLARFR** — dollar price as fraction from decimal. ~1 hour.
+- [ ] **FVSCHEDULE** — future value with variable rates. ~2 hours.
+- [ ] **ISPMT** — interest for a specific period (straight-line). ~1 hour.
+- [ ] **PDURATION** — periods required for investment to reach a value. ~1 hour.
+- [ ] **RRI** — equivalent interest rate for growth of an investment. ~1 hour.
+
+## Out of scope (v0.5+)
+
+- Compatibility aliases (STDEV -> STDEV.S, etc.)
+- Database functions (DSUM, DAVERAGE, etc.)
+- RAND/RANDBETWEEN with deterministic seeding
+- mdBook documentation site
+
+## Done when
+
+- All boxes ticked
+- `make check` passes
+- Conformance tests pass for all new functions
+- Benchmark report generated (`make bench-report VERSION=0.4.0`)
+- CHANGELOG promoted to `[0.4.0]`
+- Tagged and released

--- a/docs/roadmap/v0.4/README.md
+++ b/docs/roadmap/v0.4/README.md
@@ -50,7 +50,7 @@ High-value functions that appear in real business workbooks.
 - [ ] **TBILLPRICE** — price per $100 face value of a T-bill. ~1 hour.
 - [ ] **TBILLYIELD** — yield for a T-bill. ~1 hour.
 
-## Financial — Other (~4)
+## Financial — Other (~6)
 
 - [ ] **DOLLARDE** — dollar price as decimal from fraction. ~1 hour.
 - [ ] **DOLLARFR** — dollar price as fraction from decimal. ~1 hour.

--- a/docs/roadmap/v0.5/README.md
+++ b/docs/roadmap/v0.5/README.md
@@ -1,0 +1,100 @@
+# v0.5 Roadmap
+
+**Status:** planning
+**Target:** 2027 Q1
+**Theme:** compatibility aliases + database functions
+
+## Compatibility aliases (~39)
+
+Old function names that Excel keeps for backward compatibility. Each is a thin dispatch alias to the modern equivalent implemented in v0.3. No new logic — just match arms in `dispatch()`.
+
+### Statistical aliases (~30)
+
+- [ ] **STDEV** → STDEV.S
+- [ ] **STDEVP** → STDEV.P
+- [ ] **VAR** → VAR.S
+- [ ] **VARP** → VAR.P
+- [ ] **MODE** → MODE.SNGL
+- [ ] **PERCENTILE** → PERCENTILE.INC
+- [ ] **PERCENTRANK** → PERCENTRANK.INC
+- [ ] **QUARTILE** → QUARTILE.INC
+- [ ] **RANK** → RANK.EQ
+- [ ] **BETADIST** → BETA.DIST
+- [ ] **BETAINV** → BETA.INV
+- [ ] **BINOMDIST** → BINOM.DIST
+- [ ] **CRITBINOM** → BINOM.INV
+- [ ] **CHIDIST** → CHISQ.DIST.RT
+- [ ] **CHIINV** → CHISQ.INV.RT
+- [ ] **CHITEST** → CHISQ.TEST
+- [ ] **CONFIDENCE** → CONFIDENCE.NORM
+- [ ] **COVAR** → COVARIANCE.P
+- [ ] **EXPONDIST** → EXPON.DIST
+- [ ] **FDIST** → F.DIST.RT
+- [ ] **FINV** → F.INV.RT
+- [ ] **FORECAST** → FORECAST.LINEAR
+- [ ] **FTEST** → F.TEST
+- [ ] **GAMMADIST** → GAMMA.DIST
+- [ ] **GAMMAINV** → GAMMA.INV
+- [ ] **HYPGEOMDIST** → HYPGEOM.DIST
+- [ ] **LOGINV** → LOGNORM.INV
+- [ ] **LOGNORMDIST** → LOGNORM.DIST
+- [ ] **NEGBINOMDIST** → NEGBINOM.DIST
+- [ ] **NORMDIST** → NORM.DIST
+- [ ] **NORMINV** → NORM.INV
+- [ ] **NORMSDIST** → NORM.S.DIST
+- [ ] **NORMSINV** → NORM.S.INV
+- [ ] **POISSON** → POISSON.DIST
+- [ ] **TDIST** → T.DIST.2T
+- [ ] **TINV** → T.INV.2T
+- [ ] **TTEST** → T.TEST
+- [ ] **WEIBULL** → WEIBULL.DIST
+- [ ] **ZTEST** → Z.TEST
+
+## Database functions (~12)
+
+Range-based aggregates with structured criteria ranges. Implemented as prelude aggregates with criteria parsing.
+
+All take `(database, field, criteria)` where:
+- `database` is a range with headers in the first row
+- `field` is a column name or index
+- `criteria` is a range with headers matching database columns and criteria values below
+
+- [ ] **DSUM** — sum of values matching criteria. ~0.5 day.
+- [ ] **DAVERAGE** — average of values matching criteria. ~2 hours.
+- [ ] **DCOUNT** — count of numeric values matching criteria. ~2 hours.
+- [ ] **DCOUNTA** — count of non-blank values matching criteria. ~2 hours.
+- [ ] **DGET** — single value matching criteria (error if multiple). ~2 hours.
+- [ ] **DMAX** — max of values matching criteria. ~2 hours.
+- [ ] **DMIN** — min of values matching criteria. ~2 hours.
+- [ ] **DPRODUCT** — product of values matching criteria. ~2 hours.
+- [ ] **DSTDEV** — sample standard deviation matching criteria. ~2 hours.
+- [ ] **DSTDEVP** — population standard deviation matching criteria. ~2 hours.
+- [ ] **DVAR** — sample variance matching criteria. ~2 hours.
+- [ ] **DVARP** — population variance matching criteria. ~2 hours.
+
+### Streaming model for database functions
+
+Database functions reference a "database" range (prelude-loaded) and a "criteria" range (also prelude-loaded). The field and criteria are resolved during prelude. At row-eval time, the result is a pre-computed scalar — same pattern as SUMIF/COUNTIF. No streaming invariant concerns.
+
+Implementation plan:
+1. Parse the criteria range structure (headers + values)
+2. Build criteria predicates from the values
+3. Scan the database range during prelude, matching rows against predicates
+4. Store the aggregate result as a prelude scalar
+5. At row-eval time, return the pre-computed value
+
+## Out of scope (v1.0)
+
+- New function implementations (all shipped by v0.5)
+- API stability commitment
+- Performance hardening
+- mdBook documentation site
+
+## Done when
+
+- All boxes ticked
+- `make check` passes
+- Conformance tests pass for all new functions
+- Benchmark report generated (`make bench-report VERSION=0.5.0`)
+- CHANGELOG promoted to `[0.5.0]`
+- Tagged and released

--- a/docs/roadmap/v0.5/README.md
+++ b/docs/roadmap/v0.5/README.md
@@ -8,7 +8,7 @@
 
 Old function names that Excel keeps for backward compatibility. Each is a thin dispatch alias to the modern equivalent implemented in v0.3. No new logic — just match arms in `dispatch()`.
 
-### Statistical aliases (~30)
+### Statistical aliases (~39)
 
 - [ ] **STDEV** → STDEV.S
 - [ ] **STDEVP** → STDEV.P

--- a/docs/roadmap/v1.0/README.md
+++ b/docs/roadmap/v1.0/README.md
@@ -47,7 +47,7 @@ No new functions. v1.0 is the stability commitment — after this release, the p
 
 ## Out of scope (post v1.0)
 
-- New functions beyond the ~360 shipped in v0.1–v0.5
+- New functions beyond the ~434 shipped in v0.1–v0.5
 - `.xlsb`, `.xls`, `.ods` input formats
 - External workbook references
 - Cell formatting preservation

--- a/docs/roadmap/v1.0/README.md
+++ b/docs/roadmap/v1.0/README.md
@@ -1,0 +1,67 @@
+# v1.0 Roadmap
+
+**Status:** planning
+**Target:** 2027 Q2
+**Theme:** API stability, performance, documentation
+
+No new functions. v1.0 is the stability commitment — after this release, the public API is frozen for 1 year (semver).
+
+## API freeze
+
+- [ ] **`evaluate()` signature locked** — `fn evaluate(input, output, &EvaluateOptions) -> Result<EvaluateSummary>`. No breaking changes.
+- [ ] **`EvaluateOptions` fields locked** — `workers`, `iterative_calc`, `max_iterations`, `max_change`, `output_mode`. New fields are additive only (with defaults).
+- [ ] **`EvaluateSummary` fields locked** — `rows_processed`, `formulas_evaluated`, `duration`. New fields additive only.
+- [ ] **`OutputMode` enum locked** — `PreserveFormulas`, `ValuesOnly`. New variants are additive only.
+- [ ] **Python API locked** — `xlstream.evaluate()` signature, kwargs, return dict shape, exception types.
+- [ ] **CLI interface locked** — `xlstream evaluate`, `xlstream classify`. Flags and output format.
+- [ ] **Error types locked** — `XlStreamError` variants. New variants additive only.
+- [ ] **Audit all `pub` items** — remove or hide any pub item not intended as stable API. Anything pub at v1.0 stays pub.
+
+## Performance hardening
+
+- [ ] **Memory target: < 250 MB for 700k rows** — investigate and reduce calamine shared-strings buffering and rust_xlsxwriter string table overhead. Current: ~734 MB, evaluator itself ~10 MB.
+- [ ] **Wall-clock target: < 3 min for 700k rows** — profile and optimize hot paths. Current: ~2.5 min (1 worker), ~2.3 min (8 workers).
+- [ ] **Benchmark regression gate** — CI blocks merge on >10% RSS or >20% wall-clock regression. Currently only micro-benchmarks are gated.
+- [ ] **Memory benchmark in CI** — add tier benchmarks (small/medium/large) to CI with RSS tracking.
+
+## Documentation
+
+- [ ] **mdBook site** — hosted documentation covering architecture, API reference, streaming model, function reference. Replaces the `docs/` folder for external users.
+- [ ] **Per-crate README audit** — verify each crate README is accurate and has a working example.
+- [ ] **Python documentation** — docstrings on all public Python functions, published to readthedocs or equivalent.
+- [ ] **Migration guide v0.x -> v1.0** — document any breaking changes from the v0.x series.
+
+## Quality
+
+- [ ] **100% conformance coverage** — every implemented function has a conformance fixture with >=15 formulas.
+- [ ] **Fuzz testing** — fuzz the formula parser with cargo-fuzz. Target: 1M iterations without panic.
+- [ ] **Property-based testing** — proptest for `extract_row_refs` / `reconstruct` round-trips and `FormulaTemplate` correctness.
+- [ ] **Error message audit** — every `XlStreamError` variant produces an actionable error message with enough context to diagnose without reading source.
+
+## Packaging
+
+- [ ] **PyPI metadata** — correct project URLs, description, classifiers, license.
+- [ ] **Cargo publish readiness** — all crates publishable to crates.io with correct metadata.
+- [ ] **GitHub release automation** — tag triggers: build wheels, publish to PyPI, create GitHub release with changelog.
+- [ ] **Supported platforms documented** — linux x86_64, macOS arm64/x86_64, Windows x86_64. Python 3.9+.
+
+## Out of scope (post v1.0)
+
+- New functions beyond the ~360 shipped in v0.1–v0.5
+- `.xlsb`, `.xls`, `.ods` input formats
+- External workbook references
+- Cell formatting preservation
+- RAND/RANDBETWEEN with deterministic seeding
+- Incremental re-evaluation
+- Web API / server mode
+
+## Done when
+
+- All boxes ticked
+- `make check` passes
+- All conformance tests pass
+- Benchmark report meets targets (< 250 MB, < 3 min for 700k rows)
+- mdBook site published
+- CHANGELOG promoted to `[1.0.0]`
+- Tagged and released
+- Blog post / announcement


### PR DESCRIPTION
## Summary
- Add detailed roadmap READMEs for v0.4, v0.5, and v1.0
- Update main roadmap README with accurate function counts and version summaries

## What's in each version

| Version | Target | Theme | Functions added |
|---|---|---|---|
| v0.4 | 2026 Q4 | LET + financial | +38 (LET + 37 financial) |
| v0.5 | 2027 Q1 | Compat + database | +51 (39 aliases + 12 database) |
| v1.0 | 2027 Q2 | API stability | 0 (freeze, perf, docs, quality) |

## Function trajectory

| Version | Cumulative | Total surfaces |
|---|---|---|
| v0.2 (current) | 106 | 119 |
| v0.3 | 345 | 358 |
| v0.4 | 383 | 396 |
| v0.5 | 434 | 447 |
| v1.0 | 434 | 447 (frozen) |

## Test plan
- [x] Docs only — no code changes