### PR TITLE
feat: add xlstream facade crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,3 +213,4 @@ jobs:
       - run: cargo publish -p xlstream-parse --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - run: cargo publish -p xlstream-io --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - run: cargo publish -p xlstream-eval --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - run: cargo publish -p xlstream --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,8 +1931,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xlstream"
+version = "0.2.1"
+dependencies = [
+ "xlstream-core",
+ "xlstream-eval",
+]
+
+[[package]]
 name = "xlstream-benchmarks"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "memory-stats",
@@ -1946,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "memory-stats",
@@ -1960,14 +1968,14 @@ dependencies = [
 
 [[package]]
 name = "xlstream-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "xlstream-eval"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "calamine",
  "crossbeam-channel",
@@ -1985,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-io"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "calamine",
  "rust_xlsxwriter",
@@ -1995,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-parse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "formualizer-common",
  "formualizer-parse",
@@ -2006,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "pyo3",
  "xlstream-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/xlstream-parse",
     "crates/xlstream-io",
     "crates/xlstream-eval",
+    "crates/xlstream",
     "crates/xlstream-cli",
     "bindings/python",
     "benchmarks",
@@ -17,6 +18,7 @@ default-members = [
     "crates/xlstream-parse",
     "crates/xlstream-io",
     "crates/xlstream-eval",
+    "crates/xlstream",
     "crates/xlstream-cli",
 ]
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We are not building a general-purpose spreadsheet engine. We are building the *f
 
 ## Supported functions
 
-103 functions + 13 operators across 9 categories. [Full list with cross-reference](docs/functions.md).
+106 functions + 13 operators across 9 categories. [Full list with cross-reference](docs/functions.md).
 
 | Category   | Count | Examples                                          |
 | ---------- | ----- | ------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Excel has ~500 functions. ~465 are streaming-compatible. We're adding more each 
 
 ## Install
 
+**Rust:**
+```bash
+cargo add xlstream
+```
+
+**Python:**
 ```bash
 pip install xlstream
 ```
@@ -60,7 +66,13 @@ result = xlstream.evaluate("input.xlsx", "output.xlsx", workers=8)
 ### Rust
 
 ```rust
-let summary = xlstream_eval::evaluate(&input, &output, Some(8))?;
+use std::path::Path;
+
+let summary = xlstream::evaluate(
+    Path::new("input.xlsx"),
+    Path::new("output.xlsx"),
+    &xlstream::EvaluateOptions::default(),
+)?;
 ```
 
 ## Error handling

--- a/crates/xlstream-cli/src/main.rs
+++ b/crates/xlstream-cli/src/main.rs
@@ -11,6 +11,7 @@
     clippy::dbg_macro
 )]
 #![allow(clippy::module_name_repetitions, clippy::cargo_common_metadata)]
+#![allow(clippy::multiple_crate_versions)]
 
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/xlstream/Cargo.toml
+++ b/crates/xlstream/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "xlstream"
+description = "Streaming Excel formula evaluation engine — evaluate .xlsx formulas in bounded memory"
+readme = "README.md"
+keywords = ["excel", "xlsx", "streaming", "formula", "evaluator"]
+categories = ["parser-implementations"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+xlstream-eval = { path = "../xlstream-eval", version = "0.2.1" }
+xlstream-core = { path = "../xlstream-core", version = "0.2.1" }
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+cargo_common_metadata = "allow"

--- a/crates/xlstream/README.md
+++ b/crates/xlstream/README.md
@@ -48,13 +48,14 @@ fn main() -> Result<(), xlstream::XlStreamError> {
 Parallelism is automatic — rows are sharded across cores when the sheet has >= 10k data rows. Control it explicitly:
 
 ```rust
+use std::path::Path;
 use xlstream::EvaluateOptions;
 
 let opts = EvaluateOptions { workers: Some(4), ..Default::default() };
 xlstream::evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), &opts)?;
 ```
 
-## 103 Excel-compatible functions
+## 106 Excel-compatible functions
 
 | Category   | Count | Examples                                          |
 | ---------- | ----- | ------------------------------------------------- |
@@ -73,6 +74,7 @@ xlstream::evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), &opts)?;
 ## Error handling
 
 ```rust
+use std::path::Path;
 use xlstream::{evaluate, XlStreamError};
 
 match evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), &Default::default()) {

--- a/crates/xlstream/README.md
+++ b/crates/xlstream/README.md
@@ -1,0 +1,127 @@
+# xlstream
+
+[![Crates.io](https://img.shields.io/crates/v/xlstream.svg)](https://crates.io/crates/xlstream)
+[![docs.rs](https://docs.rs/xlstream/badge.svg)](https://docs.rs/xlstream)
+[![CI](https://github.com/cilladev/xlstream/actions/workflows/ci.yml/badge.svg)](https://github.com/cilladev/xlstream/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/cilladev/xlstream#license)
+
+A streaming Excel formula evaluation engine. Reads `.xlsx` files row-by-row, evaluates formulas in bounded memory, writes results to a new `.xlsx`. No dependency graph, no full-workbook buffering.
+
+## Quick start
+
+```toml
+[dependencies]
+xlstream = "0.2"
+```
+
+```rust
+use std::path::Path;
+
+fn main() -> Result<(), xlstream::XlStreamError> {
+    let summary = xlstream::evaluate(
+        Path::new("input.xlsx"),
+        Path::new("output.xlsx"),
+        &xlstream::EvaluateOptions::default(),
+    )?;
+
+    println!(
+        "Evaluated {} formulas across {} rows in {:?}",
+        summary.formulas_evaluated,
+        summary.rows_processed,
+        summary.duration,
+    );
+
+    Ok(())
+}
+```
+
+## Performance
+
+**425x faster** than graph-based evaluation on the same workbook.
+
+|                     | xlstream           | formualizer           |
+| ------------------- | ------------------ | --------------------- |
+| 700k rows x 20 cols | **48s**            | 5h 40m                |
+| Peak memory         | **734 MB**         | 3.3 GB                |
+| Architecture        | Streaming (2-pass) | Full dependency graph |
+
+Parallelism is automatic — rows are sharded across cores when the sheet has >= 10k data rows. Control it explicitly:
+
+```rust
+use xlstream::EvaluateOptions;
+
+let opts = EvaluateOptions { workers: Some(4), ..Default::default() };
+xlstream::evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), &opts)?;
+```
+
+## 103 Excel-compatible functions
+
+| Category   | Count | Examples                                          |
+| ---------- | ----- | ------------------------------------------------- |
+| Operators  | 13    | `+`, `-`, `*`, `/`, `^`, `&`, `%`, comparisons    |
+| Logical    | 11    | IF, IFS, SWITCH, IFERROR, AND, OR, NOT, XOR       |
+| Aggregates | 15    | SUM, SUMIF, SUMIFS, AVERAGE, COUNTIF, MEDIAN      |
+| Lookups    | 7     | VLOOKUP, XLOOKUP, INDEX/MATCH, HLOOKUP, CHOOSE    |
+| Text       | 19    | LEFT, UPPER, TRIM, CONCAT, TEXT, FIND, SUBSTITUTE |
+| Date       | 12    | TODAY, YEAR, EDATE, EOMONTH, DATEDIF, NETWORKDAYS |
+| Math       | 23    | ROUND, MOD, ABS, SQRT, LOG, SIN, PI, FLOOR        |
+| Info       | 10    | ISNUMBER, ISTEXT, ISERROR, ISBLANK, ISREF, TYPE   |
+| Financial  | 6     | PMT, PV, FV, NPV, IRR, RATE                       |
+
+[Full cross-reference](https://github.com/cilladev/xlstream/blob/main/docs/functions.md) against Excel, formualizer, and xlcalculator.
+
+## Error handling
+
+```rust
+use xlstream::{evaluate, XlStreamError};
+
+match evaluate(Path::new("in.xlsx"), Path::new("out.xlsx"), &Default::default()) {
+    Ok(summary) => println!("{} formulas evaluated", summary.formulas_evaluated),
+    Err(XlStreamError::Unsupported { address, formula, reason, .. }) => {
+        eprintln!("Unsupported formula at {address}: {formula} ({reason})");
+    }
+    Err(e) => eprintln!("Error: {e}"),
+}
+```
+
+Unsupported formulas (OFFSET, INDIRECT, LAMBDA, dynamic arrays) are rejected at classification with a specific reason and documentation link — not at runtime.
+
+## Architecture
+
+Two-pass streaming model:
+
+1. **Prelude** — single-threaded scan. Computes whole-column aggregates (SUM, AVERAGE, COUNT), loads lookup sheets into hash-indexed memory, resolves named ranges.
+2. **Row stream** — multi-threaded. Each row is evaluated using prelude scalars and the current row's cells. No row reads from future rows. Bounded memory regardless of file size.
+
+Formulas that can't fit this model (OFFSET, INDIRECT, dynamic arrays, LAMBDA) are refused at classification with a clear error.
+
+## Workspace crates
+
+| Crate | Purpose |
+|---|---|
+| [`xlstream`](https://crates.io/crates/xlstream) | Facade — re-exports the public API (this crate) |
+| [`xlstream-eval`](https://crates.io/crates/xlstream-eval) | Streaming evaluator, builtins, parallel dispatch |
+| [`xlstream-parse`](https://crates.io/crates/xlstream-parse) | Formula parser adapter + streaming classifier |
+| [`xlstream-io`](https://crates.io/crates/xlstream-io) | Calamine reader + rust_xlsxwriter writer |
+| [`xlstream-core`](https://crates.io/crates/xlstream-core) | Value, error, and date types |
+
+## Python bindings
+
+Also available as a Python package with the same streaming architecture:
+
+```bash
+pip install xlstream
+```
+
+```python
+import xlstream
+result = xlstream.evaluate("input.xlsx", "output.xlsx")
+```
+
+## Minimum supported Rust version
+
+1.88
+
+## License
+
+Dual-licensed under [Apache-2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT), at your option.

--- a/crates/xlstream/src/lib.rs
+++ b/crates/xlstream/src/lib.rs
@@ -1,0 +1,39 @@
+//! # xlstream
+//!
+//! Streaming Excel formula evaluation engine. Reads `.xlsx` files row-by-row,
+//! evaluates formulas in bounded memory, writes results to a new `.xlsx`.
+//!
+//! This crate re-exports the public API from [`xlstream_eval`] and
+//! [`xlstream_core`]. For direct access to internals, depend on those
+//! crates instead.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use std::path::Path;
+//!
+//! let summary = xlstream::evaluate(
+//!     Path::new("input.xlsx"),
+//!     Path::new("output.xlsx"),
+//!     &xlstream::EvaluateOptions::default(),
+//! )?;
+//!
+//! assert!(summary.rows_processed > 0);
+//! # Ok::<(), xlstream::XlStreamError>(())
+//! ```
+
+#![warn(missing_docs, rust_2018_idioms, clippy::pedantic, clippy::cargo)]
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::print_stdout,
+    clippy::dbg_macro
+)]
+#![allow(clippy::module_name_repetitions, clippy::cargo_common_metadata)]
+#![allow(clippy::multiple_crate_versions)]
+
+pub use xlstream_core::{CellError, EvaluateOptions, Value, XlStreamError};
+pub use xlstream_eval::{evaluate, EvaluateSummary};

--- a/crates/xlstream/src/lib.rs
+++ b/crates/xlstream/src/lib.rs
@@ -3,8 +3,8 @@
 //! Streaming Excel formula evaluation engine. Reads `.xlsx` files row-by-row,
 //! evaluates formulas in bounded memory, writes results to a new `.xlsx`.
 //!
-//! This crate re-exports the public API from [`xlstream_eval`] and
-//! [`xlstream_core`]. For direct access to internals, depend on those
+//! This crate re-exports the primary entry points from [`xlstream_eval`]
+//! and [`xlstream_core`]. For direct access to internals, depend on those
 //! crates instead.
 //!
 //! # Examples
@@ -35,5 +35,8 @@
 #![allow(clippy::module_name_repetitions, clippy::cargo_common_metadata)]
 #![allow(clippy::multiple_crate_versions)]
 
-pub use xlstream_core::{CellError, EvaluateOptions, Value, XlStreamError};
+pub use xlstream_core::{
+    CellError, EvaluateOptions, ExcelDate, OutputMode, Value, XlStreamError,
+    ITERATIVE_CALC_DEFAULT_MAX_CHANGE, ITERATIVE_CALC_DEFAULT_MAX_ITERATIONS,
+};
 pub use xlstream_eval::{evaluate, EvaluateSummary};


### PR DESCRIPTION
## Summary
- Adds thin `xlstream` facade crate at `crates/xlstream/` that re-exports `evaluate`, `EvaluateSummary`, `Value`, `CellError`, `EvaluateOptions`, and `XlStreamError`
- Adds `xlstream` to workspace members, default-members, and `publish-crates` CI job
- Updates root README with `cargo add xlstream` install instructions and corrected Rust API usage
- Fixes pre-existing `clippy::multiple_crate_versions` lint gap in `xlstream-cli`

Resolves: `docs/issues/xlstream-facade-crate.md`

## Test plan
- [x] `cargo check -p xlstream` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (no regressions)
- [x] `cargo test -p xlstream --doc` passes (doctest compiles)
- [x] Pre-commit and pre-push hooks pass