### PR TITLE
fix: broken pypi project links and remove rust-only content

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,13 +1,46 @@
-# xlstream (Python)
+# xlstream
 
-Python bindings for the xlstream streaming Excel formula evaluation engine.
+![CI](https://github.com/cilladev/xlstream/actions/workflows/ci.yml/badge.svg)
+![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)
 
-## Install (development)
+`xlstream` is a **streaming Excel formula evaluation engine** with Python bindings. It reads `.xlsx` files row-by-row, evaluates formulas in a single (or two-pass) streaming traversal (no dependency graph, no full-workbook buffering), and writes the results to a new `.xlsx` — all in bounded memory regardless of file size.
+
+We are not building a general-purpose spreadsheet engine. We are building the *fastest, leanest* Excel formula evaluator — supporting ~465 of Excel's ~500 functions, everything that fits a streaming architecture.
+
+## Performance
+
+**425x faster** on the same workbook. [Full benchmarks](https://github.com/cilladev/xlstream/tree/main/benchmarks/reports)
+
+|                     | xlstream           | formualizer           |
+| ------------------- | ------------------ | --------------------- |
+| 700k rows x 20 cols | **48s**            | 5h 40m                |
+| Peak memory         | **734 MB**         | 3.3 GB                |
+| Architecture        | Streaming (2-pass) | Full dependency graph |
+
+
+## Supported functions
+
+106 functions + 13 operators across 9 categories. [Full list with cross-reference](https://github.com/cilladev/xlstream/blob/main/docs/functions.md).
+
+| Category   | Count | Examples                                          |
+| ---------- | ----- | ------------------------------------------------- |
+| Operators  | 13    | `+`, `-`, `*`, `/`, `^`, `&`, `%`, comparisons    |
+| Logical    | 11    | IF, IFS, SWITCH, IFERROR, AND, OR, NOT, XOR       |
+| Aggregates | 15    | SUM, SUMIF, SUMIFS, AVERAGE, COUNTIF, MEDIAN      |
+| Lookups    | 7     | VLOOKUP, XLOOKUP, INDEX/MATCH, HLOOKUP, CHOOSE    |
+| Text       | 19    | LEFT, UPPER, TRIM, CONCAT, TEXT, FIND, SUBSTITUTE |
+| Date       | 12    | TODAY, YEAR, EDATE, EOMONTH, DATEDIF, NETWORKDAYS |
+| Math       | 23    | ROUND, MOD, ABS, SQRT, LOG, SIN, PI, FLOOR        |
+| Info       | 10    | ISNUMBER, ISTEXT, ISERROR, ISBLANK, ISREF, TYPE   |
+| Financial  | 6     | PMT, PV, FV, NPV, IRR, RATE                       |
+
+Excel has ~500 functions. ~465 are streaming-compatible. We're adding more each release — see the [roadmap](https://github.com/cilladev/xlstream/blob/main/docs/roadmap/README.md).
+
+
+## Install
 
 ```bash
-cd bindings/python
-pip install maturin pytest openpyxl
-maturin develop --release
+pip install xlstream
 ```
 
 ## Usage
@@ -16,22 +49,26 @@ maturin develop --release
 import xlstream
 
 result = xlstream.evaluate("input.xlsx", "output.xlsx")
-print(result["rows_processed"])
-print(result["formulas_evaluated"])
-print(result["duration_ms"])
+# {'rows_processed': 700001, 'formulas_evaluated': 7000000, 'duration_ms': 48000}
 
-# With parallel workers
-result = xlstream.evaluate("input.xlsx", "output.xlsx", workers=4)
+# Parallel (row-sharded across cores)
+result = xlstream.evaluate("input.xlsx", "output.xlsx", workers=8)
 ```
 
-## Run tests
+## Error handling
 
-```bash
-pytest tests/ -v
+```python
+try:
+    xlstream.evaluate("input.xlsx", "output.xlsx")
+except xlstream.UnsupportedFormula as e:
+    print(e)  # names the cell, formula, and reason
+except xlstream.FormulaParseError as e:
+    print(e)
+except OSError as e:
+    print(e)  # file not found, corrupt xlsx
 ```
 
-## Build wheel
 
-```bash
-maturin build --release
-```
+## License
+
+Dual-licensed under Apache-2.0 or MIT, at your option.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "xlstream"
 requires-python = ">=3.9"
 dynamic = ["version"]
 description = "Streaming Excel formula evaluation engine"
-readme = {file = "../../README.md", content-type = "text/markdown"}
+readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }
 authors = [{ name = "Priscilla Emasoga" }]
 classifiers = [
@@ -16,6 +16,14 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",
 ]
+
+[project.urls]
+Homepage = "https://github.com/cilladev/xlstream"
+Repository = "https://github.com/cilladev/xlstream"
+"Bug Tracker" = "https://github.com/cilladev/xlstream/issues"
+Documentation = "https://github.com/cilladev/xlstream/blob/main/docs/functions.md"
+Benchmarks = "https://github.com/cilladev/xlstream/tree/main/benchmarks/reports"
+Changelog = "https://github.com/cilladev/xlstream/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0"]

--- a/docs/architecture/python-bindings.md
+++ b/docs/architecture/python-bindings.md
@@ -50,7 +50,7 @@ name = "xlstream"
 requires-python = ">=3.9"
 dynamic = ["version"]
 description = "Streaming Excel formula evaluation engine"
-readme = "../../README.md"
+readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }
 authors = [{ name = "Priscilla Emasoga" }]
 classifiers = [

--- a/docs/research/pyo3-maturin.md
+++ b/docs/research/pyo3-maturin.md
@@ -61,7 +61,7 @@ name = "myproject"
 requires-python = ">=3.9"
 dynamic = ["version"]
 description = "Short project description"
-readme = "../../README.md"
+readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }
 authors = [{ name = "Your Name" }]
 classifiers = [


### PR DESCRIPTION
## Summary
- Fixes broken relative links on PyPI page (`benchmarks/reports`, `docs/functions.md`) by converting to absolute GitHub URLs
- Adds `[project.urls]` section with Homepage, Repository, Bug Tracker, Documentation, Benchmarks, Changelog
- Points `readme` at local `bindings/python/README.md` instead of root `../../README.md`
- Removes Rust install/usage sections from PyPI README (Python package, Python docs)

## Test plan
- [x] `maturin build --release` succeeds with new readme path
- [x] Verify links render correctly on PyPI (test.pypi.org or next release)
- [x] `[project.urls]` shows sidebar links on PyPI project page

Closes #94