### PR TITLE
fix: cache operator criteria to resolve O(n^2) regression

### DIFF
--- a/crates/xlstream-eval/src/prelude.rs
+++ b/crates/xlstream-eval/src/prelude.rs
@@ -4,6 +4,7 @@
 //! adds volatile data (TODAY/NOW).
 
 use std::collections::HashMap;
+use std::sync::RwLock;
 
 use xlstream_core::{CellError, ExcelDate, Value};
 use xlstream_parse::{AggKind, AggregateKey};
@@ -161,6 +162,11 @@ pub struct Prelude {
     volatile: Option<VolatileData>,
     /// Cached bounded ranges for range-expanding functions.
     cached_ranges: HashMap<BoundedRangeKey, Vec<Value>>,
+    /// Lazily populated cache for operator criteria lookups (e.g.,
+    /// `COUNTIF(B:B,">500")`). Avoids re-scanning the inner map on every
+    /// row — the scan runs once per unique (key, composite) pair, then
+    /// all subsequent calls hit this cache.
+    operator_cache: RwLock<HashMap<(MultiConditionalAggKey, String), Value>>,
 }
 
 impl Prelude {
@@ -182,6 +188,7 @@ impl Prelude {
             lookup_sheets: HashMap::new(),
             volatile: None,
             cached_ranges: HashMap::new(),
+            operator_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -211,6 +218,7 @@ impl Prelude {
             lookup_sheets: HashMap::new(),
             volatile: None,
             cached_ranges: HashMap::new(),
+            operator_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -241,6 +249,7 @@ impl Prelude {
             lookup_sheets: HashMap::new(),
             volatile: None,
             cached_ranges: HashMap::new(),
+            operator_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -268,6 +277,7 @@ impl Prelude {
             lookup_sheets: HashMap::new(),
             volatile: None,
             cached_ranges: HashMap::new(),
+            operator_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -316,6 +326,11 @@ impl Prelude {
             self.volatile = other.volatile;
         }
         self.cached_ranges.extend(other.cached_ranges);
+        if let Ok(other_cache) = other.operator_cache.into_inner() {
+            if let Ok(ref mut self_cache) = self.operator_cache.write() {
+                self_cache.extend(other_cache);
+            }
+        }
     }
 
     /// Look up a pre-loaded sheet by name (case-insensitive).
@@ -444,7 +459,19 @@ impl Prelude {
             if let Some(v) = inner.get(composite_key) {
                 return v.clone();
             }
+
+            let cache_key = (key.clone(), composite_key.to_string());
+
+            if let Ok(cache) = self.operator_cache.read() {
+                if let Some(v) = cache.get(&cache_key) {
+                    return v.clone();
+                }
+            }
+
             if let Some(result) = try_operator_criteria(key, inner, composite_key) {
+                if let Ok(mut cache) = self.operator_cache.write() {
+                    return cache.entry(cache_key).or_insert(result).clone();
+                }
                 return result;
             }
         }


### PR DESCRIPTION
## Summary

- Cache operator criteria results in `get_multi_conditional` using `RwLock<HashMap>` so the linear scan runs once per unique (key, composite) pair instead of once per row
- Medium benchmark restored from ~2000s to 43s (pre-regression: 44s)
- Single file change: `crates/xlstream-eval/src/prelude.rs` (+27 lines)

## Root cause

Commit `4cdb74e` added `try_operator_criteria` which scans the entire inner groupby map on every call when the exact key misses. For `COUNTIF(B:B,">500")` on 100k rows with ~100k unique float values: 100k rows x 100k entries = ~10B iterations.

## Verification

| Commit | Medium 1w | RSS |
|---|---|---|
| `a7d4cc1` (before regression) | 44.4s | 687 MB |
| `4cdb74e` (regression) | ~2000s | -- |
| This fix | 43.3s | 655 MB |

## Test plan

- [x] `cargo clippy -D warnings` clean
- [x] Full test suite (2,876 tests) passes
- [x] Conformance tests (82) pass
- [x] Medium benchmark verified at 43s

Fixes #170