### PR TITLE
deps: upgrade calamine, crossbeam-epoch, anyhow for rustsec advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: |
           source .venv/bin/activate 2>/dev/null || source .venv/Scripts/activate
-          maturin develop --release
+          maturin develop --profile wheel
       - if: steps.guard.outputs.present == 'true'
         name: Run pytest
         working-directory: bindings/python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
           working-directory: ./bindings/python
-          args: --release --out dist
+          args: --profile wheel --out dist
       - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ Semver.
 
 ## [Unreleased]
 
+### Security
+- Upgrade calamine 0.35 -> 0.36 (quick-xml 0.41: RUSTSEC-2026-0194, RUSTSEC-2026-0195), pyo3 0.28 -> 0.29 (RUSTSEC-2026-0176, RUSTSEC-2026-0177), crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204), anyhow 1.0.103 (RUSTSEC-2026-0190)
+
 ### Fixed
 - Parallel evaluation (workers > 1, >= 10,000 rows) reordered output sheets, writing lookup sheets before the formula sheet; sheets now keep input order (#197)
 - Conditional aggregates (COUNTIF, SUMIF, AVERAGEIF, COUNTIFS, SUMIFS, AVERAGEIFS, MINIFS, MAXIFS) respect row bounds — `COUNTIF(A2:A11, ...)` no longer scans the whole column (#138)
 - *IFS functions return #VALUE! for incongruent range shapes, matching Excel; SUMIF/AVERAGEIF with an offset value range (`SUMIF(A2:A11, x, B5:B14)`) return #VALUE! instead of silently mis-pairing rows (documented divergence: Excel resizes the value range)
 - Blank and `<>` criteria count implicit empty rows: `COUNTIF(D:D,"")` returns 1,048,576 minus non-blank cells instead of counting only streamed rows
 - Operator criteria (`">30"`) merge prelude buckets exactly: AVERAGEIF(S) weight by row count instead of averaging per-bucket averages, and empty buckets no longer poison AVERAGEIF(S) with #DIV/0! or MINIFS/MAXIFS with 0
-
 ### Changed
 - Centralize formula registration — single registry replaces 9 scattered function-name registration sites. `classify()`, `rewrite()`, and `collect_lookup_keys()` now take a `fn_lookup` callback. Dispatch uses `registry::dispatch()` instead of 200-arm match.
 - Multi-conditional prelude buckets store partials (`BucketAgg`) finished at lookup time, replacing finished-value buckets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Semver.
 - *IFS functions return #VALUE! for incongruent range shapes, matching Excel; SUMIF/AVERAGEIF with an offset value range (`SUMIF(A2:A11, x, B5:B14)`) return #VALUE! instead of silently mis-pairing rows (documented divergence: Excel resizes the value range)
 - Blank and `<>` criteria count implicit empty rows: `COUNTIF(D:D,"")` returns 1,048,576 minus non-blank cells instead of counting only streamed rows
 - Operator criteria (`">30"`) merge prelude buckets exactly: AVERAGEIF(S) weight by row count instead of averaging per-bucket averages, and empty buckets no longer poison AVERAGEIF(S) with #DIV/0! or MINIFS/MAXIFS with 0
+
 ### Changed
 - Centralize formula registration — single registry replaces 9 scattered function-name registration sites. `classify()`, `rewrite()`, and `collect_lookup_keys()` now take a `fn_lookup` callback. Dispatch uses `registry::dispatch()` instead of 200-arm match.
 - Multi-conditional prelude buckets store partials (`BucketAgg`) finished at lookup time, replacing finished-value buckets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"
@@ -113,11 +113,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "atoi_simd"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
 dependencies = [
  "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -210,9 +211,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calamine"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8822fe6253ca47aa5ad9a3be09f6fe7cd20c6a74e41b0aa42e8f4e3d523508df"
+checksum = "6975084f43060e56343ffba7f9731fa52a7dcf2e1cd8e2459fd4c6bf4a1bff59"
 dependencies = [
  "atoi_simd",
  "byteorder",
@@ -222,7 +223,7 @@ dependencies = [
  "log",
  "quick-xml",
  "serde",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -410,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1011,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -1182,7 +1183,7 @@ checksum = "f281b687352597d29efaad39701d1167d5c48aa76fb973e392bc13e9d44e7f36"
 dependencies = [
  "ryu",
  "tempfile",
- "zip",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -2048,6 +2049,20 @@ name = "zip"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ authors = ["Priscilla Emasoga"]
 
 [workspace.dependencies]
 # xlsx I/O
-calamine = "0.35"
+calamine = "0.36"
 rust_xlsxwriter = { version = "0.95", features = ["constant_memory", "zlib", "ryu"] }
 
 # formula parser — pinned exactly per ADR docs/decisions/2026-04-18-phase-02-toolchain-bump.md.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,14 @@ codegen-units = 1
 opt-level = 3
 strip = true
 
+# Python wheels only. Fat LTO drops encoding_rs static definitions when
+# linking the abi3 cdylib on linux-gnu (undefined R_X86_64_PC32
+# relocations, "recompile with -fPIC"); thin LTO links clean. Rust/CLI
+# builds keep fat LTO.
+[profile.wheel]
+inherits = "release"
+lto = "thin"
+
 [profile.bench]
 lto = "fat"
 codegen-units = 1

--- a/docs/architecture/parallelism.md
+++ b/docs/architecture/parallelism.md
@@ -51,7 +51,7 @@ fn stream_parallel(
     let chunk_size = (total_data_rows as usize).div_ceil(num_workers);
 
     // Header: read from fresh reader, write before spawning workers.
-    // Non-main sheets: written by caller before this function.
+    // Non-main sheets: written by caller interleaved in input order.
 
     let (tx, rx) = crossbeam_channel::bounded(num_workers * 1024);
 

--- a/docs/architecture/python-bindings.md
+++ b/docs/architecture/python-bindings.md
@@ -1,6 +1,6 @@
 # Python bindings
 
-PyO3 0.28 + maturin 1.13. Pattern cribbed from `pydantic-core` / `huggingface/tokenizers`.
+PyO3 0.29 + maturin 1.13. Pattern cribbed from `pydantic-core` / `huggingface/tokenizers`.
 
 ## Layout
 
@@ -32,7 +32,7 @@ name = "_xlstream"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 xlstream-core = { path = "../../crates/xlstream-core" }
 xlstream-eval = { path = "../../crates/xlstream-eval" }
 xlstream-io   = { path = "../../crates/xlstream-io" }

--- a/docs/operations/repo-structure.md
+++ b/docs/operations/repo-structure.md
@@ -109,10 +109,10 @@ repository = "https://github.com/cilladev/xlstream"
 authors = ["Priscilla Emasoga"]
 
 [workspace.dependencies]
-calamine = "0.34"
+calamine = "0.36"
 rust_xlsxwriter = { version = "0.94", features = ["constant_memory", "zlib", "ryu"] }
 formualizer-parse = "0.5"     # pin exact version after first integration
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 rayon = "1.10"
 smallvec = "1.13"
 thiserror = "2.0"

--- a/docs/research/calamine.md
+++ b/docs/research/calamine.md
@@ -97,7 +97,7 @@ Each reader opens its own file handle. For our row-parallel design (N workers), 
 
 ## Version pin
 
-Track stable (`^0.34` at time of writing). Not pinned exactly — calamine's surface is conservative.
+Track stable (`^0.36` at time of writing). Not pinned exactly — calamine's surface is conservative.
 
 ## What we use, what we don't
 

--- a/docs/research/pyo3-maturin.md
+++ b/docs/research/pyo3-maturin.md
@@ -2,7 +2,7 @@
 
 ## What we picked
 
-- **PyO3 0.28** with the Bound API.
+- **PyO3 0.29** with the Bound API.
 - **maturin 1.13+** as build tool.
 - **abi3-py39** for single-wheel-per-platform.
 - **Layout**: Rust workspace + `bindings/python/` nested crate. Pattern from `huggingface/tokenizers`.
@@ -93,11 +93,11 @@ name = "_myproject"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 myproject-core = { path = "../../crates/myproject-core" }
 ```
 
-## PyO3 0.28 idioms (changed from older versions)
+## PyO3 0.29 idioms (changed from older versions)
 
 ### Bound API (0.21+, mandatory 0.25+)
 
@@ -189,7 +189,7 @@ pydantic-core's trick: `pyproject.toml` reads version from `Cargo.toml` via `dyn
 
 ## Free-threaded Python (3.13t, 3.14t)
 
-PyO3 0.28 supports the free-threaded (GIL-less) CPython builds via `#[pymodule(gil_used = false)]`. Defer for v0.1 — add when users ask.
+PyO3 0.29 supports the free-threaded (GIL-less) CPython builds via `#[pymodule(gil_used = false)]`. Defer for v0.1 — add when users ask.
 
 ## Type stubs
 


### PR DESCRIPTION
## Problem
CI `cargo audit` failed with 5 vulnerabilities (2 high). The calamine upgrade then broke the `python (ubuntu-latest)` wheel link.

## Scope
This branch carries only the calamine 0.36 upgrade plus crossbeam-epoch/anyhow lockfile updates, and the Linux wheel link fix. The pyo3 0.29 bump (RUSTSEC-2026-0176/-0177) already landed on main via dependabot and is not part of this PR.

## Fix
| Crate | Was | Now | Advisories | How |
|---|---|---|---|---|
| quick-xml | 0.39.2 | 0.41.0 | RUSTSEC-2026-0194, -0195 (both 7.5 high) | calamine 0.35 -> 0.36 |
| crossbeam-epoch | 0.9.18 | 0.9.20 | RUSTSEC-2026-0204 | cargo update (via rayon) |
| anyhow | 1.0.102 | 1.0.103 | RUSTSEC-2026-0190 (warning) | cargo update |

## Linux wheel link fix
calamine 0.36 pulls `encoding_rs`, and the workspace's fat LTO drops its static definitions when linking the abi3 cdylib on linux-gnu — undefined `R_X86_64_PC32` relocations ("recompile with -fPIC"). Verified in a rust:1.88 container:
- fat LTO: fails, **with or without** `-C relocation-model=pic` (PIC is already the default on x86_64-linux — the earlier `.cargo/config.toml` attempt is dropped)
- thin LTO: links clean

New `[profile.wheel]` (inherits release, `lto = "thin"`) used by maturin in CI and the release workflow. Rust binary/bench builds keep fat LTO, so CLI perf posture is unchanged.

## Design notes
- calamine 0.36: additive API; MSRV 1.88 matches our pin. Shared strings now trim unpreserved leading/trailing whitespace — full conformance suite passes.
- zip duplication: calamine pulls zip 8.6 alongside rust_xlsxwriter's 7.2 — no advisory on either; unify later via rust_xlsxwriter 0.96 if desired.

## Test plan
- [x] `make check` passes
- [x] Linux container (rust:1.88): `maturin build --profile wheel` builds the manylinux wheel
- [x] macOS: `maturin build --profile wheel` + 26/26 pytest against the wheel
- [x] Lockfile satisfies every advisory's fixed range; CI audit job confirms