### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Semver.
 
 ## [Unreleased]
 
+### Changed
+- Pin Rust 1.94.1 — rustc 1.88 fat LTO drops encoding_rs statics, breaking release-profile links of any binary using calamine 0.36 (see docs/decisions/2026-07-10-toolchain-bump-1.94-lto-fix.md)
+
 ### Security
 - Upgrade calamine 0.35 -> 0.36 (quick-xml 0.41: RUSTSEC-2026-0194, RUSTSEC-2026-0195), pyo3 0.28 -> 0.29 (RUSTSEC-2026-0176, RUSTSEC-2026-0177), crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204), anyhow 1.0.103 (RUSTSEC-2026-0190)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,19 @@ Semver.
 
 ## [Unreleased]
 
-### Changed
-- Pin Rust 1.94.1 — rustc 1.88 fat LTO drops encoding_rs statics, breaking release-profile links of any binary using calamine 0.36 (see docs/decisions/2026-07-10-toolchain-bump-1.94-lto-fix.md)
-
 ### Security
-- Upgrade calamine 0.35 -> 0.36 (quick-xml 0.41: RUSTSEC-2026-0194, RUSTSEC-2026-0195), pyo3 0.28 -> 0.29 (RUSTSEC-2026-0176, RUSTSEC-2026-0177), crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204), anyhow 1.0.103 (RUSTSEC-2026-0190)
+- Upgrade calamine 0.35 -> 0.36 (RUSTSEC-2026-0194, RUSTSEC-2026-0195), pyo3 0.28 -> 0.29 (RUSTSEC-2026-0176, RUSTSEC-2026-0177), crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204), anyhow 1.0.103 (RUSTSEC-2026-0190)
 
 ### Fixed
-- Parallel evaluation (workers > 1, >= 10,000 rows) reordered output sheets, writing lookup sheets before the formula sheet; sheets now keep input order (#197)
+- Parallel evaluation reordered output sheets; sheets now keep input order (#197)
 - Conditional aggregates (COUNTIF, SUMIF, AVERAGEIF, COUNTIFS, SUMIFS, AVERAGEIFS, MINIFS, MAXIFS) respect row bounds — `COUNTIF(A2:A11, ...)` no longer scans the whole column (#138)
-- *IFS functions return #VALUE! for incongruent range shapes, matching Excel; SUMIF/AVERAGEIF with an offset value range (`SUMIF(A2:A11, x, B5:B14)`) return #VALUE! instead of silently mis-pairing rows (documented divergence: Excel resizes the value range)
+- *IFS functions return #VALUE! for incongruent range shapes, matching Excel; SUMIF/AVERAGEIF with an offset value range return #VALUE! instead of silently mis-pairing rows (divergence: Excel resizes the value range)
 - Blank and `<>` criteria count implicit empty rows: `COUNTIF(D:D,"")` returns 1,048,576 minus non-blank cells instead of counting only streamed rows
-- Operator criteria (`">30"`) merge prelude buckets exactly: AVERAGEIF(S) weight by row count instead of averaging per-bucket averages, and empty buckets no longer poison AVERAGEIF(S) with #DIV/0! or MINIFS/MAXIFS with 0
+- Operator criteria (`">30"`) merge prelude buckets exactly: AVERAGEIF(S) weight by row count, empty buckets no longer poison AVERAGEIF(S) with #DIV/0! or MINIFS/MAXIFS with 0
 
 ### Changed
-- Centralize formula registration — single registry replaces 9 scattered function-name registration sites. `classify()`, `rewrite()`, and `collect_lookup_keys()` now take a `fn_lookup` callback. Dispatch uses `registry::dispatch()` instead of 200-arm match.
-- Multi-conditional prelude buckets store partials (`BucketAgg`) finished at lookup time, replacing finished-value buckets
+- Pin Rust toolchain to 1.94.1 — fixes fat-LTO linker failure with calamine 0.36
+- Centralize formula registration into a single registry (internal)
 
 ## [0.3.0] - 2026-05-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "xlstream-core",
  "xlstream-eval",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-benchmarks"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "memory-stats",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "memory-stats",
@@ -1968,14 +1968,14 @@ dependencies = [
 
 [[package]]
 name = "xlstream-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "xlstream-eval"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "calamine",
  "crossbeam-channel",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-io"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "calamine",
  "rust_xlsxwriter",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-parse"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags",
  "formualizer-common",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "xlstream-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "pyo3",
  "xlstream-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,16 @@ docs-check: ## verify internal markdown links (requires markdown-link-check; opt
 
 ## release
 
+.PHONY: bump
+bump: ## bump all crate versions: make bump VERSION=0.5.0
+	@[ -n "$(VERSION)" ] || { echo "usage: make bump VERSION=x.y.z"; exit 1; }
+	@echo "-> bumping to $(VERSION)"
+	sed -i '' 's/version = "0\.[0-9]*\.[0-9]*"/version = "$(VERSION)"/g' \
+		Cargo.toml $$(find crates/ bindings/ benchmarks/ -name Cargo.toml)
+	@echo "-> verifying workspace"
+	cargo check --workspace --quiet
+	@echo "-> done. git diff to review."
+
 .PHONY: release-dry
 release-dry: ## cargo publish --dry-run + maturin build check
 	cargo publish -p xlstream-core --dry-run

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -63,10 +63,10 @@ name = "end_to_end"
 harness = false
 
 [dependencies]
-xlstream-core = { path = "../crates/xlstream-core", version = "0.3.0" }
-xlstream-eval = { path = "../crates/xlstream-eval", version = "0.3.0" }
-xlstream-io = { path = "../crates/xlstream-io", version = "0.3.0" }
-xlstream-parse = { path = "../crates/xlstream-parse", version = "0.3.0" }
+xlstream-core = { path = "../crates/xlstream-core", version = "0.4.0" }
+xlstream-eval = { path = "../crates/xlstream-eval", version = "0.4.0" }
+xlstream-io = { path = "../crates/xlstream-io", version = "0.4.0" }
+xlstream-parse = { path = "../crates/xlstream-parse", version = "0.4.0" }
 rust_xlsxwriter = { version = "0.95", features = ["zlib", "ryu"] }
 
 [dev-dependencies]

--- a/benchmarks/reports/v0.4.0.md
+++ b/benchmarks/reports/v0.4.0.md
@@ -1,0 +1,24 @@
+# Benchmark Report — v0.4.0
+
+**Date:** 2026-07-10
+**Hardware:** iMac20,2 — Intel(R) Core(TM) i9-10910 CPU @ 3.60GHz, 128 GB
+**Rust:** rustc 1.94.1
+**Profile:** release (LTO fat, codegen-units=1)
+
+## Tier results
+
+| Tier | Rows | Workers | Wall-clock | Peak RSS |
+|---|---|---|---|---|
+| Small | 10,000 | 1 | 2.49 s | 79 MB |
+| Small | 10,000 | 4 | 2.46 s | 76 MB |
+| Medium | 100,000 | 1 | 23.73 s | 649 MB |
+| Medium | 100,000 | 4 | 20.24 s | 729 MB |
+
+## Comparison with v0.3.0
+
+| Tier | v0.3.0 | v0.4.0 | Change |
+|---|---|---|---|
+| Small (1w) | 5.68 s | 2.49 s | -56.2% |
+| Small (4w) | 6.57 s | 2.46 s | -62.6% |
+| Medium (1w) | 56.43 s | 23.73 s | -57.9% |
+| Medium (4w) | 46.04 s | 20.24 s | -56.0% |

--- a/benchmarks/src/bin/generate_fixtures.rs
+++ b/benchmarks/src/bin/generate_fixtures.rs
@@ -143,7 +143,7 @@ fn write_data_row(ws: &mut Worksheet, row: u32, rng: &mut Rng) {
     ws.write_number(row, 16, rng.int_range(1, 10) as f64).expect("Q");
     ws.write_string(row, 17, REGIONS[(row as usize) % REGIONS.len()]).expect("R");
     ws.write_number(row, 18, rng.f64_range(45292.0, 46023.0).round()).expect("S");
-    ws.write_boolean(row, 19, row % 2 == 0).expect("T");
+    ws.write_boolean(row, 19, row.is_multiple_of(2)).expect("T");
 }
 
 // ---------------------------------------------------------------------------

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3.workspace = true
-xlstream-core = { path = "../../crates/xlstream-core", version = "0.3.0" }
-xlstream-eval = { path = "../../crates/xlstream-eval", version = "0.3.0" }
-xlstream-io = { path = "../../crates/xlstream-io", version = "0.3.0" }
+xlstream-core = { path = "../../crates/xlstream-core", version = "0.4.0" }
+xlstream-eval = { path = "../../crates/xlstream-eval", version = "0.4.0" }
+xlstream-io = { path = "../../crates/xlstream-io", version = "0.4.0" }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/xlstream-cli/Cargo.toml
+++ b/crates/xlstream-cli/Cargo.toml
@@ -17,10 +17,10 @@ name = "xlstream"
 path = "src/main.rs"
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.3.0" }
-xlstream-eval = { path = "../xlstream-eval", version = "0.3.0" }
-xlstream-parse = { path = "../xlstream-parse", version = "0.3.0" }
-xlstream-io = { path = "../xlstream-io", version = "0.3.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.4.0" }
+xlstream-eval = { path = "../xlstream-eval", version = "0.4.0" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.4.0" }
+xlstream-io = { path = "../xlstream-io", version = "0.4.0" }
 clap.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/xlstream-core/src/options.rs
+++ b/crates/xlstream-core/src/options.rs
@@ -13,18 +13,13 @@ pub const ITERATIVE_CALC_DEFAULT_MAX_CHANGE: f64 = 0.001;
 /// use xlstream_core::OutputMode;
 /// assert_eq!(OutputMode::default(), OutputMode::Formulas);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OutputMode {
     /// Write both formula text and cached values: `<f>formula</f><v>cached</v>`.
+    #[default]
     Formulas,
     /// Write only cached values: `<v>cached</v>`.
     ValuesOnly,
-}
-
-impl Default for OutputMode {
-    fn default() -> Self {
-        Self::Formulas
-    }
 }
 
 impl OutputMode {

--- a/crates/xlstream-eval/Cargo.toml
+++ b/crates/xlstream-eval/Cargo.toml
@@ -12,9 +12,9 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.3.0" }
-xlstream-parse = { path = "../xlstream-parse", version = "0.3.0" }
-xlstream-io = { path = "../xlstream-io", version = "0.3.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.4.0" }
+xlstream-parse = { path = "../xlstream-parse", version = "0.4.0" }
+xlstream-io = { path = "../xlstream-io", version = "0.4.0" }
 rust_decimal.workspace = true
 ssfmt.workspace = true
 tracing.workspace = true

--- a/crates/xlstream-eval/src/builtins/conditional.rs
+++ b/crates/xlstream-eval/src/builtins/conditional.rs
@@ -48,7 +48,7 @@ pub(crate) fn builtin_ifs(
     interp: &Interpreter<'_>,
     scope: &RowScope<'_>,
 ) -> Value {
-    if args.len() < 2 || args.len() % 2 != 0 {
+    if args.len() < 2 || !args.len().is_multiple_of(2) {
         return Value::Error(CellError::Value);
     }
     for pair in args.chunks(2) {

--- a/crates/xlstream-eval/src/builtins/multi_conditional.rs
+++ b/crates/xlstream-eval/src/builtins/multi_conditional.rs
@@ -62,7 +62,7 @@ fn value_ifs_lookup(
 ) -> Value {
     // Minimum: value_range + at least one (criteria_range, criteria) pair = 3
     // args. After first arg, remaining must be pairs.
-    if args.len() < 3 || (args.len() - 1) % 2 != 0 {
+    if args.len() < 3 || !(args.len() - 1).is_multiple_of(2) {
         return Value::Error(CellError::Value);
     }
 
@@ -121,7 +121,7 @@ pub(crate) fn builtin_countifs(
     scope: &RowScope<'_>,
 ) -> Value {
     // Must have pairs: at least 2 args, even count.
-    if args.len() < 2 || args.len() % 2 != 0 {
+    if args.len() < 2 || !args.len().is_multiple_of(2) {
         return Value::Error(CellError::Value);
     }
 

--- a/crates/xlstream-eval/src/prelude_plan.rs
+++ b/crates/xlstream-eval/src/prelude_plan.rs
@@ -196,7 +196,7 @@ impl FoldState {
                 }
                 self.nums.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
                 let mid = self.nums.len() / 2;
-                if self.nums.len() % 2 == 0 {
+                if self.nums.len().is_multiple_of(2) {
                     Value::Number(f64::midpoint(self.nums[mid - 1], self.nums[mid]))
                 } else {
                     Value::Number(self.nums[mid])
@@ -453,7 +453,7 @@ fn extract_value_ifs_key(
     kind: AggKind,
 ) -> Option<crate::prelude::MultiConditionalAggKey> {
     let args = node.args();
-    if args.len() < 3 || (args.len() - 1) % 2 != 0 {
+    if args.len() < 3 || !(args.len() - 1).is_multiple_of(2) {
         return None;
     }
     let (sum_col, sheet) = extract_range_col_and_sheet(args[0])?;
@@ -481,7 +481,7 @@ fn extract_countifs_key(
     node: xlstream_parse::NodeRef<'_>,
 ) -> Option<crate::prelude::MultiConditionalAggKey> {
     let args = node.args();
-    if args.len() < 2 || args.len() % 2 != 0 {
+    if args.len() < 2 || !args.len().is_multiple_of(2) {
         return None;
     }
     let num_pairs = args.len() / 2;

--- a/crates/xlstream-eval/tests/fixtures/.gitignore
+++ b/crates/xlstream-eval/tests/fixtures/.gitignore
@@ -1,2 +1,5 @@
 # Override root *.xlsx ignore — regression fixtures are committed (Excel-verified golden files).
 !*.xlsx
+
+# Excel lock files
+~$*.xlsx

--- a/crates/xlstream-io/Cargo.toml
+++ b/crates/xlstream-io/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.3.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.4.0" }
 calamine.workspace = true
 rust_xlsxwriter.workspace = true
 

--- a/crates/xlstream-parse/Cargo.toml
+++ b/crates/xlstream-parse/Cargo.toml
@@ -12,7 +12,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-core = { path = "../xlstream-core", version = "0.3.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.4.0" }
 formualizer-parse = { workspace = true }
 formualizer-common = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/xlstream-parse/src/classify.rs
+++ b/crates/xlstream-parse/src/classify.rs
@@ -540,7 +540,9 @@ fn classify_aggregate(
 fn is_criteria_arg(fn_upper: &str, index: usize) -> bool {
     match fn_upper {
         "SUMIF" | "COUNTIF" | "AVERAGEIF" => index == 1,
-        "SUMIFS" | "COUNTIFS" | "AVERAGEIFS" | "MINIFS" | "MAXIFS" => index >= 2 && index % 2 == 0,
+        "SUMIFS" | "COUNTIFS" | "AVERAGEIFS" | "MINIFS" | "MAXIFS" => {
+            index >= 2 && index.is_multiple_of(2)
+        }
         _ => false,
     }
 }

--- a/crates/xlstream/Cargo.toml
+++ b/crates/xlstream/Cargo.toml
@@ -13,8 +13,8 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-xlstream-eval = { path = "../xlstream-eval", version = "0.3.0" }
-xlstream-core = { path = "../xlstream-core", version = "0.3.0" }
+xlstream-eval = { path = "../xlstream-eval", version = "0.4.0" }
+xlstream-core = { path = "../xlstream-core", version = "0.4.0" }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/docs/decisions/2026-07-10-toolchain-bump-1.94-lto-fix.md
+++ b/docs/decisions/2026-07-10-toolchain-bump-1.94-lto-fix.md
@@ -1,0 +1,36 @@
+# Toolchain bump: 1.88.0 -> 1.94.1 (LTO bug dropping encoding_rs statics)
+
+**Date:** 2026-07-10
+**Status:** accepted
+
+## Context
+
+calamine 0.36 (RUSTSEC fix, PR #199) pulls in `encoding_rs`. rustc 1.88's
+fat LTO internalizes and then drops `encoding_rs`'s `pub static` encoding
+tables, leaving undefined symbols at link time. Any binary that references
+`calamine::Xlsx::new` under `lto = "fat"` fails to link:
+
+- Linux abi3 Python wheel (caught in PR #199 CI; worked around with the
+  thin-LTO `[profile.wheel]`)
+- macOS release CLI (caught by `make bench-report` on release/v0.4.0)
+
+Verified matrix: 1.88 + fat = link failure; 1.88 + thin = OK;
+1.94.1 + fat = OK. The bug is fixed upstream between 1.89 and 1.94.
+
+## Decision
+
+Pin 1.94.1 (current stable). Keep `lto = "fat"` for release and bench
+profiles — the perf posture is unchanged. Keep `rust-version = "1.88"`
+(the code still compiles on 1.88; only fat-LTO release builds need newer).
+Keep the thin-LTO `[profile.wheel]` for now — revisit once wheels are
+confirmed good on 1.94 across all release targets.
+
+Fallout: 9 new clippy lints (8x `manual_is_multiple_of`, 1x derivable
+impl), all mechanical, fixed in the same commit.
+
+## Consequences
+
+- Bench numbers from 1.94 are not directly comparable to 1.88-era
+  baselines; the v0.4.0 bench report is the first on the new toolchain.
+- CI bench-gate baseline will shift on first merge; expect one noisy
+  comparison (see #201 for the gate's known cross-run weakness).

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -1,10 +1,10 @@
 # Release
 
 Every release produces two artefact families:
-- **Rust crates** on crates.io (`xlstream-core`, `xlstream-parse`, `xlstream-io`, `xlstream-eval`).
+- **Rust crates** on crates.io (`xlstream-core`, `xlstream-parse`, `xlstream-io`, `xlstream-eval`, `xlstream`).
 - **Python wheels + sdist** on PyPI (`xlstream`).
 
-Versions are locked in step. v0.1.0 is v0.1.0 across everything.
+Versions are locked in step. v0.4.0 is v0.4.0 across everything.
 
 ## Versioning
 
@@ -13,49 +13,60 @@ Semver.
 - **0.x.y**: pre-1.0. Minor bumps allowed for breaking changes.
 - **x.y.0**: minor release, may include new features.
 - **x.y.z**: patch, no new features.
-- Tag: `v0.1.0` (prefix `v`).
+- Tag: `v0.4.0` (prefix `v`).
 
 Version is defined once in `Cargo.toml` workspace `[workspace.package]` and `bindings/python/pyproject.toml` (via `dynamic = ["version"]` reading from Cargo). They MUST match. A pre-push hook or CI check enforces this.
 
 ## Pre-release checklist
 
-Before tagging:
+Before merging the version bump to main:
 
-1. **CHANGELOG.md** updated — `[Unreleased]` promoted to `[0.1.0] - YYYY-MM-DD`.
-2. **All phase checklists** for this release's scope are ticked.
+1. **All roadmap checkboxes** for this release's scope are ticked.
+2. **CHANGELOG.md** updated — `[Unreleased]` promoted to `[0.4.0] - YYYY-MM-DD`.
 3. **Docs reviewed** — no TODOs, no broken links.
-4. **Benchmarks pass** — reference workload within budget.
-5. **`cargo publish --dry-run`** works for each crate.
-6. **`maturin build --release`** works locally.
-7. **Rust version bumps** in `Cargo.toml` and `pyproject.toml`.
-8. **Commit the bump**: `chore: bump to 0.1.0`.
-9. **Tag**: `git tag -s v0.1.0 -m "v0.1.0"` then `git push origin v0.1.0`.
+4. **Benchmarks pass** — `make bench-report VERSION=0.4.0`, reference workload within budget.
+5. **`make release-dry`** works (`cargo publish --dry-run` for each crate + `maturin build`).
+6. **Version bumped** in `Cargo.toml` workspace and `pyproject.toml`.
+7. **Commit**: `chore: bump to 0.4.0`.
+8. **Merge to main** — CI auto-tags `v0.4.0` and triggers the release pipeline.
 
-## Release workflow (automated)
+## Release pipeline (automated)
 
-Tag push triggers `.github/workflows/release.yml`:
+Push to `main` triggers `release.yml`:
 
-1. Build wheels on Linux x86_64 / aarch64, macOS x86_64 / arm64, Windows x64.
-2. Build sdist.
-3. Upload artefacts.
-4. **Manual approval gate** (`environment: release-pypi`).
-5. `maturin upload` to PyPI.
-6. **Manual approval gate** (`environment: release-crates`).
-7. `cargo publish` each crate in dependency order.
-8. GitHub Release created with auto-generated notes.
+1. **Auto-tag** — reads version from `Cargo.toml`, creates `v0.4.0` tag if missing.
+2. Tag push triggers the build + publish jobs:
+   - **Build wheels** — Linux x86_64/aarch64, macOS x86_64/arm64, Windows x64 (abi3-py39).
+   - **Build sdist** — source distribution for platforms without prebuilt wheels.
+3. **Publish to PyPI** — gated on manual approval (`pypi` environment). Uses Trusted Publishing (OIDC, no token).
+4. **Publish to crates.io** — gated on manual approval (`crates-io` environment). Uses `CARGO_REGISTRY_TOKEN`.
+5. **GitHub Release** — extracts changelog section, attaches wheels + sdist.
 
-Manual approval gates ensure we don't accidentally publish a bad release.
+PyPI and crates.io publish independently (both depend on the build step, not each other). GitHub Release also publishes independently.
+
+## Crate publish order
+
+```
+xlstream-core       (no deps on siblings)
+xlstream-parse      (deps: xlstream-core)
+xlstream-io         (deps: xlstream-core)
+xlstream-eval       (deps: xlstream-core, xlstream-parse, xlstream-io)
+xlstream            (facade crate, deps: all above)
+```
+
+crates.io requires published dependencies before publishing a dependent. `release.yml` runs them sequentially.
+
+`xlstream-cli` is not published (dev-only). `bindings/python` is published to PyPI, not crates.io.
 
 ## Post-release
 
 1. Verify `pip install xlstream` works on a clean machine for each major OS.
 2. Verify `cargo add xlstream-eval` pulls the new version.
 3. Announcement post (GitHub Discussion, optionally social).
-4. Move README `Status: pre-alpha` to `Status: v0.1.0` or remove.
 
 ## Hotfix releases
 
-Patch versions (0.1.1, 0.1.2) are cherry-picks from main onto a release branch, then the same workflow. Release branches are `release/0.1.x`.
+Patch versions (0.4.1, 0.4.2) are cherry-picks from main onto a release branch (`release/0.4.x`), then the same workflow: bump version, merge, auto-tag.
 
 If the bug is on main but hasn't shipped, just fix on main and bump.
 
@@ -63,10 +74,10 @@ If the bug is on main but hasn't shipped, just fix on main and bump.
 
 If a published release has a serious bug:
 
-- `cargo yank --vers 0.1.0 xlstream-core` (and each crate).
-- `twine yank xlstream==0.1.0` (via maturin or PyPI UI).
+- `cargo yank --vers 0.4.0 xlstream-core` (and each crate).
+- Yank from PyPI via the PyPI project page.
 - Publish a patch with the fix.
-- Document in `CHANGELOG.md` that 0.1.0 was yanked.
+- Document in `CHANGELOG.md` that the version was yanked.
 
 Do NOT delete the git tag.
 
@@ -91,32 +102,10 @@ crates.io does not yet support OIDC, so this one stays on tokens.
 
 Never expose outside CI. Token is scoped to just the `xlstream-*` crates.
 
-## First release (v0.1.0) specifics
-
-- Announce on Reddit `/r/rust` and `/r/Python`, plus relevant Discord channels.
-- PyPI description is the `README.md`.
-- crates.io description is the first line of each crate's `README.md`.
-- Open discussion posts on any prior-art projects (formualizer) cross-linking for users who hit memory issues.
-
-## Crate publish order
-
-```
-xlstream-core       (no deps on siblings)
-xlstream-parse      (deps: xlstream-core)
-xlstream-io         (deps: xlstream-core)
-xlstream-eval       (deps: xlstream-core, xlstream-parse, xlstream-io)
-```
-
-crates.io requires published dependencies before publishing a dependent. `release.yml` runs them sequentially.
-
-`xlstream-cli` is not published (dev-only). `bindings/python` is published to PyPI, not crates.io.
-
 ## Pre-publish `cargo publish --dry-run`
 
-Always dry-run first. Catches unbilletable edge cases like missing `description` fields, files that shouldn't be packaged, etc.
+Always dry-run first. Catches edge cases like missing `description` fields, files that shouldn't be packaged, etc.
 
 ```bash
-for c in xlstream-core xlstream-parse xlstream-io xlstream-eval; do
-  cargo publish -p $c --dry-run
-done
+make release-dry
 ```

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -25,8 +25,8 @@ Before merging the version bump to main:
 2. **CHANGELOG.md** updated — `[Unreleased]` promoted to `[0.4.0] - YYYY-MM-DD`.
 3. **Docs reviewed** — no TODOs, no broken links.
 4. **Benchmarks pass** — `make bench-report VERSION=0.4.0`, reference workload within budget.
-5. **`make release-dry`** works (`cargo publish --dry-run` for each crate + `maturin build`).
-6. **Version bumped** in `Cargo.toml` workspace and `pyproject.toml`.
+5. **Version bumped** — `make bump VERSION=0.4.0` (updates all Cargo.toml files, runs `cargo check`).
+6. **`make release-dry`** works (`cargo publish --dry-run` for each crate + `maturin build`).
 7. **Commit**: `chore: bump to 0.4.0`.
 8. **Merge to main** — CI auto-tags `v0.4.0` and triggers the release pipeline.
 

--- a/docs/roadmap/v0.4/03-datevalue.md
+++ b/docs/roadmap/v0.4/03-datevalue.md
@@ -1,0 +1,394 @@
+# Feature: DATEVALUE (with reusable date text parser)
+
+**Branch:** `feat/datevalue`
+**Effort:** ~1 day (parser infra + DATEVALUE)
+**Crates:** xlstream-core, xlstream-eval
+
+## What
+
+`DATEVALUE(date_text)` parses a text string representing a date and returns its Excel serial number (integer, no time component).
+
+```
+=DATEVALUE("2026-01-15")      -> 46037  (ISO 8601)
+=DATEVALUE("15-Jan-2026")     -> 46037  (named month, day first)
+=DATEVALUE("Jan-15-2026")     -> 46037  (named month, month first — unambiguous)
+=DATEVALUE("January 15, 2026")-> 46037  (comma format — unambiguous)
+=DATEVALUE("15 January 2026") -> 46037  (full month name)
+=DATEVALUE("Jan-2026")        -> 46023  (month-year, day defaults to 1)
+=DATEVALUE("15-Jan")          -> current year serial (no-year, defaults to today's year)
+=DATEVALUE("2026-01-15 14:30")-> 46037  (date+time, time stripped)
+=DATEVALUE("01/02/2026")      -> #VALUE! (ambiguous numeric — locale-dependent MEANING)
+=DATEVALUE("15-Jan-26")       -> #VALUE! (2-digit year — century-window surprise)
+=DATEVALUE("not a date")      -> #VALUE!
+```
+
+Current behavior: no registry entry — returns `#VALUE!` via unknown-function path.
+
+## Design decision: ambiguity-based acceptance
+
+DATEVALUE in Excel delegates text parsing to the OS regional settings — not the
+workbook. `"01/02/2026"` parses as Jan 2 on a US machine, Feb 1 on a UK
+machine. The same file recalculated on two machines caches two different
+values. There is no locale we can pin to that makes us "match Excel," because
+Excel does not match itself across machines.
+
+Locale-dependence comes in two kinds, and only one is dangerous:
+
+- **Locale-dependent meaning** (`01/02/2026`): parsing it can produce a
+  silently wrong date. Reject.
+- **Locale-dependent acceptance** (`Jan-15-2026`): some Excel locales accept
+  it, some reject it, but there is only one possible interpretation — the
+  month token is named, so `15` can only be a day and `2026` only a year.
+  Accepting it can never produce a wrong date. Accept.
+
+One named-month case IS meaning-ambiguous, verified against Excel
+(`datevalue_formats_test.xlsx`, EU-locale save): a single number FOLLOWING
+the month is read by Excel as a 2-digit year, not a day — `"January 15"`
+cached as Jan-1-**2015**, while `"15-Jan"` cached as day 15 of the current
+year. Month-first no-year input is therefore rejected; day-first no-year
+stays accepted.
+
+**Rule: all-numeric input must be ISO year-first (`yyyy` then month then
+day, `-` or `/` separators in any mix). Named-month input is accepted in
+any token order, resolved by value: the named token is the month, a 4-digit
+number is the year, a number <= 31 is the day — except a single number <= 31
+that follows the month with no year present, which is ambiguous (day vs
+Excel's 2-digit year) and rejected. 2-digit years are rejected. A pure time
+string returns 0, matching Excel. Everything else is `#VALUE!`.**
+
+This never produces a silently wrong date in any locale. Divergences are loud
+(`#VALUE!` where some Excel locale computes a value) and documented.
+
+### Accepted inputs (examples of the rule, not an exhaustive list)
+
+| # | Example | Parsed as | Notes |
+|---|---|---|---|
+| 1 | `2026-01-15` | 2026-01-15 | ISO 8601. Primary. |
+| 2 | `2026/01/15`, `2026-01/15` | 2026-01-15 | ISO slash variant; mixed separators allowed (Excel-verified). |
+| 3 | `15-Jan-2026` | 2026-01-15 | Named month, any single separator. |
+| 4 | `Jan-15-2026` | 2026-01-15 | Month first — unambiguous, order-free. |
+| 5 | `2026-Jan-15` | 2026-01-15 | Year first named — unambiguous. |
+| 6 | `January 15, 2026` | 2026-01-15 | Comma treated as separator. |
+| 7 | `15 January 2026` | 2026-01-15 | Full month name, spaces. |
+| 8 | `Jan-2026` / `January 2026` | 2026-01-01 | Month-year, day defaults to 1. |
+| 9 | `15-Jan` | day 15, current year | No year, day BEFORE month only. |
+| 10 | `2026-01-15 14:30` | 2026-01-15 | Trailing time parsed then ignored by DATEVALUE. |
+| 11 | `14:30:00` | 0 | Pure time string — date part is 0. Matches Excel (verified). |
+
+Month names are case-insensitive: `jan`, `Jan`, `JAN`, `JANUARY` all match.
+Leading/trailing whitespace is trimmed.
+
+### Rejected inputs
+
+| Example | Why rejected |
+|---|---|
+| `1/15/2026`, `15/01/2026` | All-numeric, not year-first — locale-dependent meaning. |
+| `15-Jan-26`, `1/15/26` | 2-digit year. Excel accepts named-month 2-digit years via a 29/30 century window; we reject the surprise. Documented divergence. |
+| `2026.01.15`, `15.Jan.2026` | Dot separators — rejected by Excel. |
+| `2026-01-15T14:30` | T separator — rejected by Excel. |
+| `Jan 15`, `January 15` | Month-first no-year — Excel reads the number as a 2-digit year (Jan-1-2015), day-reading would silently differ. Meaning-ambiguous. |
+| `Jan` | Month alone — no day or year. |
+| `12345` | Serial-as-text — not a date format. |
+
+### Error conditions
+
+- Wrong arity (0 or 2+ args) -> `#VALUE!`
+- Non-text arg (number, bool, date, empty) -> `#VALUE!`
+- Error in arg -> propagate
+- Empty string -> `#VALUE!`
+- Unparseable text -> `#VALUE!`
+- Day/month out of valid range -> `#VALUE!` (no rollover, unlike `DATE()`)
+- Year < 1900 or > 9999 -> `#VALUE!`
+- No-year format when volatile data is not configured -> `#VALUE!` (`volatile_today()` unset returns serial 0; silently producing 1900 dates is worse than erroring)
+- Time-only string (e.g. `"14:30:00"`) -> `0`. Matches Excel (verified in `datevalue_formats_test.xlsx` row 50).
+
+### Known locale limitations (documented, not mitigated)
+
+- **Month names are English-only.** Workbooks authored in non-English Excel
+  with localized month names (`15-janv.-2026`, `15-Dez-2026`) get `#VALUE!` —
+  loud, never wrong.
+- **Gregorian calendar only.** Thai-locale Excel writes Buddhist-era years
+  (2569 BE = 2026 CE); a string like `2569-01-15` would parse here as
+  Gregorian year 2569. Within the 1900-9999 window this is indistinguishable
+  from a real Gregorian date — the single known case where output could be a
+  different date rather than an error. Exotic; documented divergence.
+- Field-order locales (mdy/dmy/ymd) and separator conventions are fully
+  covered by the ambiguity rule — rejected when meaning differs by locale.
+
+### Special case: 1900-02-29
+
+`DATEVALUE("1900-02-29")` returns 60 (the Lotus 1-2-3 phantom date). `from_ymd(1900, 2, 29)` already handles this.
+
+## Reusable parser design
+
+The date text parser lives in **xlstream-core** so it's available to all crates. TIMEVALUE consumes the same parse — so the parser must return the time components, not just note their presence.
+
+### API in `xlstream-core/src/date.rs`
+
+```rust
+/// Parsed components from a date text string.
+///
+/// `year` and `day` are `Option` because some formats omit them (no-year
+/// defaults to the current year, month-year defaults day to 1). The
+/// caller supplies defaults and validates ranges.
+pub struct ParsedDate {
+    pub year: Option<i32>,
+    pub month: u32,
+    pub day: Option<u32>,
+    /// Trailing time component, if present: (hour, minute, seconds).
+    /// DATEVALUE ignores it; TIMEVALUE requires it.
+    pub time: Option<(u32, u32, f64)>,
+}
+
+/// Parse a date text string into components.
+///
+/// All-numeric input must be ISO year-first (`yyyy-mm-dd`, one separator
+/// kind). Input containing a month name is accepted in any token order.
+/// All-numeric non-ISO and 2-digit-year formats are rejected as
+/// locale-ambiguous.
+///
+/// Returns `None` for unparseable input. Caller supplies defaults
+/// (current year, day 1) and validates ranges.
+pub fn parse_date_text(text: &str) -> Option<ParsedDate>
+
+/// Look up a month name (case-insensitive, 3-letter or full).
+/// Returns 1-12 or None.
+pub fn month_from_name(name: &str) -> Option<u32>
+
+/// Parse a pure time string (`HH:MM`, `HH:MM:SS`, `HH:MM:SS.fff`).
+/// Returns (hour, minute, seconds) or None. Used by DATEVALUE for the
+/// time-only -> 0 case and by TIMEVALUE directly.
+pub fn parse_time_text(text: &str) -> Option<(u32, u32, f64)>
+```
+
+### Why in core, not eval
+
+- TIMEVALUE (eval) reuses `parse_date_text` and takes `ParsedDate::time`.
+- Future: `coerce::to_number` could try date text parsing for implicit coercion (Excel does this for functions like `YEAR("2026-01-15")`).
+- Future: I/O crate might need date parsing for CSV import.
+- Zero new dependencies — just string splitting and matching.
+
+### Parser logic
+
+1. Trim whitespace.
+2. Strip a trailing time component (`HH:MM`, `HH:MM:SS`, `HH:MM:SS.fff` after the last space). Parse it into `(h, m, s)`: h 0-23, m 0-59, s 0-59.999. A malformed or out-of-range time fails the whole parse (`None`).
+3. Try ISO numeric: split on `-` and `/` (mixing allowed — Excel-verified), 3 parts, first part 4 digits -> `yyyy-mm-dd`.
+4. Try named-month: tokenize on `-`, `/`, space, comma; empty tokens from consecutive separators are dropped (Excel rejects `"January  15,  2026"` — minor permissive divergence, we accept). Exactly one token must match a month name; every remaining token must be numeric, and there must be 1 or 2 of them:
+   - 4-digit token -> year. Token <= 31 -> day. Anything else (2-digit year, 3-digit, 32-99) -> `None`.
+   - 1 numeric token, 4-digit -> month-year (day `None`).
+   - 1 numeric token <= 31 BEFORE the month -> no-year day (`15-Jan`). AFTER the month -> `None`: Excel reads `"Jan 15"` as year 2015, a day-reading would silently differ.
+   - 2 numeric tokens: must be exactly one year and one day, any order, else `None`.
+5. Validate: month 1..=12, day (if present) 1..=days_in_month. Year (if present) 1900..=9999. Real Gregorian leap rules, except 1900-02-29 (Lotus bug).
+
+### Month name lookup
+
+Static match, no allocations:
+
+```rust
+pub fn month_from_name(name: &str) -> Option<u32> {
+    const MONTHS: [(&str, &str, u32); 12] = [
+        ("jan", "january", 1), ("feb", "february", 2), ("mar", "march", 3),
+        ("apr", "april", 4), ("may", "may", 5), ("jun", "june", 6),
+        ("jul", "july", 7), ("aug", "august", 8), ("sep", "september", 9),
+        ("oct", "october", 10), ("nov", "november", 11), ("dec", "december", 12),
+    ];
+    MONTHS
+        .iter()
+        .find(|(short, full, _)| name.eq_ignore_ascii_case(short) || name.eq_ignore_ascii_case(full))
+        .map(|&(_, _, n)| n)
+}
+```
+
+## What already exists
+
+- `crates/xlstream-core/src/date.rs:50-192` — `ExcelDate` with `from_serial()`, `from_ymd()`, `year_month_day()`, `weekday()`.
+- `crates/xlstream-core/src/date.rs:36-48` — `month_days()` and `year_days()` private helpers. `month_days` returns `[i32; 12]` for real Gregorian calendar — needed for day validation.
+- `crates/xlstream-core/src/date.rs:31-33` — `is_real_leap_year()` private helper.
+- `crates/xlstream-core/src/lib.rs:47` — `EXCEL_MAX_DATE_SERIAL = 2_958_465.0`.
+- `crates/xlstream-eval/src/builtins/date.rs:20-26` — `date_serial()` helper for extracting serial from Value.
+- `crates/xlstream-eval/src/builtins/date.rs:61-103` — `builtin_date()` shows the pattern.
+- `crates/xlstream-eval/src/builtins/mod.rs:644-706` — eager handler wrappers for date builtins.
+- `crates/xlstream-eval/src/registry.rs:440-541` — all 12 date function entries.
+- `crates/xlstream-eval/src/registry.rs:2379-2381` — `entry_count_is_exact` asserts 208; bump to 209.
+- `docs/functions.md:284` — DATEVALUE listed as `.` (planned), target v0.4.
+
+## Where to look
+
+- `crates/xlstream-core/src/date.rs:31-48` — make `is_real_leap_year` and `month_days` pub(crate) or pub, since `parse_date_text` needs them for validation.
+- `crates/xlstream-core/src/date.rs` — add `parse_date_text`, `ParsedDate`, `month_from_name` here.
+- `crates/xlstream-core/src/lib.rs` — re-export `parse_date_text`, `ParsedDate`, `month_from_name`.
+- `crates/xlstream-eval/src/builtins/date.rs` — add `builtin_datevalue` using the core parser.
+- `crates/xlstream-eval/src/builtins/mod.rs:700-706` — add `handle_datevalue` wrapper.
+- `crates/xlstream-eval/src/registry.rs:511-520` — add registry entry after DATEDIF.
+- `crates/xlstream-eval/tests/conformance/date.rs` — add conformance test.
+
+## DATEVALUE evaluation
+
+**Classification:** RowLocal — pure function of a single text arg.
+
+**Prelude:** Nothing.
+
+**Row eval:**
+1. Arity check: exactly 1 arg, else `#VALUE!`.
+2. Arg must be `Value::Text`. Error propagates. Number/Bool/Date/Empty -> `#VALUE!`.
+3. Call `parse_date_text(text)`. On `None`, try `parse_time_text(text)` — pure time -> `Value::Number(0.0)` (matches Excel). Both `None` -> `#VALUE!`.
+4. Fill defaults: day defaults to 1. Year defaults to `prelude.volatile_today()`'s year — if volatile data is not configured, return `#VALUE!` instead of defaulting from serial 0.
+5. Validate ranges: year 1900..=9999, month 1..=12, day 1..=days_in_month. Fail -> `#VALUE!`.
+6. Call `ExcelDate::from_ymd(year, month, day)`. Ignore `ParsedDate::time`.
+7. Return `Value::Number(serial.floor())`.
+
+Note: step 4 means DATEVALUE needs prelude access (for today's year). Use the stateful handler pattern like `builtin_today`, not the eager `&[Value]` pattern.
+
+## Tests
+
+### Unit tests for parser (in `xlstream-core/src/date.rs`)
+
+**`parse_date_text` happy path:**
+- `parse_iso_dash` — `"2026-01-15"` -> `ParsedDate { year: Some(2026), month: 1, day: Some(15), time: None }`
+- `parse_iso_slash` — `"2026/01/15"` -> same with slashes
+- `parse_named_day_first_dash` — `"15-Jan-2026"` -> year 2026, month 1, day 15
+- `parse_named_day_first_full` — `"15-January-2026"` -> same
+- `parse_named_day_first_space` — `"15 Jan 2026"` -> same
+- `parse_named_month_first` — `"Jan-15-2026"` -> same (order-free)
+- `parse_named_year_first` — `"2026-Jan-15"` -> same (order-free)
+- `parse_named_comma` — `"January 15, 2026"` -> same
+- `parse_month_year_dash` — `"Jan-2026"` -> year 2026, month 1, day None
+- `parse_month_year_space` — `"January 2026"` -> same
+- `parse_no_year` — `"15-Jan"` -> year None, month 1, day 15
+- `parse_extracts_time` — `"2026-01-15 14:30"` -> date parts + `time: Some((14, 30, 0.0))`
+- `parse_extracts_time_seconds` — `"2026-01-15 14:30:15.5"` -> `time: Some((14, 30, 15.5))`
+
+**`parse_date_text` rejections (return None):**
+- `parse_rejects_us_numeric` — `"1/15/2026"` -> None
+- `parse_rejects_eu_numeric` — `"15/01/2026"` -> None
+- `parse_iso_mixed_separators` — `"2026-01/15"` -> year 2026, month 1, day 15 (Excel-verified acceptance)
+- `parse_rejects_two_digit_year_numeric` — `"1/15/26"` -> None
+- `parse_rejects_two_digit_year_named` — `"15-Jan-26"` -> None
+- `parse_rejects_dots` — `"2026.01.15"` -> None
+- `parse_rejects_t_separator` — `"2026-01-15T14:30"` -> None
+- `parse_rejects_month_alone` — `"Jan"` -> None
+- `parse_rejects_month_first_no_year` — `"Jan 15"`, `"January 15"` -> None (Excel reads the number as year 2015)
+- `parse_rejects_invalid_time` — `"2026-01-15 25:00"` -> None
+- `parse_rejects_empty` — `""` -> None
+- `parse_rejects_plain_text` — `"hello"` -> None
+- `parse_rejects_number_text` — `"12345"` -> None
+
+**`month_from_name`:**
+- All 12 months, short + full, case variations
+
+### Unit tests for `builtin_datevalue` (in `xlstream-eval/src/builtins/date.rs`)
+
+**Happy path:**
+- `datevalue_iso` — `DATEVALUE("2026-01-15")` -> 46037.0
+- `datevalue_named_month` — `DATEVALUE("15-Jan-2026")` -> 46037.0
+- `datevalue_named_month_first` — `DATEVALUE("Jan-15-2026")` -> 46037.0
+- `datevalue_comma_format` — `DATEVALUE("January 15, 2026")` -> 46037.0
+- `datevalue_month_year` — `DATEVALUE("Jan-2026")` -> 46023.0
+- `datevalue_jan_1_1900` — `DATEVALUE("1900-01-01")` -> 1.0
+- `datevalue_dec_31_9999` — `DATEVALUE("9999-12-31")` -> 2958465.0
+
+**Edge cases:**
+- `datevalue_strips_time` — `DATEVALUE("2026-01-15 14:30")` -> 46037.0
+- `datevalue_whitespace_trimmed` — `DATEVALUE("  2026-01-15  ")` -> 46037.0
+- `datevalue_feb_29_leap` — `DATEVALUE("2024-02-29")` -> 45351.0
+- `datevalue_feb_29_1900_lotus` — `DATEVALUE("1900-02-29")` -> 60.0
+- `datevalue_feb_29_non_leap` — `DATEVALUE("2025-02-29")` -> `#VALUE!`
+- `datevalue_day_exceeds_month` — `DATEVALUE("2026-04-31")` -> `#VALUE!`
+- `datevalue_month_0` — `DATEVALUE("2026-00-15")` -> `#VALUE!`
+- `datevalue_month_13` — `DATEVALUE("2026-13-01")` -> `#VALUE!`
+- `datevalue_no_year_uses_volatile_year` — `DATEVALUE("15-Jan")` with injected TODAY -> that year's serial
+- `datevalue_no_year_without_volatile_errors` — `DATEVALUE("15-Jan")`, no volatile data -> `#VALUE!`
+
+**Error propagation:**
+- `datevalue_propagates_na` — arg is `#N/A` -> `#N/A`
+- `datevalue_wrong_arity_zero` — `DATEVALUE()` -> `#VALUE!`
+- `datevalue_wrong_arity_two` — `DATEVALUE("a", "b")` -> `#VALUE!`
+
+**Type rejection:**
+- `datevalue_rejects_number` — `DATEVALUE(44927)` -> `#VALUE!`
+- `datevalue_rejects_bool` — `DATEVALUE(TRUE)` -> `#VALUE!`
+- `datevalue_rejects_date` — `DATEVALUE(DATE(2026,1,1))` -> `#VALUE!`
+- `datevalue_rejects_plain_text` — `DATEVALUE("hello")` -> `#VALUE!`
+- `datevalue_rejects_us_numeric` — `DATEVALUE("01/15/2026")` -> `#VALUE!` (deliberate divergence from US-locale Excel — unit-tested here, kept out of the fixture)
+- `datevalue_rejects_two_digit_year` — `DATEVALUE("15-Jan-26")` -> `#VALUE!` (deliberate divergence — Excel's century window)
+- `datevalue_rejects_month_first_no_year` — `DATEVALUE("January 15")` -> `#VALUE!` (Excel reads year 2015; day-reading would silently differ)
+- `datevalue_accepts_year_first_named` — `DATEVALUE("2026-Jan-15")` -> 46037.0 (deliberate divergence — EU Excel rejects it, verified; unambiguous so we accept)
+- `datevalue_time_only_returns_zero` — `DATEVALUE("14:30:00")` -> 0.0 (matches Excel, verified)
+
+**Month name case insensitivity:**
+- `datevalue_uppercase_month` — `DATEVALUE("15-JAN-2026")` -> 46037.0
+- `datevalue_lowercase_month` — `DATEVALUE("15-jan-2026")` -> 46037.0
+
+### Conformance fixture
+
+`crates/xlstream-eval/tests/fixtures/date/datevalue.xlsx`
+
+The fixture contains only inputs where we expect Excel (US locale) to agree.
+Deliberate divergences (`01/15/2026`, `15-Jan-26`) are unit-tested, never
+fixture rows — no hand-editing of cached values, Excel stays the oracle.
+`2026-Jan-15` is already verified as an EU-Excel rejection
+(`datevalue_formats_test.xlsx` row 62) — we accept it (unambiguous); it lives
+in unit tests as a documented divergence, not here. Text inputs must be
+written via openpyxl: typing them into Excel converts the cell itself to a
+date (`Jan-15` typed into a cell became the date Jan-2015 in the formats
+fixture).
+
+| Row | A (input) | B (formula) | Expected |
+|---|---|---|---|
+| 1 | `2026-01-15` | `=DATEVALUE(A1)` | 46037 |
+| 2 | `2026/01/15` | `=DATEVALUE(A2)` | 46037 |
+| 3 | `15-Jan-2026` | `=DATEVALUE(A3)` | 46037 |
+| 4 | `15-January-2026` | `=DATEVALUE(A4)` | 46037 |
+| 5 | `15 Jan 2026` | `=DATEVALUE(A5)` | 46037 |
+| 6 | `15 January 2026` | `=DATEVALUE(A6)` | 46037 |
+| 7 | `15/Jan/2026` | `=DATEVALUE(A7)` | 46037 |
+| 8 | `Jan-15-2026` | `=DATEVALUE(A8)` | 46037 |
+| 9 | `January 15, 2026` | `=DATEVALUE(A9)` | 46037 |
+| 10 | `Jan-2026` | `=DATEVALUE(A10)` | 46023 |
+| 11 | `January 2026` | `=DATEVALUE(A11)` | 46023 |
+| 12 | `1900-01-01` | `=DATEVALUE(A12)` | 1 |
+| 13 | `9999-12-31` | `=DATEVALUE(A13)` | 2958465 |
+| 14 | `2024-02-29` | `=DATEVALUE(A14)` | 45351 |
+| 15 | `1900-02-29` | `=DATEVALUE(A15)` | 60 |
+| 16 | `  2026-01-15  ` | `=DATEVALUE(A16)` | 46037 |
+| 17 | `2026-01-15 14:30` | `=DATEVALUE(A17)` | 46037 |
+| 18 | `15-JAN-2026` | `=DATEVALUE(A18)` | 46037 |
+| 19 | (empty) | `=DATEVALUE(A19)` | `#VALUE!` |
+| 20 | `not a date` | `=DATEVALUE(A20)` | `#VALUE!` |
+| 21 | `2025-02-29` | `=DATEVALUE(A21)` | `#VALUE!` |
+| 22 | | `=DATEVALUE(123)` | `#VALUE!` |
+| 23 | | `=DATEVALUE(TRUE)` | `#VALUE!` |
+| 24 | `14:30:00` | `=DATEVALUE(A24)` | 0 |
+
+`15-Jan` (no-year) stays out of the fixture — its value depends on the year
+at recalc time, so it can never be a stable cached value. Unit-tested with an
+injected TODAY.
+
+**Fixture workflow:**
+1. Generate with openpyxl
+2. Open in Excel (US locale), save
+3. Diff cached values against the table. Any mismatch: decide match-Excel vs documented divergence, update spec and fixture, regenerate.
+4. Add `#[test] fn datevalue()` in conformance/date.rs
+
+## Future reuse map
+
+| Future function | Reuses from this PR |
+|---|---|
+| TIMEVALUE | `parse_time_text` directly; `parse_date_text` for date+time strings via `ParsedDate::time` |
+| HOUR, MINUTE, SECOND | `serial_to_hms` (not in this PR — add in their PR) |
+| TIME | `serial_from_hms` (not in this PR) |
+| DAYS, DAYS360, etc. | Nothing from parser — they take serial input |
+| Implicit date coercion | `parse_date_text` in `coerce::to_number` (future, not this PR) |
+
+## Docs to update (same PR)
+
+| File | Change |
+|---|---|
+| `CHANGELOG.md` | `[Unreleased]` -> `### Added`: `xlstream-core: add date text parser (parse_date_text, month_from_name)` and `xlstream-eval: add DATEVALUE` |
+| `docs/functions.md:284` | Change DATEVALUE from `.` to `x` |
+| `docs/roadmap/v0.4/README.md` | Tick the DATEVALUE checkbox |
+| `crates/xlstream-eval/src/registry.rs:2380` | Bump entry count 208 -> 209 |
+
+## Streaming invariant
+
+**No violation.** DATEVALUE is RowLocal. The only prelude access is `volatile_today()` for default year on no-year formats — this is a read of a prelude-computed scalar, same pattern as `TODAY()`. No cross-row reads, no range references.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.94.1"
 components = ["rustfmt", "clippy", "rust-src"]
 profile = "default"


### PR DESCRIPTION
## Summary
- Bump all crate versions 0.3.0 -> 0.4.0
- Bump Rust toolchain to 1.94.1 (fixes fat-LTO encoding_rs linker failure with calamine 0.36)
- Update CHANGELOG for v0.4.0
- Update release docs to match current CI (auto-tagger, environment names, crate publish order)
- Add `make bump VERSION=x.y.z` target for automated version bumps
- Add DATEVALUE feature spec (`docs/roadmap/v0.4/03-datevalue.md`)
- Add benchmark report for v0.4.0

## Test plan
- [x] `cargo check --workspace` passes
- [x] `make check` passes
- [x] `make release-dry` passes
- [x] CI green on this PR